### PR TITLE
Move macro definitions into SwiftGodot target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ check-args:
 	@if test x$(VERSION)$(NOTES) = x; then echo You need to provide both VERSION=XX NOTES=FILENAME arguments to this makefile target; exit 1; fi
 
 sync:
-	@if test ../SwiftGodotBinary; then rsync -a Sources/SwiftGodotMacros Sources/SwiftGodotMacroLibrary ../SwiftGodotBinary/Sources; else echo "missing directory ../SwiftGodotBinary"; fi
+	@if test ../SwiftGodotBinary; then rsync -a Sources/SwiftGodotMacroLibrary ../SwiftGodotBinary/Sources; else echo "missing directory ../SwiftGodotBinary"; fi

--- a/Package.swift
+++ b/Package.swift
@@ -24,10 +24,6 @@ let package = Package(
             name: "SwiftGodot",
             type: .dynamic,
             targets: ["SwiftGodot"]),
-        .library(
-            name: "SwiftGodotMacros",
-            type: .dynamic,
-            targets: ["SwiftGodotMacros"]),
         .plugin(name: "CodeGeneratorPlugin", targets: ["CodeGeneratorPlugin"]),
         .library(
             name: "SimpleExtension",
@@ -70,7 +66,7 @@ let package = Package(
             dependencies: ["GDExtension"],
             swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
             linkerSettings: linkerSettings,
-            plugins: ["CodeGeneratorPlugin"]),
+            plugins: ["CodeGeneratorPlugin", "SwiftGodotMacroLibrary"]),
         
         // These are macros that can be used by third parties to simplify their
         // SwiftGodot development experience, these are used at compile time by
@@ -81,22 +77,18 @@ let package = Package(
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
                ]),
-        
-        // This contains the macro API contract that is referenced by applications
-        .target (
-            name: "SwiftGodotMacros",
-            dependencies: ["SwiftGodotMacroLibrary", .target(name: "SwiftGodot")]),
-        
+                
         // This contains sample code showing how to use the SwiftGodot API
         .target(
             name: "SimpleExtension",
-            dependencies: ["SwiftGodotMacros"],
+            dependencies: ["SwiftGodot"],
             swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
             linkerSettings: linkerSettings),
         // Idea: -mark_dead_strippable_dylib
         .testTarget(name: "SwiftGodotMacroTests",
                     dependencies: [
                         "SwiftGodotMacroLibrary",
+                        "SwiftGodot",
                         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
                     ])
 

--- a/Package.swift
+++ b/Package.swift
@@ -12,24 +12,95 @@ linkerSettings.append(.unsafeFlags([
 ]))
 #endif
 
+// Products define the executables and libraries a package produces, and make them visible to other packages.
+var products: [Product] = [
+    .library(
+        name: "SwiftGodot",
+        type: .dynamic,
+        targets: ["SwiftGodot"]),
+    .plugin(name: "CodeGeneratorPlugin", targets: ["CodeGeneratorPlugin"]),
+]
+
+// Macros aren't supported on Windows yet
+#if !os(Windows)
+products.append(
+    .library(
+        name: "SimpleExtension",
+        type: .dynamic,
+        targets: ["SimpleExtension"]))
+#endif
+
+var targets: [Target] = [
+    // The generator takes Godot's JSON-based API description as input and
+    // produces Swift API bindings that can be used to call into Godot.
+    .executableTarget(
+        name: "Generator",
+        dependencies: ["XMLCoder"],
+        path: "Generator",
+        swiftSettings: [.unsafeFlags (["-enable-bare-slash-regex"])]),
+    
+    // This is a build-time plugin that invokes the generator and produces
+    // the bindings that are compiled into SwiftGodot
+    .plugin(
+        name: "CodeGeneratorPlugin",
+        capability: .buildTool(),
+        dependencies: ["Generator"]
+    ),
+    
+    // This allows the Swift code to call into the Godot bridge API (GDExtension)
+    .target(
+        name: "GDExtension"),
+]
+
+var swiftGodotPlugins: [Target.PluginUsage] = ["CodeGeneratorPlugin"]
+
+// Macros aren't supported on Windows yet
+#if !os(Windows)
+targets.append(contentsOf: [
+    // These are macros that can be used by third parties to simplify their
+    // SwiftGodot development experience, these are used at compile time by
+    // third party projects
+    .macro(name: "SwiftGodotMacroLibrary",
+           dependencies: [
+            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+            .product(name: "SwiftSyntax", package: "swift-syntax"),
+            .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+           ]),
+    // This contains sample code showing how to use the SwiftGodot API
+    .target(
+        name: "SimpleExtension",
+        dependencies: ["SwiftGodot"],
+        swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
+        linkerSettings: linkerSettings),
+    // Idea: -mark_dead_strippable_dylib
+    .testTarget(name: "SwiftGodotMacroTests",
+                dependencies: [
+                    "SwiftGodotMacroLibrary",
+                    "SwiftGodot",
+                    .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+                ])
+    ])
+swiftGodotPlugins.append("SwiftGodotMacroLibrary")
+#endif
+
+targets.append(
+    // This is the binding itself, it is made up of our generated code for the
+    // Godot API, supporting infrastructure and extensions to the API to provide
+    // a better Swift experience
+    .target(
+        name: "SwiftGodot",
+        dependencies: ["GDExtension"],
+        swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
+        linkerSettings: linkerSettings,
+        plugins: swiftGodotPlugins))
+
 let package = Package(
     name: "SwiftGodot",
     platforms: [
         .macOS(.v13),
         .iOS ("16.0")
     ],
-    products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
-        .library(
-            name: "SwiftGodot",
-            type: .dynamic,
-            targets: ["SwiftGodot"]),
-        .plugin(name: "CodeGeneratorPlugin", targets: ["CodeGeneratorPlugin"]),
-        .library(
-            name: "SimpleExtension",
-            type: .dynamic,
-            targets: ["SimpleExtension"]),
-    ],
+    products: products,
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
@@ -37,64 +108,5 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
     ],
-    targets: [
-        // The generator takes Godot's JSON-based API description as input and
-        // produces Swift API bindings that can be used to call into Godot.
-        .executableTarget(
-            name: "Generator",
-            dependencies: ["XMLCoder"],
-            path: "Generator",
-            swiftSettings: [.unsafeFlags (["-enable-bare-slash-regex"])]),
-        
-        // This is a build-time plugin that invokes the generator and produces
-        // the bindings that are compiled into SwiftGodot
-        .plugin(
-            name: "CodeGeneratorPlugin",
-            capability: .buildTool(),
-            dependencies: ["Generator"]
-        ),
-        
-        // This allows the Swift code to call into the Godot bridge API (GDExtension)
-        .target(
-            name: "GDExtension"),
-        
-        // This is the binding itself, it is made up of our generated code for the
-        // Godot API, supporting infrastructure and extensions to the API to provide
-        // a better Swift experience
-        .target(
-            name: "SwiftGodot",
-            dependencies: ["GDExtension"],
-            swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
-            linkerSettings: linkerSettings,
-            plugins: ["CodeGeneratorPlugin", "SwiftGodotMacroLibrary"]),
-        
-        // These are macros that can be used by third parties to simplify their
-        // SwiftGodot development experience, these are used at compile time by
-        // third party projects
-        .macro(name: "SwiftGodotMacroLibrary",
-               dependencies: [
-                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
-                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
-               ]),
-                
-        // This contains sample code showing how to use the SwiftGodot API
-        .target(
-            name: "SimpleExtension",
-            dependencies: ["SwiftGodot"],
-            swiftSettings: [.unsafeFlags (["-suppress-warnings"])],
-            linkerSettings: linkerSettings),
-        // Idea: -mark_dead_strippable_dylib
-        .testTarget(name: "SwiftGodotMacroTests",
-                    dependencies: [
-                        "SwiftGodotMacroLibrary",
-                        "SwiftGodot",
-                        .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
-                    ])
-
-        // Test suite for SwiftGodot
-//        .testTarget(
-//            name: "SwiftGodotTests",
-//            dependencies: ["SwiftGodot"]),
-    ]
+    targets: targets
 )

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ let package = Package(
     targets: [
         .target(
             name: "MyFirstGame",
-            dependencies: ["SwiftGodot", .product (name: "SwiftGodotMacros", package: "SwiftGodot")],
+            dependencies: ["SwiftGodot"],
             swiftSettings: [.unsafeFlags(["-suppress-warnings"])],
             linkerSettings: [.unsafeFlags(
                 ["-Xlinker", "-undefined",
@@ -99,7 +99,6 @@ here we declare a spinning cube:
 
 ```
 import SwiftGodot
-import SwiftGodotMacros
 
 @Godot
 class SpinningCube: Node3D {
@@ -146,7 +145,7 @@ public func swift_entry_point(
 Alternatively, you can use the `#initSwiftExtension` macro:
 
 ```
-import SwiftGodotMacros
+import SwiftGodot
 
 #initSwiftExtension(name: "swift_entry_point", types: [SpinningCube.self])
 ```

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import SwiftGodot
-import SwiftGodotMacros
 
 var sequence = 0
 

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import SwiftGodot
 
 /// Creates the definition for a Swift class to be surfaced to Godot.
 ///

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -5,7 +5,7 @@
 //  Created by Miguel de Icaza on 9/25/23.
 //
 
-import Foundation
+#if !os(Windows)
 
 /// Creates the definition for a Swift class to be surfaced to Godot.
 ///
@@ -126,3 +126,4 @@ public macro NativeHandleDiscarding() = #externalMacro(module: "SwiftGodotMacroL
 @attached(accessor)
 public macro SceneTree(path: String) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SceneTreeMacro")
 
+#endif

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-3.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-3.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftGodot
-import SwiftGodotMacros
 
 @Godot
 class MainLevel: Node2D {

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-4.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-4.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftGodot
-import SwiftGodotMacros
 
 @Godot
 class MainLevel: Node2D {

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-5.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-5.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftGodot
-import SwiftGodotMacros
 
 @Godot
 class MainLevel: Node2D {

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-6.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-6.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftGodot
-import SwiftGodotMacros
 
 @Godot
 class MainLevel: Node2D {

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-init.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-init.swift
@@ -7,4 +7,3 @@
 
 import Foundation
 import SwiftGodot
-import SwiftGodotMacros

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/Package-starter-4.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/Package-starter-4.swift
@@ -24,7 +24,6 @@ let package = Package(
             name: "SimpleRunnerDriver",
             dependencies: [
                 "SwiftGodot",
-                .product(name: "SwiftGodotMacros", package: "SwiftGodot")
             ],
             swiftSettings: [.unsafeFlags(["-suppress-warnings"])],
             linkerSettings: [.unsafeFlags(

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SimpleRunnerDriver-multiscript-2.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SimpleRunnerDriver-multiscript-2.swift
@@ -2,7 +2,6 @@
 // https://docs.swift.org/swift-book
 
 import SwiftGodot
-import SwiftGodotMacros
 
 let allNodes: [Wrapped.Type] = [PlayerController.self, MainLevel.self]
 

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SimpleRunnerDriver-starter-2.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SimpleRunnerDriver-starter-2.swift
@@ -2,6 +2,5 @@
 // https://docs.swift.org/swift-book
 
 import SwiftGodot
-import SwiftGodotMacros
 
 #initSwiftExtension(cdecl: "swift_entry_point", types: [])

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SimpleRunnerDriver-starter-3.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SimpleRunnerDriver-starter-3.swift
@@ -2,6 +2,5 @@
 // https://docs.swift.org/swift-book
 
 import SwiftGodot
-import SwiftGodotMacros
 
 #initSwiftExtension(cdecl: "swift_entry_point", types: [PlayerController.self])

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SwiftGodotKit-Main.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SwiftGodotKit-Main.swift
@@ -8,7 +8,6 @@
 import Foundation
 import SwiftGodotKit
 import SwiftGodot
-import SwiftGodotMacros
 
 
 func loadScene (scene: SceneTree) {

--- a/Sources/SwiftGodot/SwiftGodot.docc/Tutorials/Writing Multiple Scripts.tutorial
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Tutorials/Writing Multiple Scripts.tutorial
@@ -70,7 +70,7 @@
         @Steps {
             @Step {
                 Create a new Swift file called **MainLevel** in the SimpleRunnerDriver package and import the SwiftGodot
-                and SwiftGodotMacros libraries.
+                library.
                 
                 @Code(name: "MainLevel.swift", file: "MainLevel-multiscript-init.swift", reset: true)
             }

--- a/Sources/SwiftGodot/SwiftGodot.docc/Tutorials/Your First Extension.tutorial
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Tutorials/Your First Extension.tutorial
@@ -47,7 +47,7 @@
                 @Code(name: "Package.swift", file: "Package-starter-4.swift")
             }
             @Step {
-                In SimpleRunnerDriver.swift, import the SwiftGodot and SwiftGodotMacros libraries and call the
+                In SimpleRunnerDriver.swift, import the SwiftGodot library and call the
                 `initSwiftExtension` macro to create an entry point. For now, we can pass an empty array for the nodes
                 to be registered.
                 

--- a/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
@@ -8,6 +8,7 @@
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
+import SwiftGodot
 import SwiftGodotMacroLibrary
 
 final class InitSwiftExtensionMacroTests: XCTestCase {


### PR DESCRIPTION
This should avoid all the complications discussed in #148, leaving `SwiftGodot` the only dependency and only import to worry about for the users. And it'll keep the initial composition of `libDriver.dylib`+`libSwiftGodot.dylib` as the build output.

But it'll require additional workarounds for Windows, since macros aren't supported there yet.