### PR TITLE
only guard unwrap args if there are arguments

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -93,7 +93,9 @@ func generateVirtualProxy (_ p: Printer,
     }
     p ("func _\(cdef.name)_proxy\(method.name) (instance: UnsafeMutableRawPointer?, args: UnsafePointer<UnsafeRawPointer?>?, retPtr: UnsafeMutableRawPointer?)") {
         p ("guard let instance else { return }")
-        p ("guard let args else { return }")
+        if let arguments = method.arguments, arguments.count > 0 {
+            p ("guard let args else { return }")
+        }
         p ("let swiftObject = Unmanaged<\(cdef.name)>.fromOpaque(instance).takeUnretainedValue()")
         
         var argCall = ""


### PR DESCRIPTION
https://github.com/migueldeicaza/SwiftGodot/issues/33

I created a `Node2D` subclass and overrode `_ready()` and `_input(event:)` and in both cases add a child node of a certain name.

<img width="478" alt="Screenshot 2023-04-27 at 7 54 46 AM" src="https://user-images.githubusercontent.com/3056529/234854454-b04a5c5c-3791-40e2-9db7-5e553128cdc8.png">

Before making the change this happens on game launch & player input...

<img width="443" alt="Screenshot 2023-04-27 at 7 28 28 AM" src="https://user-images.githubusercontent.com/3056529/234854657-e592e554-79c4-4e1f-a548-f50b8526a078.png">

After making the change this is the result

<img width="445" alt="Screenshot 2023-04-27 at 7 40 05 AM" src="https://user-images.githubusercontent.com/3056529/234854735-d6401555-c2d2-4f9b-a386-4ea7bad5eeab.png">

