### PR TITLE
Fix ObjectCollection Subscript Crash

### DIFF
--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -37,7 +37,7 @@ public class ObjectCollection<T:Object>: GArray, Collection {
             var v = super [index]
             var handle = UnsafeMutableRawPointer(bitPattern: 0)
             v.toType(.object, dest: &handle)
-            return objectFromHandle (nativeHandle: handle!) as! T
+            return lookupObject(nativeHandle: handle!)
         }
         set {
             super [index] = Variant (newValue)


### PR DESCRIPTION
I am running into a crash for this scenario..

I have a class I created in `SimpleExtension` named `UIGround` that is a subclass of `Node2D` and registered the object to use in Godot.

The makeup of this scene in Godot is:
```
- Ground (UIGround)
  - Sprite2D
  - Area2D
    - CollisionShape2D
```

I have another class `PlayerActions` that has a `Area2D` which I use to call `Area2D.getOverlappingAreas()` which returns the `Godot.Area2D` which it is not able to lookup in `liveFrameworkObjects` or `liveSubtypedObjects` because the `nativeHandler` doesn't exist for that object.

By using `lookupObject<T>(nativeHandler:) -> T` it first does the `objectFromHandle(nativeHandle:) --> Wrapped?` check and if it doesn't exist there does the `gi` call and successfully returns the typed object.

Maybe there is a more elegant solution or this will cause other issues but it solved my problem and doesn't seem to be causing any others but I have a fairly small project.


