### PR TITLE
Fixing the SwiftPM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,29 @@ will call.   To get started, the simplest thing to do is to
 create a Swift Library Package that references the Swift Godot 
 package, like this:
 
-```
+```swift
+// swift-tools-version: 5.8
+import PackageDescription
+
 let package = Package(
     name: "MyFirstGame",
     products: [
-        .library (name; "MyFirstGame", type: .dynamic, targets: ["MyFirstGame"]),
+        .library(name: "MyFirstGame", type: .dynamic, targets: ["MyFirstGame"]),
     ],
     dependencies: [
-        .package (url: "https://github.com/migueldeicaza/SwiftGodot")
+        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "main")
     ],
     targets: [
-        .target (
+        .target(
             name: "MyFirstGame",
             dependencies: ["SwiftGodot"],
-            swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
-            linkerSettings: [.unsafeFlags (
+            swiftSettings: [.unsafeFlags(["-suppress-warnings"])],
+            linkerSettings: [.unsafeFlags(
                 ["-Xlinker", "-undefined",
-                 "-Xlinker", "dynamic_lookup")]])            
+                 "-Xlinker", "dynamic_lookup"]
+            )]
+        )
+		            
     ]
 )
 ```


### PR DESCRIPTION
~~So it can be generated with `swift package generate-xcodeproj`~~
Edit: Nevermind that, it's deprecated. 
Still fixes issues with semicolons and matching closing tags. 