### PR TITLE
Fix source generation on Windows

### DIFF
--- a/Generator/Generator/Printer.swift
+++ b/Generator/Generator/Printer.swift
@@ -59,7 +59,7 @@ class Printer {
                 return
             }
         }
-        try! result.write(toFile: file, atomically: true, encoding: .utf8)
+        try! result.write(toFile: file, atomically: false, encoding: .utf8)
     }
 }
 
@@ -81,6 +81,6 @@ actor PrinterFactory {
                 return
             }
         }
-        try! result.write(toFile: file, atomically: true, encoding: .utf8)
+        try! result.write(toFile: file, atomically: false, encoding: .utf8)
     }
 }

--- a/Plugins/CodeGeneratorPlugin/plugin.swift
+++ b/Plugins/CodeGeneratorPlugin/plugin.swift
@@ -26,17 +26,21 @@ import PackagePlugin
         outputFiles.append(genSourcesDir.appending(subpath: "Generated.swift"))
         arguments.append(context.package.directory.appending(subpath: "doc"))
         arguments.append("--singlefile")
+        let cmd: Command = Command.prebuildCommand(
+            displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
+            executable: generator,
+            arguments: arguments,
+            outputFilesDirectory: genSourcesDir)
         #else
         outputFiles.append (contentsOf: knownBuiltin.map { genSourcesDir.appending(["generated-builtin", $0])})
         outputFiles.append (contentsOf: known.map { genSourcesDir.appending(["generated", $0])})
-        #endif
-        
         let cmd: Command = Command.buildCommand(
-            displayName: "Generating Swift API ffrom \(api) to \(genSourcesDir)",
+            displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
             executable: generator,
             arguments: arguments,
             inputFiles: [api],
             outputFiles: outputFiles)
+        #endif
         
         return [cmd]
     }


### PR DESCRIPTION
1. `buildCommand` does not work on Windows seemingly because of an SPM bug. I described the whole thing in https://github.com/apple/swift-package-manager/issues/6962. Using `prebuildCommand` instead fixes the issue.
2. After fixing codegen command Windows build fails with `You don't have permission` error. I suggest it's because generator executable doesn't have write permissions to the temporary directory `Foundation` implementation uses for atomic writes, since toggling off `atomically` fixed the issue for me. Not sure what benefit atomic writes can bring in context of code generator, so I disabled it for all platforms.