### PR TITLE
Replace instances of Float with Double

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -26,7 +26,7 @@ func getInitializer (_ bc: JGodotBuiltinClass, _ val: String) -> String? {
 
                     // Some Godot constants leak into the initializers
                     if pval.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) == "inf" {
-                        pval = "Float.infinity"[...]
+                        pval = "Double.infinity"[...]
                     }
 
                     prefixedArgs = prefixedArgs + name + ": " + pval

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -24,7 +24,7 @@ func BuiltinJsonTypeToSwift (_ type: String) -> String {
 // regardless of what the sizes are declared for the API.
 func MemberBuiltinJsonTypeToSwift (_ type: String) -> String {
     switch type {
-    case "float": return "Float"
+    case "float": return "Double"
     case "int":
         return "Int32"
     case "bool": return "Bool"
@@ -261,7 +261,7 @@ func getGodotType (_ t: TypeWithMeta?, kind: ArgumentKind = .classes) -> String 
         }
     case "float", "real":
         if kind == .builtInField {
-            return "Float"
+            return "Double"
         } else {
             if let meta = t.meta {
                 switch meta {

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -80,8 +80,8 @@ class SwiftSprite: Sprite2D {
         time_passed += delta
     
         SwiftSprite.lerp (from: 0.1, to: 10, weight: 1)
-        var newPos = Vector2(x: Float (10 + (10 * sin(time_passed * 2.0))),
-                             y: Float (10.0 + (10.0 * cos(time_passed * 1.5))))
+        var newPos = Vector2(x: Double (10 + (10 * sin(time_passed * 2.0))),
+                             y: Double (10.0 + (10.0 * cos(time_passed * 1.5))))
         
         self.position = newPos
     }


### PR DESCRIPTION
I noticed that when initializing color you could create a Color value of Color(r: 1, g: 1, b: 1, a: 1) and somehow only get Color(r: 0, g: 0, b: 0, a: 0) with some random numbers sometimes in place of the zeros. With some testing I realized that using Double for Color instead solved the issue. So it seems like the cpp expects doubles and not floats.

Note: this actually seems to cause issues with Vector. So it's possible that it's not as cut and dry and replacing all instances of Float with Double. 

https://github.com/migueldeicaza/SwiftGodot/issues/83
