### PR TITLE
Wrapped: Cast generic types to AnyObject explicitly

### DIFF
--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -167,7 +167,7 @@ func register<T:Wrapped> (type name: StringName, parent: StringName, type: T.Typ
     info.get_virtual_func = getVirtual
     info.notification_func = notificationFunc
     
-    let retained = Unmanaged<AnyObject>.passRetained(type)
+    let retained = Unmanaged<AnyObject>.passRetained(type as AnyObject)
     info.class_userdata = retained.toOpaque()
     
     gi.classdb_register_extension_class (library, UnsafeRawPointer (&name.content), UnsafeRawPointer(&parent.content), &info)
@@ -194,7 +194,7 @@ public func register<T:Wrapped> (type: T.Type) {
         return String (describing: t)
     }
     
-    guard let superStr = getSuperType (type: type) else {
+    guard let superStr = getSuperType (type: type as AnyObject) else {
         print ("You can not register the root class")
         return
     }


### PR DESCRIPTION
Trying to build SwiftGodot on Windows results in the following errors:
```
C:\Projects\SwiftGodot\Sources\SwiftGodot\Core\Wrapped.swift:197:46: error: argument type 'T.Type' expected to be an instance of a class or class-constrained type
    guard let superStr = getSuperType (type: type) else {
                                             ^
C:\Projects\SwiftGodot\Sources\SwiftGodot\Core\Wrapped.swift:170:54: error: argument type 'T.Type' expected to be an instance of a class or class-constrained type
    let retained = Unmanaged<AnyObject>.passRetained(type)
                                                     ^
```
Explicit cast to AnyObject seems to fix the issue.