### PR TITLE
Fix method flags type mismatch on Windows

### DIFF
--- a/Sources/SwiftGodot/Export.swift
+++ b/Sources/SwiftGodot/Export.swift
@@ -32,7 +32,7 @@ func additionalRegistations (name: StringName) {
                 minfo.method_userdata = UnsafeMutableRawPointer (bitPattern: 0x123123123)
                 minfo.call_func = callFunc
                 minfo.ptrcall_func = ptrCallFunc
-                minfo.method_flags = (GDEXTENSION_METHOD_FLAG_VIRTUAL).rawValue
+                minfo.method_flags = UInt32((GDEXTENSION_METHOD_FLAG_VIRTUAL).rawValue)
                 minfo.has_return_value = 0
                 minfo.argument_count = 1
                 minfo.arguments_metadata = UnsafeMutablePointer (mutating: argMetaPtr.baseAddress)


### PR DESCRIPTION
Don't know why, but C enums on Windows implicitly get signed integer as the underlying type, which results in type mismatch for method_flags assignment (which is explicitly declared as uint32_t). This was also the cause for type mismatch at #123. Doesn't happen when building on Ubuntu.