### PR TITLE
Fix issue where `initSwiftExtension` types were expected to be homogenous

### DIFF
--- a/Sources/SwiftGodotMacros/MacroDefs.swift
+++ b/Sources/SwiftGodotMacros/MacroDefs.swift
@@ -60,9 +60,9 @@ public macro Export(_ hint: PropertyHint = .none, _ hintStr: String? = nil) = #e
 /// - Parameter cdecl: The name of the entrypoint exposed to C.
 /// - Parameter types: The node types that should be registered with Godot.
 @freestanding(declaration, names: named(enterExtension), named(setupExtension))
-public macro initSwiftExtension<T: Wrapped>(cdecl: String,
-                                            types: [T.Type]) = #externalMacro(module: "SwiftGodotMacroLibrary",
-                                                                              type: "InitSwiftExtensionMacro")
+public macro initSwiftExtension(cdecl: String,
+                                types: [Wrapped.Type]) = #externalMacro(module: "SwiftGodotMacroLibrary",
+                                                                        type: "InitSwiftExtensionMacro")
 
 /// A macro that instantiates a `Texture2D` from a specified resource path. If the texture cannot be created, a
 /// `preconditionFailure` will be thrown.


### PR DESCRIPTION
```swift
#initSwiftExtension(cdecl: "swift_entry_point", types: [
    Jumper.self,
    Circle.self,
    MainScene.self,
    HUD.self,
    BaseScreen.self,
    Screens.self,
    AboutScreen.self,
])
```

This code was failing with:
>CircleJumpDriver.swift:19:5: error: cannot convert value of type 'BaseScreen.Type' to expected element type 'Array<AboutScreen.Type>.ArrayLiteralElement' (aka 'AboutScreen.Type')
    BaseScreen.self,

This is because the generic on the `initSwiftExtension` definition was set up to expect an array of identically typed classes.

This PR changes the type to just be:`[Wrapped.Type]` which allows any types that conform to `Wrapped`, as opposed to a being an array of a single specific type that conforms.
