### PR TITLE
Update build scripts to add arm64 to Mac builds

### DIFF
--- a/scripts/make-swiftgodot-framework
+++ b/scripts/make-swiftgodot-framework
@@ -22,9 +22,15 @@ esac
 
 rm -rf $2
 bdMac=$1/Build/Products/Debug/
+bdMacArm="$(echo "$1" | rev | cut -c2- | rev)_arm/Build/Products/Debug/"
 bdiOS=$1/Build/Products/Debug-iphoneos/
-xcodebuild -create-xcframework -framework $bdMac/PackageFrameworks/SwiftGodot.framework -framework $bdiOS/PackageFrameworks/SwiftGodot.framework -output $2
-fd=$2//macos-x86_64/SwiftGodot.framework
+mkdir universal
+echo $bdMacArm
+cp -rf $bdMac/PackageFrameworks/SwiftGodot.framework universal/
+lipo -create -output ./universal/SwiftGodot.framework/SwiftGodot $bdMac/PackageFrameworks/SwiftGodot.framework/SwiftGodot $bdMacArm/PackageFrameworks/SwiftGodot.framework/SwiftGodot
+xcodebuild -create-xcframework -framework ./universal/SwiftGodot.framework -framework $bdiOS/PackageFrameworks/SwiftGodot.framework -output $2
+rm -rf ./universal
+fd=$2//macos-arm64_x86_64/SwiftGodot.framework
 (cd $fd; mkdir -p Versions/Current/Headers; ln -sf Versions/Current/Headers .)
 (cd $fd; mkdir -p Versions/Current/Modules; ln -sf Versions/Current/Modules .)
 rsync -a $bdMac/SwiftGodot.swiftmodule $fd/Versions/Current/Modules/

--- a/scripts/make-swiftgodot-framework
+++ b/scripts/make-swiftgodot-framework
@@ -26,7 +26,7 @@ bdMacArm="$(echo "$1" | rev | cut -c2- | rev)_arm/Build/Products/Debug/"
 bdiOS=$1/Build/Products/Debug-iphoneos/
 mkdir universal
 echo $bdMacArm
-cp -rf $bdMac/PackageFrameworks/SwiftGodot.framework universal/
+cp -rf $bdMacArm/PackageFrameworks/SwiftGodot.framework universal/
 lipo -create -output ./universal/SwiftGodot.framework/SwiftGodot $bdMac/PackageFrameworks/SwiftGodot.framework/SwiftGodot $bdMacArm/PackageFrameworks/SwiftGodot.framework/SwiftGodot
 xcodebuild -create-xcframework -framework ./universal/SwiftGodot.framework -framework $bdiOS/PackageFrameworks/SwiftGodot.framework -output $2
 rm -rf ./universal
@@ -34,6 +34,7 @@ fd=$2//macos-arm64_x86_64/SwiftGodot.framework
 (cd $fd; mkdir -p Versions/Current/Headers; ln -sf Versions/Current/Headers .)
 (cd $fd; mkdir -p Versions/Current/Modules; ln -sf Versions/Current/Modules .)
 rsync -a $bdMac/SwiftGodot.swiftmodule $fd/Versions/Current/Modules/
+rsync -a $bdMacArm/SwiftGodot.swiftmodule $fd/Versions/Current/Modules/
 
 cat > $fd/Modules/module.modulemap << EOF
 framework module SwiftGodot {

--- a/scripts/release
+++ b/scripts/release
@@ -49,7 +49,7 @@ xcodebuild -scheme SwiftGodot -destination platform=generic/macOS,arch=arm64 -de
 xcodebuild -scheme SwiftGodot -destination generic/platform=iOS -derivedDataPath $derivedData -archivePath $archivePath >& $dir/arm64.log
 sh scripts/make-swiftgodot-framework $dir/derived/ $outputDir/SwiftGodot.xcframework
 
-if [ -z "$SWIFT_GODOT_NODEPLOY" ]; then
+if [ ! -z "$SWIFT_GODOT_NODEPLOY" ]; then
     echo "Skipping deployment stage."
     exit
 fi

--- a/scripts/release
+++ b/scripts/release
@@ -42,6 +42,7 @@ echo DerivedData: $derivedData
 echo ArchiveData: $archivePath
 
 xcodebuild -scheme SwiftGodot -destination platform=generic/macOS,arch=x86_64 -derivedDataPath $derivedData -archivePath $archivePath >& $dir/x86_64.log
+xcodebuild -scheme SwiftGodot -destination platform=generic/macOS,arch=arm64 -derivedDataPath "${derivedData}_arm" -archivePath $archivePath >& $dir/arm64.log
 xcodebuild -scheme SwiftGodot -destination generic/platform=iOS -derivedDataPath $derivedData -archivePath $archivePath >& $dir/arm64.log
 sh scripts/make-swiftgodot-framework $dir/derived/ $outputDir/SwiftGodot.xcframework
 

--- a/scripts/release
+++ b/scripts/release
@@ -49,6 +49,11 @@ sh scripts/make-swiftgodot-framework $dir/derived/ $outputDir/SwiftGodot.xcframe
 (cd $outputDir; zip --symlinks -ru SwiftGodot.xcframework.zip SwiftGodot.xcframework)
 csum=`swift package compute-checksum $outputDir/SwiftGodot.xcframework.zip`
 
+if [ -z "$SWIFT_GODOT_NODEPLOY" ]; then
+    echo "Skipping deployment stage."
+    return
+fi
+
 gh release create $tag $outputDir/SwiftGodot.xcframework.zip -R migueldeicaza/SwiftGodot -F $2
 cat > ../SwiftGodotBinary/Package.swift  <<EOF
 // swift-tools-version:5.7

--- a/scripts/release
+++ b/scripts/release
@@ -12,9 +12,12 @@ if test ! -e scripts/make-swiftgodot-framework; then
    echo expected this to run from the SwiftGodot directory
    exit 1
 fi
-if test ! -e ../SwiftGodotBinary; then
-   echo expected to have a peer directory SwiftGodotBinary to publish results
-   exit 1
+
+if [ -z "$SWIFT_GODOT_NODEPLOY" ]; then
+    if test ! -e ../SwiftGodotBinary; then
+       echo expected to have a peer directory SwiftGodotBinary to publish results
+       exit 1
+    fi
 fi
 
 case $1 in
@@ -46,13 +49,13 @@ xcodebuild -scheme SwiftGodot -destination platform=generic/macOS,arch=arm64 -de
 xcodebuild -scheme SwiftGodot -destination generic/platform=iOS -derivedDataPath $derivedData -archivePath $archivePath >& $dir/arm64.log
 sh scripts/make-swiftgodot-framework $dir/derived/ $outputDir/SwiftGodot.xcframework
 
-(cd $outputDir; zip --symlinks -ru SwiftGodot.xcframework.zip SwiftGodot.xcframework)
-csum=`swift package compute-checksum $outputDir/SwiftGodot.xcframework.zip`
-
 if [ -z "$SWIFT_GODOT_NODEPLOY" ]; then
     echo "Skipping deployment stage."
     return
 fi
+
+(cd $outputDir; zip --symlinks -ru SwiftGodot.xcframework.zip SwiftGodot.xcframework)
+csum=`swift package compute-checksum $outputDir/SwiftGodot.xcframework.zip`
 
 gh release create $tag $outputDir/SwiftGodot.xcframework.zip -R migueldeicaza/SwiftGodot -F $2
 cat > ../SwiftGodotBinary/Package.swift  <<EOF

--- a/scripts/release
+++ b/scripts/release
@@ -18,19 +18,19 @@ if [ -z "$SWIFT_GODOT_NODEPLOY" ]; then
        echo expected to have a peer directory SwiftGodotBinary to publish results
        exit 1
     fi
-fi
 
-case $1 in
-   v*)
-	echo Tagging with $1
-	git tag $1
-	tag=$1
-	;;
-   *)
-	echo "version to tag should be vXXX"
-	exit 1
-	;;
-esac
+    case $1 in
+        v*)
+            echo Tagging with $1
+            git tag $1
+            tag=$1
+            ;;
+        *)
+            echo "version to tag should be vXXX"
+            exit 1
+            ;;
+    esac
+fi
 
 outputDir=$HOME/sg-builds
 dir=$outputDir/$$-build

--- a/scripts/release
+++ b/scripts/release
@@ -51,7 +51,7 @@ sh scripts/make-swiftgodot-framework $dir/derived/ $outputDir/SwiftGodot.xcframe
 
 if [ -z "$SWIFT_GODOT_NODEPLOY" ]; then
     echo "Skipping deployment stage."
-    return
+    exit
 fi
 
 (cd $outputDir; zip --symlinks -ru SwiftGodot.xcframework.zip SwiftGodot.xcframework)


### PR DESCRIPTION
The xcframework now contains a universal framework on the macOS side for arm64 and x86_64. The two are stitched together using lipo.