### PR TITLE
Limit struct stored property generation to members with offsets

### DIFF
--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -73,11 +73,20 @@ for x in ["Float", "Int", "float", "int", "Int32", "Bool", "bool"] {
     isStructMap [x] = true
 }
 
+let buildConfiguration: String = "float_64"
 var builtinSizes: [String: Int] = [:]
 for cs in jsonApi.builtinClassSizes {
-    if cs.buildConfiguration == "float_64" {
+    if cs.buildConfiguration == buildConfiguration {
         for c in cs.sizes {
             builtinSizes [c.name] = c.size
+        }
+    }
+}
+var builtinMemberOffsets: [String: [JGodotMember]] = [:]
+for mo in jsonApi.builtinClassMemberOffsets {
+    if mo.buildConfiguration == buildConfiguration {
+        for c in mo.classes {
+            builtinMemberOffsets [c.name.rawValue] = c.members
         }
     }
 }

--- a/Sources/SwiftGodot/Extensions/Endable.swift
+++ b/Sources/SwiftGodot/Extensions/Endable.swift
@@ -5,8 +5,6 @@
 //  Created by Mikhail Tishin on 15.10.2023.
 //
 
-import Foundation
-
 public protocol Endable {
     
     associatedtype VectorType: AdditiveArithmetic

--- a/Sources/SwiftGodot/Extensions/Endable.swift
+++ b/Sources/SwiftGodot/Extensions/Endable.swift
@@ -1,0 +1,39 @@
+//
+//  Endable.swift
+//  
+//
+//  Created by Mikhail Tishin on 15.10.2023.
+//
+
+import Foundation
+
+public protocol Endable {
+    
+    associatedtype VectorType: AdditiveArithmetic
+    
+    var position: VectorType { get }
+    var size: VectorType { get set }
+
+}
+
+public extension Endable {
+    
+    var end: VectorType {
+        set {
+            size = newValue - position
+        }
+        get {
+            return position + size
+        }
+    }
+    
+}
+
+extension Vector2: AdditiveArithmetic {}
+extension Vector2i: AdditiveArithmetic {}
+extension Vector3: AdditiveArithmetic {}
+extension Vector3i: AdditiveArithmetic {}
+
+extension AABB: Endable {}
+extension Rect2: Endable {}
+extension Rect2i: Endable {}


### PR DESCRIPTION
Should fix #173. This PR should also make `Color` and `Plane` generation work fine out of the box (unless you want `red` instead of the documented `r`, in that case I'll revert it).