### PR TITLE
Clean up unnecessary dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
             name: "GDExtension"),
         .target(
             name: "SwiftGodot",
-            dependencies: ["GDExtension", "Generator"],
+            dependencies: ["GDExtension"],
             swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
             linkerSettings: [
                 .unsafeFlags (


### PR DESCRIPTION
CodeGeneratorPlugin's dependency should be enough, There's no need for the core target to depend on Generator.