### PR TITLE
Update SwiftGodot Tutorials.tutorial - grammar fix

### DIFF
--- a/Sources/SwiftGodot/SwiftGodot.docc/SwiftGodot Tutorials.tutorial
+++ b/Sources/SwiftGodot/SwiftGodot.docc/SwiftGodot Tutorials.tutorial
@@ -20,7 +20,7 @@
 
     @Chapter(name: "Embedding Godot in Swift") {
         If rather than embedding Swift into Godot, you want to embed Godot into 
-        your Swift application or you prefer to prototype your code with
+        your Swift application or, if you prefer to prototype your code with
         a code-first approach, you can use the companion SwiftGodotKit.
 
         @Image(source: "Birdie2",


### PR DESCRIPTION
Tiny grammar fix that I spotted when reading through your lovely tutorials (hat tip to Dave Verwer for the link from IOSDevWeekly last week)