### PR TITLE
Update docs, tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ public func swift_entry_point(
 }
 ```
 
+Alternatively, you can use the `#initSwiftExtension` macro:
+
+```
+import SwiftGodotMacros
+
+#initSwiftExtension(name: "swift_entry_point", types: [SpinningCube.self])
+```
+
 ## Bundling Your Extension
 
 To make your extension available to Godot, you will need to 

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/Package-starter-4.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/Package-starter-4.swift
@@ -22,7 +22,10 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "SimpleRunnerDriver",
-            dependencies: ["SwiftGodot"],
+            dependencies: [
+                "SwiftGodot",
+                .product(name: "SwiftGodotMacros", package: "SwiftGodot")
+            ],
             swiftSettings: [.unsafeFlags(["-suppress-warnings"])],
             linkerSettings: [.unsafeFlags(
                 ["-Xlinker", "-undefined",


### PR DESCRIPTION
The tutorial now includes the step for adding SwiftGodotMacros to Package.swift.

The README now also demonstrates the initSwiftExtension macro.