### PR TITLE
Use GDExtensionVariantType.RawValue abstraction

### DIFF
--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -214,7 +214,7 @@ public struct PropInfo {
     }
     func makeNativeStruct () -> GDExtensionPropertyInfo {
         GDExtensionPropertyInfo(
-            type: GDExtensionVariantType(UInt32 (propertyType.rawValue)),
+            type: GDExtensionVariantType(GDExtensionVariantType.RawValue (propertyType.rawValue)),
             name: &propertyName.content,
             class_name: &className.content,
             hint: UInt32 (hint.rawValue),

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -24,7 +24,7 @@ public class ObjectCollection<T:Object>: GArray, Collection {
         var name = StringName()
         var variant = Variant()
 
-        gi.array_set_typed (&content, GDExtensionVariantType (UInt32(Variant.GType.object.rawValue)), &name.content, &variant.content)
+        gi.array_set_typed (&content, GDExtensionVariantType (GDExtensionVariantType.RawValue(Variant.GType.object.rawValue)), &name.content, &variant.content)
     }
     
     public required init? (_ variant: Variant) {

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -25,7 +25,7 @@ public class VariantCollection<T:GodotVariant>: GArray, Collection {
         var name = StringName()
         var variant = Variant()
 
-        //gi.array_set_typed (&content, GDExtensionVariantType (UInt32(T.variantType.rawValue)), &name.content, &variant.content)
+        //gi.array_set_typed (&content, GDExtensionVariantType (GDExtensionVariantType.RawValue(T.variantType.rawValue)), &name.content, &variant.content)
     }
     
     public required init? (_ variant: Variant) {

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -43,7 +43,7 @@ public class Variant: Hashable, Equatable, ExpressibleByStringLiteral {
         var map: [GDExtensionVariantFromTypeConstructorFunc] = []
         
         for vtype in 0..<Variant.GType.max.rawValue {
-            let v = UInt32 (vtype == 0 ? 1 : vtype)
+            let v = GDExtensionVariantType.RawValue (vtype == 0 ? 1 : vtype)
             map.append (gi.get_variant_from_type_constructor (GDExtensionVariantType (v))!)
         }
         return map
@@ -53,7 +53,7 @@ public class Variant: Hashable, Equatable, ExpressibleByStringLiteral {
         var map: [GDExtensionTypeFromVariantConstructorFunc] = []
         
         for vtype in 0..<Variant.GType.max.rawValue {
-            let v = UInt32 (vtype == 0 ? 1 : vtype)
+            let v = GDExtensionVariantType.RawValue (vtype == 0 ? 1 : vtype)
             map.append (gi.get_variant_to_type_constructor (GDExtensionVariantType (v))!)
         }
         return map


### PR DESCRIPTION
GDExtensionVariantType.RawValue is Int32 when building on Windows. Using RawValue abstraction instead of concrete type should help to avoid type mismatch.