### PR TITLE
Remove classInfo variable

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -165,7 +165,7 @@ class GodotMacroProcessor {
     """
     static func _initClass () {
         let className = StringName("\(className)")
-        let classInfo = ClassInfo<\(className)> (name: className)\n
+        let _ = ClassInfo<\(className)> (name: className)\n
     """
         for member in classDecl.memberBlock.members.enumerated() {
             let decl = member.element.decl


### PR DESCRIPTION
Since I build without the option of suppressing warnings I get this error when I build. This is because we don't use the classInfo variable.

```
/var/folders/vg/yjyvdt016d5_ws4fz5_qycmc0000gn/T/swift-generated-sources/@__swiftmacro_19PlantGenerationDemo26CatmullRomSplineVisualizer5GodotfMm_.swift:12:9: warning: initialization of immutable value 'classInfo' was never used; consider replacing with assignment to '_' or removing it
    let classInfo = ClassInfo<CatmullRomSplineVisualizer> (name: className)
        ^
/Users/nvanfleet/src/PlantGeneration/swift_src/Demo/CatmullRomSplineVisualizer.swift:8:7: note: in expansion of macro 'Godot' here
final class CatmullRomSplineVisualizer: Node3D {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```