### PR TITLE
Change enum prefix detection strategy

### DIFF
--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -78,11 +78,12 @@ func getArgumentDeclaration (_ argument: JGodotArgument, eliminate: String, kind
                     } else {
                         // Need to look it up
                         if let optionType = findEnumDef(name: argumentType) {
+                            let prefix = optionType.values.commonPrefix()
                             var setValues = ""
                             
                             for value in optionType.values {
                                 if (defIntValue & value.value) != 0 {
-                                    let name = dropMatchingPrefix(optionType.name, value.name)
+                                    let name = snakeToCamel(value.name.dropPrefix(prefix)).validSwiftName()
                                     if setValues != "" {
                                         setValues += ", "
                                     }

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -83,7 +83,7 @@ func getArgumentDeclaration (_ argument: JGodotArgument, eliminate: String, kind
                             
                             for value in optionType.values {
                                 if (defIntValue & value.value) != 0 {
-                                    let name = snakeToCamel(value.name.dropPrefix(prefix)).validSwiftName()
+                                    let name = snakeToCamel(value.name.dropPrefix(prefix))
                                     if setValues != "" {
                                         setValues += ", "
                                     }

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -125,9 +125,9 @@ func generateVirtualProxy (_ p: Printer,
                 // object, but if it is not known, then we create the instance
                 //
                 if cmap.isRefcounted {
-                    argPrep += "let resolved_\(i) = gi.ref_get_object (args [\(i)]!)!\n"
+                    argPrep += "let resolved_\(i) = gi.ref_get_object (args [\(i)]!.load (as: UnsafeRawPointer.self))!\n"
                 } else {
-                    argPrep += "let resolved_\(i) = args [\(i)]!\n"
+                    argPrep += "let resolved_\(i) = args [\(i)]!.load (as: UnsafeRawPointer.self)\n"
                 }
                 argCall += "lookupLiveObject (handleAddress: resolved_\(i)) as? \(arg.type) ?? \(arg.type) (nativeHandle: resolved_\(i))"
             } else if let storage = builtinClassStorage [arg.type] {

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -525,7 +525,7 @@ func generateSignalType (_ p: Printer, _ cdef: JGodotExtensionAPIClass, _ signal
             p ("get async") {
                 p ("await withCheckedContinuation") {
                     p ("c in")
-                    p ("connect (flags: .connectOneShot) { \(lambdaIgnore) in c.resume () }")
+                    p ("connect (flags: .oneShot) { \(lambdaIgnore) in c.resume () }")
                 }
             }
         }

--- a/Generator/Generator/Enums.swift
+++ b/Generator/Generator/Enums.swift
@@ -57,7 +57,7 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
                     p ("self.rawValue = rawValue")
                 }
                 for enumVal in enumDef.values {
-                    let name = snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix)).validSwiftName()
+                    let name = snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix))
                     if let ed = docEnumToValue [enumVal.name] {
                         doc (p, cdef, ed)
                     }
@@ -83,7 +83,7 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
                         continue
                     }
                 }
-                let name = snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix)).validSwiftName()
+                let name = snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix))
                 let prefix: String
                 if used.contains(enumVal.value) {
                     prefix = "// "

--- a/Generator/Generator/Enums.swift
+++ b/Generator/Generator/Enums.swift
@@ -48,7 +48,7 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
         let isBitField = enumDef.isBitfield ?? false
         
         var enumDefName = enumDef.name
-        let enumCasePrefix = enumDef.values.map(\.name).commonPrefix()?.dropAfterLastUnderscore() ?? ""
+        let enumCasePrefix = enumDef.values.commonPrefix()
         
         if isBitField || enumDef.name == "ConnectFlags" {
             p ("public struct \(getGodotType (SimpleType (type: enumDef.name))): OptionSet") {
@@ -107,49 +107,3 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
     }
 }
 
-private extension [String] {
-    func commonPrefix() -> String? {
-        guard count > 1 else { return nil }
-        let alphabeticallySorted = sorted()
-        
-        guard let first = alphabeticallySorted.first,
-              let last = alphabeticallySorted.last else {
-            return nil
-        }
-        let prefix = first.commonPrefix(with: last)
-        return prefix != "" ? prefix : nil
-    }
-}
-
-private extension String {
-    func dropPrefix(_ prefix: String) -> String {
-        guard hasPrefix(prefix) else { return self }
-        guard prefix != self else { return self }
-        return String(dropFirst(prefix.count))
-    }
-    
-    func dropAfterLastUnderscore() -> String? {
-        if let range = range(of: "_", options: .backwards) {
-            return String(prefix(upTo: range.upperBound))
-        } else {
-            return nil
-        }
-    }
-    
-    func validSwiftName() -> String {
-        if isValidSwiftName() { return self }
-        
-        return "_\(self)"
-    }
-    
-    func isValidSwiftName() -> Bool {
-        let pattern = #"\b[a-zA-Z_][a-zA-Z0-9_]*\b"#
-        
-        do {
-            let regex = try Regex(pattern)
-            return self.wholeMatch(of: regex) != nil
-        } catch {
-            fatalError("Invalid regex pattern: \(error)")
-        }
-    }
-}

--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -23,7 +23,7 @@ extension String {
         return self.processCamalCaseRegex(pattern: acronymPattern)?
             .processCamalCaseRegex(pattern: normalPattern)?.lowercased() ?? self.lowercased()
     }
-              
+    
     fileprivate func processCamalCaseRegex(pattern: String) -> String? {
         let regex = try? NSRegularExpression(pattern: pattern, options: [])
         let range = NSRange(location: 0, length: count)
@@ -57,7 +57,7 @@ extension String {
 func escapeSwift (_ id: String) -> String {
     switch id {
     case "protocol", "func", "static", "inout", "in", "self", "case", "repeat", "default",
-         "import", "init", "continue", "class", "operator", "where", "var", "enum", "nil", "extension", "internal":
+        "import", "init", "continue", "class", "operator", "where", "var", "enum", "nil", "extension", "internal":
         return "`\(id)`"
     default:
         return id
@@ -88,19 +88,19 @@ extension String {
     func dropPrefix(_ prefix: String) -> String {
         guard hasPrefix(prefix) else { return self }
         guard prefix != self else { return self }
-		let prefixSize: Int
-		// special-case for https://github.com/migueldeicaza/SwiftGodot/issues/23
-		if prefix == "METHOD_", contains("METHOD_FLAG") {
-			if self == "METHOD_FLAGS_DEFAULT" {
-				prefixSize = "METHOD_FLAGS_".count
-			} else {
-				prefixSize = "METHOD_FLAG_".count
-			}
-		} else {
-			prefixSize = prefix.count
-		}
-		let suffix = String(dropFirst(prefixSize))
-		return suffix.isValidSwiftName() ? suffix : self
+        let prefixSize: Int
+        // special-case for https://github.com/migueldeicaza/SwiftGodot/issues/23
+        if prefix == "METHOD_", contains("METHOD_FLAG") {
+            if self == "METHOD_FLAGS_DEFAULT" {
+                prefixSize = "METHOD_FLAGS_".count
+            } else {
+                prefixSize = "METHOD_FLAG_".count
+            }
+        } else {
+            prefixSize = prefix.count
+        }
+        let suffix = String(dropFirst(prefixSize))
+        return suffix.isValidSwiftName() ? suffix : self
     }
     
     func dropAfterLastUnderscore() -> String? {
@@ -110,7 +110,7 @@ extension String {
             return nil
         }
     }
-	
+    
     func isValidSwiftName() -> Bool {
         let pattern = #"\b[a-zA-Z_][a-zA-Z0-9_]*\b"#
         

--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -63,3 +63,56 @@ func escapeSwift (_ id: String) -> String {
         return id
     }
 }
+
+extension [String] {
+    func commonPrefix() -> String? {
+        guard count > 1 else { return nil }
+        let alphabeticallySorted = sorted()
+        
+        guard let first = alphabeticallySorted.first,
+              let last = alphabeticallySorted.last else {
+            return nil
+        }
+        let prefix = first.commonPrefix(with: last)
+        return prefix != "" ? prefix : nil
+    }
+}
+
+extension [JGodotValueElement] {
+    func commonPrefix() -> String {
+        map(\.name).commonPrefix()?.dropAfterLastUnderscore() ?? ""
+    }
+}
+
+extension String {
+    func dropPrefix(_ prefix: String) -> String {
+        guard hasPrefix(prefix) else { return self }
+        guard prefix != self else { return self }
+        return String(dropFirst(prefix.count))
+    }
+    
+    func dropAfterLastUnderscore() -> String? {
+        if let range = range(of: "_", options: .backwards) {
+            return String(prefix(upTo: range.upperBound))
+        } else {
+            return nil
+        }
+    }
+    
+    func validSwiftName() -> String {
+        if isValidSwiftName() { return self }
+        
+        return "_\(self)"
+    }
+    
+    func isValidSwiftName() -> Bool {
+        let pattern = #"\b[a-zA-Z_][a-zA-Z0-9_]*\b"#
+        
+        do {
+            let regex = try Regex(pattern)
+            return self.wholeMatch(of: regex) != nil
+        } catch {
+            fatalError("Invalid regex pattern: \(error)")
+        }
+    }
+}

--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -88,7 +88,18 @@ extension String {
     func dropPrefix(_ prefix: String) -> String {
         guard hasPrefix(prefix) else { return self }
         guard prefix != self else { return self }
-		let suffix = String(dropFirst(prefix.count))
+		let prefixSize: Int
+		// special-case for https://github.com/migueldeicaza/SwiftGodot/issues/23
+		if prefix == "METHOD_", contains("METHOD_FLAG") {
+			if self == "METHOD_FLAGS_DEFAULT" {
+				prefixSize = "METHOD_FLAGS_".count
+			} else {
+				prefixSize = "METHOD_FLAG_".count
+			}
+		} else {
+			prefixSize = prefix.count
+		}
+		let suffix = String(dropFirst(prefixSize))
 		return suffix.isValidSwiftName() ? suffix : self
     }
     

--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-func snakeToCamel (_ s: String) -> String {
-    let parts = s.split (separator: "_")
-    let r = parts [0].lowercased() + parts.dropFirst().map { x in x.prefix (1).capitalized + String (x.dropFirst()).cleverLowercase() }.joined()
+func snakeToCamel(_ s: String) -> String {
+    let parts = s.split(separator: "_")
+    let r = parts[0].lowercased() + parts.dropFirst().map { x in x.prefix(1).capitalized + String(x.dropFirst()).cleverLowercase() }.joined()
     if s.first == "_" {
         return "_" + r
     }
@@ -20,10 +20,10 @@ extension String {
     func camelCaseToSnakeCase() -> String {
         let acronymPattern = "([A-Z]+)([A-Z][a-z]|[0-9])"
         let normalPattern = "([a-z0-9])([A-Z])"
-        return self.processCamalCaseRegex(pattern: acronymPattern)?
-            .processCamalCaseRegex(pattern: normalPattern)?.lowercased() ?? self.lowercased()
+        return processCamalCaseRegex(pattern: acronymPattern)?
+            .processCamalCaseRegex(pattern: normalPattern)?.lowercased() ?? lowercased()
     }
-    
+
     fileprivate func processCamalCaseRegex(pattern: String) -> String? {
         let regex = try? NSRegularExpression(pattern: pattern, options: [])
         let range = NSRange(location: 0, length: count)
@@ -31,18 +31,17 @@ extension String {
     }
 }
 
-func camelToSnake (_ s: String) -> String {
+func camelToSnake(_ s: String) -> String {
     s.camelCaseToSnakeCase()
         .replacingOccurrences(of: "2_D", with: "2D").replacingOccurrences(of: "3_D", with: "3D")
         .replacingOccurrences(of: "2_d", with: "2d").replacingOccurrences(of: "3_d", with: "3d")
 }
 
-extension String {
-    public func cleverLowercase () -> String
-    {
+public extension String {
+    func cleverLowercase() -> String {
         var upper = false
         var lower = false
-        
+
         for x in self {
             upper = upper || x.isUppercase
             lower = lower || x.isLowercase
@@ -50,14 +49,14 @@ extension String {
         if upper && lower {
             return self
         }
-        return self.lowercased()
+        return lowercased()
     }
 }
 
-func escapeSwift (_ id: String) -> String {
+func escapeSwift(_ id: String) -> String {
     switch id {
     case "protocol", "func", "static", "inout", "in", "self", "case", "repeat", "default",
-        "import", "init", "continue", "class", "operator", "where", "var", "enum", "nil", "extension", "internal":
+         "import", "init", "continue", "class", "operator", "where", "var", "enum", "nil", "extension", "internal":
         return "`\(id)`"
     default:
         return id
@@ -68,9 +67,10 @@ extension [String] {
     func commonPrefix() -> String? {
         guard count > 1 else { return nil }
         let alphabeticallySorted = sorted()
-        
+
         guard let first = alphabeticallySorted.first,
-              let last = alphabeticallySorted.last else {
+              let last = alphabeticallySorted.last
+        else {
             return nil
         }
         let prefix = first.commonPrefix(with: last)
@@ -101,19 +101,20 @@ extension String {
         let suffix = String(dropFirst(prefixSize))
         return suffix.isValidSwiftName() ? suffix : self
     }
-    
+
     func dropAfterLastUnderscore() -> String? {
         if let range = range(of: "_", options: .backwards) {
             return String(prefix(upTo: range.upperBound))
+        }
         return nil
     }
-    
+
     func isValidSwiftName() -> Bool {
         let pattern = #"\b[a-zA-Z_][a-zA-Z0-9_]*\b"#
-        
+
         do {
             let regex = try Regex(pattern)
-            return self.wholeMatch(of: regex) != nil
+            return wholeMatch(of: regex) != nil
         } catch {
             fatalError("Invalid regex pattern: \(error)")
         }

--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -88,7 +88,8 @@ extension String {
     func dropPrefix(_ prefix: String) -> String {
         guard hasPrefix(prefix) else { return self }
         guard prefix != self else { return self }
-        return String(dropFirst(prefix.count))
+		let suffix = String(dropFirst(prefix.count))
+		return suffix.isValidSwiftName() ? suffix : self
     }
     
     func dropAfterLastUnderscore() -> String? {
@@ -98,13 +99,7 @@ extension String {
             return nil
         }
     }
-    
-    func validSwiftName() -> String {
-        if isValidSwiftName() { return self }
-        
-        return "_\(self)"
-    }
-    
+	
     func isValidSwiftName() -> Bool {
         let pattern = #"\b[a-zA-Z_][a-zA-Z0-9_]*\b"#
         

--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -86,8 +86,7 @@ extension [JGodotValueElement] {
 
 extension String {
     func dropPrefix(_ prefix: String) -> String {
-        guard hasPrefix(prefix) else { return self }
-        guard prefix != self else { return self }
+        guard hasPrefix(prefix), prefix != self else { return self }
         let prefixSize: Int
         // special-case for https://github.com/migueldeicaza/SwiftGodot/issues/23
         if prefix == "METHOD_", contains("METHOD_FLAG") {
@@ -106,9 +105,7 @@ extension String {
     func dropAfterLastUnderscore() -> String? {
         if let range = range(of: "_", options: .backwards) {
             return String(prefix(upTo: range.upperBound))
-        } else {
-            return nil
-        }
+        return nil
     }
     
     func isValidSwiftName() -> Bool {

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -52,7 +52,7 @@ func mapEnumValue (enumDef: String, value: String) -> String? {
             }
 
             if "\(evalue.value)" == value {
-                let name = snakeToCamel(evalue.name.dropPrefix(enumCasePrefix)).validSwiftName()
+                let name = snakeToCamel(evalue.name.dropPrefix(enumCasePrefix))
                 return ".\(escapeSwift (name))"
             }
         }

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -43,6 +43,7 @@ func isBuiltinClass (_ godotTypeName: String) -> Bool {
 /// Example type: "ArrowDirection", value: "0" would return ".up"
 func mapEnumValue (enumDef: String, value: String) -> String? {
     func findEnumMatch (element:  JGodotGlobalEnumElement) -> String? {
+        let enumCasePrefix = element.values.commonPrefix()
         for evalue in element.values {
             let ename = evalue.name
             if ename == "INLINE_ALIGNMENT_TOP_TO" || ename == "INLINE_ALIGNMENT_TO_TOP" || ename == "INLINE_ALIGNMENT_IMAGE_MASK" || ename == "INLINE_ALIGNMENT_TEXT_MASK" {
@@ -51,7 +52,7 @@ func mapEnumValue (enumDef: String, value: String) -> String? {
             }
 
             if "\(evalue.value)" == value {
-                let name = dropMatchingPrefix (String (element.name), evalue.name)
+                let name = snakeToCamel(evalue.name.dropPrefix(enumCasePrefix)).validSwiftName()
                 return ".\(escapeSwift (name))"
             }
         }

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,14 @@
 import PackageDescription
 import CompilerPluginSupport
 
+var linkerSettings: [LinkerSetting] = []
+#if os(macOS)
+linkerSettings.append(.unsafeFlags([
+    "-Xlinker", "-undefined",
+    "-Xlinker", "dynamic_lookup",
+]))
+#endif
+
 let package = Package(
     name: "SwiftGodot",
     platforms: [
@@ -61,12 +69,8 @@ let package = Package(
             name: "SwiftGodot",
             dependencies: ["GDExtension"],
             swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
-            linkerSettings: [
-                .unsafeFlags (
-                    ["-Xlinker", "-undefined",
-                     "-Xlinker", "dynamic_lookup",
-                    ])
-            ], plugins: ["CodeGeneratorPlugin"]),
+            linkerSettings: linkerSettings,
+            plugins: ["CodeGeneratorPlugin"]),
         
         // These are macros that can be used by third parties to simplify their
         // SwiftGodot development experience, these are used at compile time by
@@ -88,10 +92,7 @@ let package = Package(
             name: "SimpleExtension",
             dependencies: ["SwiftGodotMacros"],
             swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
-            linkerSettings: [
-                .unsafeFlags (
-                    ["-Xlinker", "-undefined",
-                     "-Xlinker", "dynamic_lookup"])]),
+            linkerSettings: linkerSettings),
         // Idea: -mark_dead_strippable_dylib
         .testTarget(name: "SwiftGodotMacroTests",
                     dependencies: [

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -105,8 +105,8 @@ class SwiftSprite2: Sprite2D {
                      hintStr: "Some kind of food",
                      usage: .default)
         ]
-        classInfo.registerMethod(name: "demo_set_favorite_food", flags: .flagsDefault, returnValue: nil, arguments: foodArgs, function: SwiftSprite2.demoSetFavoriteFood)
-        classInfo.registerMethod(name: "demo_get_favorite_food", flags: .flagsDefault, returnValue: foodArgs [0], arguments: [], function: SwiftSprite2.demoGetFavoriteFood)
+        classInfo.registerMethod(name: "demo_set_favorite_food", flags: .default, returnValue: nil, arguments: foodArgs, function: SwiftSprite2.demoSetFavoriteFood)
+        classInfo.registerMethod(name: "demo_get_favorite_food", flags: .default, returnValue: foodArgs [0], arguments: [], function: SwiftSprite2.demoGetFavoriteFood)
         
         let foodProp = PropInfo (propertyType: .string,
                                  propertyName: "demo_favorite_food",

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -103,17 +103,17 @@ class SwiftSprite2: Sprite2D {
                      className: StringName ("food"),
                      hint: .typeString,
                      hintStr: "Some kind of food",
-                     usage: .propertyUsageDefault)
+                     usage: .default)
         ]
-        classInfo.registerMethod(name: "demo_set_favorite_food", flags: .default, returnValue: nil, arguments: foodArgs, function: SwiftSprite2.demoSetFavoriteFood)
-        classInfo.registerMethod(name: "demo_get_favorite_food", flags: .default, returnValue: foodArgs [0], arguments: [], function: SwiftSprite2.demoGetFavoriteFood)
+        classInfo.registerMethod(name: "demo_set_favorite_food", flags: .flagsDefault, returnValue: nil, arguments: foodArgs, function: SwiftSprite2.demoSetFavoriteFood)
+        classInfo.registerMethod(name: "demo_get_favorite_food", flags: .flagsDefault, returnValue: foodArgs [0], arguments: [], function: SwiftSprite2.demoGetFavoriteFood)
         
         let foodProp = PropInfo (propertyType: .string,
                                  propertyName: "demo_favorite_food",
                                  className: "SwiftSprite",
                                  hint: .multilineText,
                                  hintStr: "Name of your favorite food",
-                                 usage: .propertyUsageDefault)
+                                 usage: .default)
         classInfo.registerProperty(foodProp, getter: "demo_get_favorite_food", setter: "demo_set_favorite_food")
     }()
     

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -11,6 +11,15 @@ import SwiftGodotMacros
 var sequence = 0
 
 @Godot
+class Rigid: RigidBody2D {
+    override func _integrateForces(state: PhysicsDirectBodyState2D?) {
+        guard let xform = state?.transform else {
+            return
+        }
+    }
+}
+
+@Godot
 class SwiftSprite: Sprite2D {
     var time_passed: Double = 0
     var count: Int = 0
@@ -48,9 +57,14 @@ class SwiftSprite: Sprite2D {
         return Float(GD.lerp(from: Variant(from), to: Variant(to), weight: Variant(weight))) ?? 0
     }
     
+    var x: Rigid?
+    
     override func _process (delta: Double) {
         time_passed += delta
-        
+    
+        if x == nil {
+            self.x = Rigid()
+        }
         let imageVariant = ProjectSettings.getSetting(name: "shader_globals/heightmap", defaultValue: Variant(-1))
         GD.print("Found this value IMAGE: \(imageVariant.gtype) variant: \(imageVariant) desc: \(imageVariant.description)")
         
@@ -142,7 +156,8 @@ class SwiftSprite2: Sprite2D {
     static func lerp(from: Float, to: Float, weight: Float) -> Float {
         return Float(GD.lerp(from: Variant(from), to: Variant(to), weight: Variant(weight))) ?? 0
     }
-    
+
+
     override func _process (delta: Double) {
         time_passed += delta
         
@@ -170,6 +185,7 @@ func setupScene (level: GDExtension.InitializationLevel) {
     if level == .scene {
         register(type: SwiftSprite.self)
         register(type: SwiftSprite2.self)
+        register(type: Rigid.self)
     }
 }
 

--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -84,7 +84,7 @@ public class ClassInfo<T:Object> {
     ///         className: "MyNode",
     ///         hint: .flags,
     ///         hintStr: "Number of baddies to check",
-    ///         usage: .propertyUsageDefault)
+    ///         usage: .default)
     ///     ]
     ///     classInfo.registerMethod (name: "checkBaddies", flags: .default, returnValue: .nil, arguments: [], function: MyNode.checkBaddies)
     ///     return true

--- a/Sources/SwiftGodot/Core/SignalSupport.swift
+++ b/Sources/SwiftGodot/Core/SignalSupport.swift
@@ -24,7 +24,7 @@ public class SignalProxy: Object {
         
         let s = ClassInfo<SignalProxy>(name: "SignalProxy")
         
-        s.registerMethod(name: SignalProxy.proxyName, flags: .flagsDefault, returnValue: nil, arguments: [], function: SignalProxy.proxyFunc)
+        s.registerMethod(name: SignalProxy.proxyName, flags: .default, returnValue: nil, arguments: [], function: SignalProxy.proxyFunc)
         return true
     } ()
     

--- a/Sources/SwiftGodot/Core/SignalSupport.swift
+++ b/Sources/SwiftGodot/Core/SignalSupport.swift
@@ -24,7 +24,7 @@ public class SignalProxy: Object {
         
         let s = ClassInfo<SignalProxy>(name: "SignalProxy")
         
-        s.registerMethod(name: SignalProxy.proxyName, flags: .default, returnValue: nil, arguments: [], function: SignalProxy.proxyFunc)
+        s.registerMethod(name: SignalProxy.proxyName, flags: .flagsDefault, returnValue: nil, arguments: [], function: SignalProxy.proxyFunc)
         return true
     } ()
     
@@ -125,7 +125,7 @@ public class SimpleSignal {
     public var emitted: Void {
         get async {
             await withCheckedContinuation { c in
-                connect (flags: .connectOneShot) {
+                connect (flags: .oneShot) {
                     c.resume()
                 }
             }

--- a/Sources/SwiftGodot/Extensions/ClassInfo+ConvenienceProperties.swift
+++ b/Sources/SwiftGodot/Extensions/ClassInfo+ConvenienceProperties.swift
@@ -250,7 +250,7 @@ extension ClassInfo {
 
     private func registerGetter(prefix: String, name: String, property: PropInfo, getter: @escaping ClassInfoFunction) {
         registerMethod(name: StringName("\(prefix)_get_\(name)"),
-                       flags: .flagsDefault,
+                       flags: .default,
                        returnValue: property,
                        arguments: [],
                        function: getter)
@@ -258,7 +258,7 @@ extension ClassInfo {
 
     private func registerSetter(prefix: String, name: String, property: PropInfo, setter: @escaping ClassInfoFunction) {
         registerMethod(name: StringName("\(prefix)_set_\(name)"),
-                       flags: .flagsDefault,
+                       flags: .default,
                        returnValue: nil,
                        arguments: [property],
                        function: setter)

--- a/Sources/SwiftGodot/Extensions/ClassInfo+ConvenienceProperties.swift
+++ b/Sources/SwiftGodot/Extensions/ClassInfo+ConvenienceProperties.swift
@@ -79,7 +79,7 @@ extension ClassInfo {
                                 className: StringName("\(T.self)"),
                                 hint: .flags,
                                 hintStr: "",
-                                usage: .propertyUsageDefault)
+                                usage: .default)
         registerSetter(prefix: registeredPrefix, name: name, property: property, setter: setter)
         registerGetter(prefix: registeredPrefix, name: name, property: property, getter: getter)
         registerProperty(property,
@@ -104,7 +104,7 @@ extension ClassInfo {
                                 className: StringName("\(T.self)"),
                                 hint: .enum,
                                 hintStr: GString(Enum.allCases.map(\.name).joined(separator: ",")),
-                                usage: .propertyUsageDefault)
+                                usage: .default)
         registerGetter(prefix: registeredPrefix, name: name, property: property, getter: getter)
         registerSetter(prefix: registeredPrefix, name: name, property: property, setter: setter)
         registerProperty(property,
@@ -136,7 +136,7 @@ extension ClassInfo {
                                 className: StringName("\(T.self)"),
                                 hint: .file,
                                 hintStr: GString(fileExtensions),
-                                usage: .propertyUsageDefault)
+                                usage: .default)
         registerSetter(prefix: registeredPrefix, name: name, property: property, setter: setter)
         registerGetter(prefix: registeredPrefix, name: name, property: property, getter: getter)
         registerProperty(property,
@@ -166,7 +166,7 @@ extension ClassInfo {
                                 className: StringName("\(T.self)"),
                                 hint: .file,
                                 hintStr: GString(fileExtensions),
-                                usage: .propertyUsageDefault)
+                                usage: .default)
         registerSetter(prefix: registeredPrefix, name: name, property: property, setter: setter)
         registerGetter(prefix: registeredPrefix, name: name, property: property, getter: getter)
         registerProperty(property,
@@ -194,7 +194,7 @@ extension ClassInfo {
                                 className: StringName("\(T.self)"),
                                 hint: .range,
                                 hintStr: GString("\(range.lowerBound),\(range.upperBound),\(stride)"),
-                                usage: .propertyUsageDefault)
+                                usage: .default)
         registerSetter(prefix: registeredPrefix, name: name, property: property, setter: setter)
         registerGetter(prefix: registeredPrefix, name: name, property: property, getter: getter)
         registerProperty(property,
@@ -217,7 +217,7 @@ extension ClassInfo {
                                 className: StringName("\(T.self)"),
                                 hint: .typeString,
                                 hintStr: "",
-                                usage: .propertyUsageDefault)
+                                usage: .default)
         registerSetter(prefix: registeredPrefix, name: name, property: property, setter: setter)
         registerGetter(prefix: registeredPrefix, name: name, property: property, getter: getter)
         registerProperty(property,
@@ -240,7 +240,7 @@ extension ClassInfo {
                                 className: StringName("\(T.self)"),
                                 hint: .multilineText,
                                 hintStr: "",
-                                usage: .propertyUsageDefault)
+                                usage: .default)
         registerSetter(prefix: registeredPrefix, name: name, property: property, setter: setter)
         registerGetter(prefix: registeredPrefix, name: name, property: property, getter: getter)
         registerProperty(property,
@@ -250,7 +250,7 @@ extension ClassInfo {
 
     private func registerGetter(prefix: String, name: String, property: PropInfo, getter: @escaping ClassInfoFunction) {
         registerMethod(name: StringName("\(prefix)_get_\(name)"),
-                       flags: .default,
+                       flags: .flagsDefault,
                        returnValue: property,
                        arguments: [],
                        function: getter)
@@ -258,7 +258,7 @@ extension ClassInfo {
 
     private func registerSetter(prefix: String, name: String, property: PropInfo, setter: @escaping ClassInfoFunction) {
         registerMethod(name: StringName("\(prefix)_set_\(name)"),
-                       flags: .default,
+                       flags: .flagsDefault,
                        returnValue: nil,
                        arguments: [property],
                        function: setter)

--- a/Sources/SwiftGodot/SwiftGodot.docc/CustomTypes.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/CustomTypes.md
@@ -189,7 +189,7 @@ let textArgument =  PropInfo(
     className: "SwiftSprite",
     hint: .typeString,
     hintStr: "", 
-    usage: .propertyUsageDefault)
+    usage: .default)
 ```
 
 In this case, we are declaring a property of the Godot type string, and we call

--- a/Sources/SwiftGodot/SwiftGodot.docc/Signals.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Signals.md
@@ -184,7 +184,7 @@ static var initClass: Bool = {
             className: "Demo",
             hint: .flags,
             hintStr: "Text",
-            usage: .propertyUsageDefault)
+            usage: .default)
     ]
     classInfo.registerSignal (name: Demo.printerSignal, arguments: printArgs)
     return true

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -37,7 +37,7 @@ class GodotMacroProcessor {
         
         // TODO: perhaps for these prop infos that are parameters to functions, we should not bother making them unique
         // and instead share all the Ints, all the Floats and so on.
-        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\(parameterName)\(parameterTypeName)\", className: className, hint: .none, hintStr: \"\", usage: .propertyUsageDefault)\n")
+        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\(parameterName)\(parameterTypeName)\", className: className, hint: .none, hintStr: \"\", usage: .default)\n")
         propertyDeclarations [key] = name
         return name
     }
@@ -68,7 +68,7 @@ class GodotMacroProcessor {
             funcArgs.append ("\t]\n")
         }
         ctor.append (funcArgs)
-        ctor.append ("\tclassInfo.registerMethod(name: StringName(\"\(funcName)\"), flags: .default, returnValue: \(retProp ?? "nil"), arguments: \(funcArgs == "" ? "[]" : "\(funcName)Args"), function: \(className)._mproxy_\(funcName))")
+        ctor.append ("\tclassInfo.registerMethod(name: StringName(\"\(funcName)\"), flags: .flagsDefault, returnValue: \(retProp ?? "nil"), arguments: \(funcArgs == "" ? "[]" : "\(funcName)Args"), function: \(className)._mproxy_\(funcName))")
     }
     
     func processVariable (_ varDecl: VariableDeclSyntax) throws {
@@ -147,12 +147,12 @@ class GodotMacroProcessor {
         className: className,
         hint: .\(f?.description ?? "none"),
         hintStr: \(s?.description ?? "\"\""),
-        usage: .propertyUsageDefault)
+        usage: .default)
     
     """)
             
-            ctor.append("\tclassInfo.registerMethod (name: \"\(getterName)\", flags: .default, returnValue: \(pinfo), arguments: [], function: \(className).\(getterName))\n")
-            ctor.append("\tclassInfo.registerMethod (name: \"\(setterName)\", flags: .default, returnValue: nil, arguments: [\(pinfo)], function: \(className).\(setterName))\n")
+            ctor.append("\tclassInfo.registerMethod (name: \"\(getterName)\", flags: .flagsDefault, returnValue: \(pinfo), arguments: [], function: \(className).\(getterName))\n")
+            ctor.append("\tclassInfo.registerMethod (name: \"\(setterName)\", flags: .flagsDefault, returnValue: nil, arguments: [\(pinfo)], function: \(className).\(setterName))\n")
             ctor.append("\tclassInfo.registerProperty (\(pinfo), getter: \"\(getterName)\", setter: \"\(setterName)\")")
         }
     }

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -68,7 +68,7 @@ class GodotMacroProcessor {
             funcArgs.append ("\t]\n")
         }
         ctor.append (funcArgs)
-        ctor.append ("\tclassInfo.registerMethod(name: StringName(\"\(funcName)\"), flags: .flagsDefault, returnValue: \(retProp ?? "nil"), arguments: \(funcArgs == "" ? "[]" : "\(funcName)Args"), function: \(className)._mproxy_\(funcName))")
+        ctor.append ("\tclassInfo.registerMethod(name: StringName(\"\(funcName)\"), flags: .default, returnValue: \(retProp ?? "nil"), arguments: \(funcArgs == "" ? "[]" : "\(funcName)Args"), function: \(className)._mproxy_\(funcName))")
     }
     
     func processVariable (_ varDecl: VariableDeclSyntax) throws {
@@ -151,8 +151,8 @@ class GodotMacroProcessor {
     
     """)
             
-            ctor.append("\tclassInfo.registerMethod (name: \"\(getterName)\", flags: .flagsDefault, returnValue: \(pinfo), arguments: [], function: \(className).\(getterName))\n")
-            ctor.append("\tclassInfo.registerMethod (name: \"\(setterName)\", flags: .flagsDefault, returnValue: nil, arguments: [\(pinfo)], function: \(className).\(setterName))\n")
+            ctor.append("\tclassInfo.registerMethod (name: \"\(getterName)\", flags: .default, returnValue: \(pinfo), arguments: [], function: \(className).\(getterName))\n")
+            ctor.append("\tclassInfo.registerMethod (name: \"\(setterName)\", flags: .default, returnValue: nil, arguments: [\(pinfo)], function: \(className).\(setterName))\n")
             ctor.append("\tclassInfo.registerProperty (\(pinfo), getter: \"\(getterName)\", setter: \"\(setterName)\")")
         }
     }

--- a/TestEditor/project.godot
+++ b/TestEditor/project.godot
@@ -1,0 +1,24 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="Sample"
+run/main_scene="res://node_2d.tscn"
+config/features=PackedStringArray("4.2", "Forward Plus")
+config/icon="res://icon.svg"
+
+[editor_plugins]
+
+enabled=PackedStringArray()
+
+[rendering]
+
+textures/vram_compression/import_etc2_astc=true

--- a/Testbed/default_env.tres
+++ b/Testbed/default_env.tres
@@ -4,4 +4,4 @@
 
 [resource]
 background_mode = 2
-sky = SubResource( "1" )
+sky = SubResource("1")

--- a/Testbed/main.tscn
+++ b/Testbed/main.tscn
@@ -1,25 +1,45 @@
-[gd_scene load_steps=2 format=3 uid="uid://dmx2xuigcpvt4"]
+[gd_scene load_steps=3 format=3 uid="uid://dmx2xuigcpvt4"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_c326s"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_666f1"]
 
 [node name="Node" type="Node"]
 script = ExtResource("1_c326s")
 
 [node name="Example" type="Example" parent="."]
+_import_path = NodePath("")
+unique_name_in_owner = false
+process_mode = 0
+process_priority = 0
+process_physics_priority = 0
+process_thread_group = 0
+editor_description = ""
+script = null
 
 [node name="ExampleMin" type="ExampleMin" parent="Example"]
+_import_path = NodePath("")
+unique_name_in_owner = false
+process_mode = 0
+process_priority = 0
+process_physics_priority = 0
+process_thread_group = 0
+editor_description = ""
 layout_mode = 0
+script = null
 
 [node name="Label" type="Label" parent="Example"]
-layout_mode = 0
 offset_left = 194.0
 offset_top = -2.0
 offset_right = 234.0
 offset_bottom = 21.0
 
+[node name="Rigid" type="Rigid" parent="Example"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Example/Rigid"]
+shape = SubResource("CircleShape2D_666f1")
+
 [node name="Button" type="Button" parent="."]
 offset_right = 79.0
 offset_bottom = 29.0
 text = "Click me!"
-
-[connection signal="custom_signal" from="Example" to="." method="_on_Example_custom_signal"]

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -115,7 +115,7 @@ final class MacroGodotTests: XCTestCase {
                 static var _initClass: Void = {
                     let className = StringName("Castro")
                     let classInfo = ClassInfo<Castro> (name: className)
-                	classInfo.registerMethod(name: StringName("deleteEpisode"), flags: .flagsDefault, returnValue: nil, arguments: [], function: Castro._mproxy_deleteEpisode)
+                	classInfo.registerMethod(name: StringName("deleteEpisode"), flags: .default, returnValue: nil, arguments: [], function: Castro._mproxy_deleteEpisode)
                 } ()
             }
             """,
@@ -162,8 +162,8 @@ final class MacroGodotTests: XCTestCase {
                         hint: .none,
                         hintStr: "",
                         usage: .default)
-                	classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .flagsDefault, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
-                	classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .flagsDefault, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
+                	classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
+                	classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
                 	classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
                 } ()
             }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -69,14 +69,14 @@ final class MacroGodotTests: XCTestCase {
                 }
 
                 required init() {
-                	Hi._initClass ()
+                	Hi._initClass
                 	super.init ()
                 }
 
-                static func _initClass () {
+                static var _initClass: Void = {
                     let className = StringName("Hi")
                     let classInfo = ClassInfo<Hi> (name: className)
-                }
+                } ()
             }
             """,
 			macros: testMacros
@@ -108,15 +108,15 @@ final class MacroGodotTests: XCTestCase {
                 }
 
                 required init() {
-                	Castro._initClass ()
+                	Castro._initClass
                 	super.init ()
                 }
 
-                static func _initClass () {
+                static var _initClass: Void = {
                     let className = StringName("Castro")
                     let classInfo = ClassInfo<Castro> (name: className)
                 	classInfo.registerMethod(name: StringName("deleteEpisode"), flags: .flagsDefault, returnValue: nil, arguments: [], function: Castro._mproxy_deleteEpisode)
-                }
+                } ()
             }
             """,
 			macros: testMacros
@@ -148,11 +148,11 @@ final class MacroGodotTests: XCTestCase {
                 }
             
                 required init() {
-                	Hi._initClass ()
+                	Hi._initClass
                 	super.init ()
                 }
             
-                static func _initClass () {
+                static var _initClass: Void = {
                     let className = StringName("Hi")
                     let classInfo = ClassInfo<Hi> (name: className)
                     let _pgoodName = PropInfo (
@@ -165,7 +165,7 @@ final class MacroGodotTests: XCTestCase {
                 	classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .flagsDefault, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
                 	classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .flagsDefault, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
                 	classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
-                }
+                } ()
             }
             """,
 			macros: testMacros

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -115,7 +115,7 @@ final class MacroGodotTests: XCTestCase {
                 static func _initClass () {
                     let className = StringName("Castro")
                     let classInfo = ClassInfo<Castro> (name: className)
-                	classInfo.registerMethod(name: StringName("deleteEpisode"), flags: .default, returnValue: nil, arguments: [], function: Castro._mproxy_deleteEpisode)
+                	classInfo.registerMethod(name: StringName("deleteEpisode"), flags: .flagsDefault, returnValue: nil, arguments: [], function: Castro._mproxy_deleteEpisode)
                 }
             }
             """,
@@ -161,9 +161,9 @@ final class MacroGodotTests: XCTestCase {
                         className: className,
                         hint: .none,
                         hintStr: "",
-                        usage: .propertyUsageDefault)
-                	classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
-                	classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .flagsDefault, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
+                	classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .flagsDefault, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
                 	classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
                 }
             }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -35,14 +35,14 @@ final class MacroGodotTests: XCTestCase {
                 }
 
                 required init() {
-                	Hi._initClass ()
+                	Hi._initClass
                 	super.init ()
                 }
 
-                static func _initClass () {
+                static var _initClass: Void = {
                     let className = StringName("Hi")
                     let classInfo = ClassInfo<Hi> (name: className)
-                }
+                } ()
             }
             """,
             macros: testMacros


### PR DESCRIPTION
Fixes issue: https://github.com/migueldeicaza/SwiftGodot/issues/144

The generator will now find the common prefix among all case names instead of relying on the enum definition name.

You can see the changes to the generated API in this gist: https://gist.github.com/PadraigK/af78939c3e597635d6db5dc98e7b6c64

