### PR TITLE
Fix duplication in static keyword for method generation

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -223,6 +223,8 @@ func generateMethods (_ p: Printer,
             }
             if instanceOrStatic == "" {
                 finalp = "final "
+            } else if instanceOrStatic == "static" {
+                finalp = " "
             } else {
                 finalp = "static "
             }

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -401,7 +401,7 @@ func generateMethods (_ p: Printer,
                     p ("gi.object_method_bind_call (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), Int64 (args.count), \(ptrResult), nil)")
                 } else {
                     let staticArg = method.isStatic ? ", nil" : ""
-                    p ("gi.object_method_bind_ptrcall (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), \(ptrResult)\(staticArg)")
+                    p ("gi.object_method_bind_ptrcall (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), \(ptrResult)\(staticArg))")
                 }
                 
                 if returnType != "" {

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -400,7 +400,8 @@ func generateMethods (_ p: Printer,
                 if method.isVararg {
                     p ("gi.object_method_bind_call (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), Int64 (args.count), \(ptrResult), nil)")
                 } else {
-                    p ("gi.object_method_bind_ptrcall (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), \(ptrResult))")
+                    let staticArg = method.isStatic ? ", nil" : ""
+                    p ("gi.object_method_bind_ptrcall (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), \(ptrResult)\(staticArg)")
                 }
                 
                 if returnType != "" {

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -223,7 +223,7 @@ func generateMethods (_ p: Printer,
             }
             if instanceOrStatic == "" {
                 finalp = "final "
-            } else if instanceOrStatic == "static" {
+            } else if instanceOrStatic == " static" {
                 finalp = " "
             } else {
                 finalp = "static "

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -396,12 +396,11 @@ func generateMethods (_ p: Printer,
                     ptrResult = "nil"
                 }
                 
-                let instanceHandle = method.isStatic ? "" : "UnsafeMutableRawPointer (mutating: handle), "
+                let instanceHandle = method.isStatic ? "nil, " : "UnsafeMutableRawPointer (mutating: handle), "
                 if method.isVararg {
                     p ("gi.object_method_bind_call (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), Int64 (args.count), \(ptrResult), nil)")
                 } else {
-                    let staticArg = method.isStatic ? ", nil" : ""
-                    p ("gi.object_method_bind_ptrcall (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), \(ptrResult)\(staticArg))")
+                    p ("gi.object_method_bind_ptrcall (\(cdef.name).method_\(method.name), \(instanceHandle)\(ptrArgs), \(ptrResult))")
                 }
                 
                 if returnType != "" {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "xmlcoder",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/CoreOffice/XMLCoder",
+      "state" : {
+        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
+        "version" : "0.17.1"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
Currently, the generator ends up creating methods with the static keyword repeated, causing a build failure:

```swift
public static static func () {}
```

This PR attempts to fix this, as well as address a build error regarding gi.object_method_bind_ptrcall in cases of static methods. I don't know how well this solution works, since I couldn't really test any static methods available to me. (I was hoping this would generate the utility functions).

Edit: This should help contribute to #48 .