### PR TITLE
Added a `.spi.yml` file to tell the Swift Package Index where to find the documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://migueldeicaza.github.io/SwiftGodotDocs/documentation/swiftgodot/"


### PR DESCRIPTION
Once merged, this will add a "Documentation" menu item on the [SwiftGodot SPI listing](https://swiftpackageindex.com/migueldeicaza/SwiftGodot).

![Screenshot 2023-10-06 at 09 57 33@2x](https://github.com/migueldeicaza/SwiftGodot/assets/5180/cd99e155-d6f7-4d3d-8e17-d308db3720fc)
