### PR TITLE
Permit implictly unwrapped optionals when using @SceneTree

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/SceneTreeMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SceneTreeMacro.swift
@@ -73,7 +73,9 @@ public struct SceneTreeMacro: AccessorMacro {
             return []
         }
 
-        guard let optional = nodeType.as(OptionalTypeSyntax.self) else {
+        let unwrappedType = nodeType.as(OptionalTypeSyntax.self)?.wrappedType ?? nodeType.as(ImplicitlyUnwrappedOptionalTypeSyntax.self)?.wrappedType
+        
+        guard let unwrappedType else {
             let newOptional = OptionalTypeSyntax(wrappedType: nodeType)
             let addOptionalFix = FixIt(message: MarkOptionalMessage(),
                                        changes: [.replace(oldNode: Syntax(nodeType), newNode: Syntax(newOptional))])
@@ -90,7 +92,7 @@ public struct SceneTreeMacro: AccessorMacro {
 
         return [
             """
-            get { getNodeOrNull(path: NodePath(stringLiteral: \(argument))) as? \(optional.wrappedType) }
+            get { getNodeOrNull(path: NodePath(stringLiteral: \(argument))) as? \(unwrappedType) }
             """
         ]
     }

--- a/Tests/SwiftGodotMacrosTests/SceneTreeMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/SceneTreeMacroTests.swift
@@ -35,6 +35,27 @@ final class SceneTreeMacroTests: XCTestCase {
             macros: testMacros
         )
     }
+    
+    func testMacroExpansionWithImplicitlyUnwrappedOptional() {
+        assertMacroExpansion(
+            """
+            class MyNode: Node {
+                @SceneTree(path: "Entities/CharacterBody2D")
+                var character: CharacterBody2D!
+            }
+            """,
+            expandedSource: """
+            class MyNode: Node {
+                var character: CharacterBody2D! {
+                    get {
+                        getNodeOrNull(path: NodePath(stringLiteral: "Entities/CharacterBody2D")) as? CharacterBody2D
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
 
     func testMacroMissingPathDiagnostic() {
         assertMacroExpansion(
@@ -88,4 +109,6 @@ final class SceneTreeMacroTests: XCTestCase {
             macros: testMacros
         )
     }
+    
+    
 }


### PR DESCRIPTION
Since I know that I'm only going to reference these properties after they are available in `_ready()`, I prefer to implicitly unwrap the optional. At the moment a diagnostic warning prevents me from doing this. This PR loosens the requirement a bit so that we can use `!` as well as `?`. It will still emit a diagnostic if the type is missing both.

```swift
class MainScene: Node {
    @SceneTree(path: "StartPosition") var startPosition: Marker2D!
    @SceneTree(path: "Camera2D") var camera: Camera2D!
}
```