### PR TITLE
Adds #signal Macro 

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -554,9 +554,11 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                     }
                 }
             }
+            let gtype = gtypeFromTypeName (bc.name)
+            
+            p("public static var gType: Variant.GType { .\(gtype) }")
             
             p ("/// Creates a new instance from the given variant if it contains a \(typeName)")
-            let gtype = gtypeFromTypeName (bc.name)
             // Now generate the variant constructor
             if kind == .isClass {
                 p ("public required init? (_ from: Variant)") {

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -561,28 +561,19 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
             p ("/// Creates a new instance from the given variant if it contains a \(typeName)")
             // Now generate the variant constructor
             if kind == .isClass {
-                p ("public required init? (_ from: Variant)") {
-                    p ("guard from.gtype == .\(gtype) else") {
-                        p ("return nil")
-                    }
+                p("public static func unwrap(variant: Variant) -> \(typeName)?") {
+                    p("guard variant.gtype == .\(gtype) else { return nil }")
                     p ("var localContent: \(typeName).ContentType = \(typeName).zero")
-                    p ("from.toType(.\(gtype), dest: &localContent)")
-                    p ("// Replicate the constructor, because of a lame Swift requirement")
-                    p ("var args: [UnsafeRawPointer?] = []")
-                    p ("withUnsafePointer (to: &localContent)", arg: " ptr in") {
-                        p ("args.append (ptr)")
-                        p ("\(typeName).constructor1 (&content, &args)")
-                    }
+                    p ("variant.toType(.\(gtype), dest: &localContent)")
+                    p ("return \(typeName)(content: localContent)")
                 }
             } else {
-                p ("public init? (_ from: Variant)") {
-                    p ("guard from.gtype == .\(gtype) else") {
-                        p ("return nil")
-                    }
-                    p ("var v = \(bc.name)()")
-                    p ("from.toType(.\(gtype), dest: &v)")
-                    p ("self.init (from: v)")
-                }                
+                p("public static func unwrap(variant: Variant) -> Self?") {
+                    p("guard variant.gtype == .\(gtype) else { return nil }")
+                    p("var value = \(bc.name)()")
+                    p("variant.toType(.\(gtype), dest: &value)")
+                    p("return value")
+                }
             }
             p ("/// Wraps this \(typeName) into a Variant")
             p ("public func toVariant () -> Variant ") {

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -509,11 +509,13 @@ func generateSignalType (_ p: Printer, _ cdef: JGodotExtensionAPIClass, _ signal
                 argUnwrap += "args [\(argIdx)].toType (Variant.GType.object, dest: &ptr_\(argIdx))\n"
                 construct = "lookupLiveObject (handleAddress: ptr_\(argIdx)!) as? \(arg.type) ?? \(arg.type) (nativeHandle: ptr_\(argIdx)!)"
             } else if arg.type == "String" {
-                    construct = "\(mapTypeName(arg.type)) (args [\(argIdx)])!.description"
+                    construct = "\(mapTypeName(arg.type)).unwrap (variant: args [\(argIdx)])!.description"
             } else if arg.type == "Variant" {
                 construct = "args [\(argIdx)]"
-            } else {
+            } else if arg.type == "typedarray::StringName" {
                 construct = "\(getGodotType(arg)) (args [\(argIdx)])!"
+            } else {
+                construct = "\(getGodotType(arg)).unwrap (variant: args [\(argIdx)])!"
             }
             argUnwrap += "let arg_\(argIdx) = \(construct)\n"
             callArgs += "arg_\(argIdx)"

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -383,9 +383,9 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                     if returnType == "Variant" {
                         p ("return Variant (fromContent: _result)")
                     } else if returnType == "GodotError" {
-                        p ("return GodotError (rawValue: Int (Variant (fromContent: _result))!)!")
+                        p ("return GodotError (rawValue: Int.unwrap (variant: Variant (fromContent: _result))!)!")
                     } else if returnType == "String" {
-                        p ("return GString (Variant (fromContent: _result))?.description ?? \"\"")
+                        p ("return GString.unwrap (variant: Variant (fromContent: _result))?.description ?? \"\"")
                     } else {
                         fatalError("Do not support this return type")
                     }

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -23,7 +23,10 @@ class Rigid: RigidBody2D {
 class SwiftSprite: Sprite2D {
     var time_passed: Double = 0
     var count: Int = 0
-
+    
+    #signal("picked_up_item", arguments: ["kind": String.self, "isGroovy": Bool.self])
+    #signal("scored")
+    
     @Callable
     public func computeGodot (x: String, y: Int) -> Double {
         return 1.0
@@ -55,7 +58,7 @@ class SwiftSprite: Sprite2D {
     @Export var food: String = "none"
 
     static func lerp(from: Float, to: Float, weight: Float) -> Float {
-        return Float(GD.lerp(from: Variant(from), to: Variant(to), weight: Variant(weight))) ?? 0
+        return Float.unwrap(variant: GD.lerp(from: Variant(from), to: Variant(to), weight: Variant(weight))) ?? 0
     }
     
     var x: Rigid?
@@ -69,12 +72,12 @@ class SwiftSprite: Sprite2D {
         let imageVariant = ProjectSettings.getSetting(name: "shader_globals/heightmap", defaultValue: Variant(-1))
         GD.print("Found this value IMAGE: \(imageVariant.gtype) variant: \(imageVariant) desc: \(imageVariant.description)")
         
-        let dict2: GDictionary? = GDictionary(imageVariant)
+        let dict2: GDictionary? = GDictionary.unwrap(variant: imageVariant)
         GD.print("dictionary2: \(String(describing: dict2)) \(dict2?["type"] ?? "no type") \(dict2?["value"] ?? "no value")")
         
         // part b
         if let result = dict2?.get(key: Variant("type"), default: Variant(-1)) {
-            let value = String(result) ?? "No Result"
+            let value = String.unwrap(variant: result) ?? "No Result"
             GD.print("2 Found this value \(value)")
         }
         
@@ -146,7 +149,7 @@ class SwiftSprite2: Sprite2D {
             print ("Method registered taking one argument got none")
             return nil
         }
-        food = String (arg) ?? "The variant passed was not a string"
+        food = String.unwrap (variant: arg) ?? "The variant passed was not a string"
         print ("The favorite food was set to: \(food)")
         return nil
     }
@@ -156,7 +159,7 @@ class SwiftSprite2: Sprite2D {
     }
     
     static func lerp(from: Float, to: Float, weight: Float) -> Float {
-        return Float(GD.lerp(from: Variant(from), to: Variant(to), weight: Variant(weight))) ?? 0
+        return Float.unwrap(variant: GD.lerp(from: Variant(from), to: Variant(to), weight: Variant(weight))) ?? 0
     }
 
 
@@ -166,12 +169,12 @@ class SwiftSprite2: Sprite2D {
         let imageVariant = ProjectSettings.getSetting(name: "shader_globals/heightmap", defaultValue: Variant(-1))
         GD.print("Found this value IMAGE: \(imageVariant.gtype) variant: \(imageVariant) desc: \(imageVariant.description)")
         
-        let dict2: GDictionary? = GDictionary(imageVariant)
+        let dict2: GDictionary? = GDictionary.unwrap(variant: imageVariant)
         GD.print("dictionary2: \(String(describing: dict2)) \(dict2?["type"] ?? "no value for type") \(dict2?["value"] ?? "no value for value")")
         
         // part b
         if let result = dict2?.get(key: Variant("type"), default: Variant(-1)) {
-            let value = String(result)
+            let value = String.unwrap(variant: result)
             GD.print("2 Found this value \(value ?? "no value found")")
         }
         
@@ -205,3 +208,4 @@ public func swift_entry_point(
     initializeSwiftModule(godotGetProcAddr, libraryPtr, extensionPtr, initHook: setupScene, deInitHook: { x in })
     return 1
 }
+

--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -201,7 +201,7 @@ public struct PropInfo {
     /// The name for the property
     public let propertyName: StringName
     /// The class name of the object if `propertyType` == `.object`
-    public let className: StringName?
+    public let className: StringName
     /// Property Hint for this property
     public let hint: PropertyHint
     /// Human-readable hint
@@ -209,7 +209,7 @@ public struct PropInfo {
     /// Describes how the property can be used.
     public let usage: PropertyUsageFlags
     
-    public init(propertyType: Variant.GType, propertyName: StringName, className: StringName?, hint: PropertyHint, hintStr: GString, usage: PropertyUsageFlags) {
+    public init(propertyType: Variant.GType, propertyName: StringName, className: StringName, hint: PropertyHint, hintStr: GString, usage: PropertyUsageFlags) {
         self.propertyType = propertyType
         self.propertyName = propertyName
         self.className = className
@@ -219,23 +219,12 @@ public struct PropInfo {
     }
     func makeNativeStruct () -> GDExtensionPropertyInfo {
         withUnsafeMutablePointer(to: &propertyName.content) { propertyNamePtr in
-            withUnsafeMutablePointer(to: &hintStr.content) { hintStrPtr in
-                if let className {
-                    withUnsafeMutablePointer(to: &className.content) { classNamePtr in
-                        GDExtensionPropertyInfo(
-                            type: GDExtensionVariantType(GDExtensionVariantType.RawValue (propertyType.rawValue)),
-                            name: propertyNamePtr,
-                            class_name: classNamePtr,
-                            hint: UInt32 (hint.rawValue),
-                            hint_string: hintStrPtr,
-                            usage: UInt32 (usage.rawValue)
-                        )
-                    }
-                } else {
+            withUnsafeMutablePointer(to: &className.content) { classNamePtr in
+                withUnsafeMutablePointer(to: &hintStr.content) { hintStrPtr in
                     GDExtensionPropertyInfo(
                         type: GDExtensionVariantType(GDExtensionVariantType.RawValue (propertyType.rawValue)),
                         name: propertyNamePtr,
-                        class_name: nil,
+                        class_name: classNamePtr,
                         hint: UInt32 (hint.rawValue),
                         hint_string: hintStrPtr,
                         usage: UInt32 (usage.rawValue)

--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -200,8 +200,8 @@ public struct PropInfo {
     public let propertyType: Variant.GType
     /// The name for the property
     public let propertyName: StringName
-    /// The class name where this is defined
-    public let className: StringName
+    /// The class name of the object if `propertyType` == `.object`
+    public let className: StringName?
     /// Property Hint for this property
     public let hint: PropertyHint
     /// Human-readable hint
@@ -209,7 +209,7 @@ public struct PropInfo {
     /// Describes how the property can be used.
     public let usage: PropertyUsageFlags
     
-    public init(propertyType: Variant.GType, propertyName: StringName, className: StringName, hint: PropertyHint, hintStr: GString, usage: PropertyUsageFlags) {
+    public init(propertyType: Variant.GType, propertyName: StringName, className: StringName?, hint: PropertyHint, hintStr: GString, usage: PropertyUsageFlags) {
         self.propertyType = propertyType
         self.propertyName = propertyName
         self.className = className
@@ -219,15 +219,27 @@ public struct PropInfo {
     }
     func makeNativeStruct () -> GDExtensionPropertyInfo {
         withUnsafeMutablePointer(to: &propertyName.content) { propertyNamePtr in
-            withUnsafeMutablePointer(to: &className.content) { classNamePtr in
-                withUnsafeMutablePointer(to: &hintStr.content) { hintStrPtr in
+            withUnsafeMutablePointer(to: &hintStr.content) { hintStrPtr in
+                if let className {
+                    withUnsafeMutablePointer(to: &className.content) { classNamePtr in
+                        GDExtensionPropertyInfo(
+                            type: GDExtensionVariantType(GDExtensionVariantType.RawValue (propertyType.rawValue)),
+                            name: propertyNamePtr,
+                            class_name: classNamePtr,
+                            hint: UInt32 (hint.rawValue),
+                            hint_string: hintStrPtr,
+                            usage: UInt32 (usage.rawValue)
+                        )
+                    }
+                } else {
                     GDExtensionPropertyInfo(
                         type: GDExtensionVariantType(GDExtensionVariantType.RawValue (propertyType.rawValue)),
                         name: propertyNamePtr,
-                        class_name: classNamePtr,
+                        class_name: nil,
                         hint: UInt32 (hint.rawValue),
                         hint_string: hintStrPtr,
-                        usage: UInt32 (usage.rawValue))
+                        usage: UInt32 (usage.rawValue)
+                    )
                 }
             }
         }

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -35,7 +35,7 @@ public class ObjectCollection<T:Object>: Collection {
     
     /// Creates a new instance from the given variant if it contains a GArray
     public init? (_ variant: Variant) {
-        if let array = GArray (variant) {
+        if let array = GArray.unwrap(variant: variant) {
             self.array = array
             initType()
         } else {

--- a/Sources/SwiftGodot/Core/SignalRegistration.swift
+++ b/Sources/SwiftGodot/Core/SignalRegistration.swift
@@ -1,0 +1,229 @@
+//
+//  SignalRegistration.swift
+//
+//
+//  Created by Padraig O Cinneide on 2023-10-18.
+//
+
+public struct SignalWithNoArguments {
+    let name: StringName
+
+    public init<Source: SwiftGodot.Object>(
+        _ signalName: String,
+        classType: Source.Type
+    ) {
+        name = StringName(signalName)
+        let className = String(describing: classType)
+
+        ClassInfo<Source>(name: StringName(className)).registerSignal(
+            name: name,
+            arguments: []
+        )
+    }
+}
+
+extension PropInfo {
+    init(
+        propertyType: (some GodotVariant).Type,
+        propertyName: StringName
+    ) {
+        self.init(
+            propertyType: propertyType.gType,
+            propertyName: propertyName,
+            className: propertyType.gType == .object ? .init(String(describing: propertyType.self)) : "",
+            hint: .none,
+            hintStr: "",
+            usage: .default
+        )
+    }
+}
+
+public struct SignalWith1Argument<Argument: GodotVariant> {
+    let name: StringName
+
+    public init<Source: SwiftGodot.Object>(
+        _ signalName: String,
+        argumentName: String? = nil,
+        classType: Source.Type
+    ) {
+        name = StringName(signalName)
+
+        ClassInfo<Source>(
+            name: StringName(String(describing: classType))
+        ).registerSignal(
+            name: name,
+            arguments: [
+                PropInfo(propertyType: Argument.self, propertyName: .init(argumentName ?? "arg1")),
+            ]
+        )
+    }
+}
+
+public struct SignalWith2Arguments<
+    Argument1: GodotVariant,
+    Argument2: GodotVariant
+> {
+    let name: StringName
+
+    public init<Source: SwiftGodot.Object>(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        classType: Source.Type
+    ) {
+        name = StringName(signalName)
+
+        ClassInfo<Source>(
+            name: StringName(String(describing: classType))
+        ).registerSignal(
+            name: name,
+            arguments: [
+                PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+                PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            ]
+        )
+    }
+}
+
+public struct SignalWith3Arguments<
+    Argument1: GodotVariant,
+    Argument2: GodotVariant,
+    Argument3: GodotVariant
+> {
+    let name: StringName
+
+    public init<Source: SwiftGodot.Object>(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        argument3Name: String? = nil,
+        classType: Source.Type
+    ) {
+        name = StringName(signalName)
+
+        ClassInfo<Source>(
+            name: StringName(String(describing: classType))
+        ).registerSignal(
+            name: name,
+            arguments: [
+                PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+                PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+                PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+            ]
+        )
+    }
+}
+
+public struct SignalWith4Arguments<
+    Argument1: GodotVariant,
+    Argument2: GodotVariant,
+    Argument3: GodotVariant,
+    Argument4: GodotVariant
+> {
+    let name: StringName
+
+    public init<Source: SwiftGodot.Object>(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        argument3Name: String? = nil,
+        argument4Name: String? = nil,
+        classType: Source.Type
+    ) {
+        name = StringName(signalName)
+
+        ClassInfo<Source>(
+            name: StringName(String(describing: classType))
+        ).registerSignal(
+            name: name,
+            arguments: [
+                PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+                PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+                PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+                PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4")),
+            ]
+        )
+    }
+}
+
+public extension Object {
+    @discardableResult
+    func emit(signal: SignalWithNoArguments) -> GodotError {
+        emitSignal(signal.name)
+    }
+
+    @discardableResult
+    func connect(signal: SignalWithNoArguments, to target: some Object, method: String) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+
+    @discardableResult
+    func emit<A: GodotVariant>(signal: SignalWith1Argument<A>, _ argument: A) -> GodotError {
+        emitSignal(signal.name, argument.toVariant())
+    }
+
+    @discardableResult
+    func connect(signal: SignalWith1Argument<some Any>, to target: some Object, method: String) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+
+    @discardableResult
+    func emit<A: GodotVariant, B: GodotVariant>(
+        signal: SignalWith2Arguments<A, B>,
+        _ argument1: A,
+        _ argument2: B
+    ) -> GodotError {
+        emitSignal(signal.name, argument1.toVariant(), argument2.toVariant())
+    }
+
+    @discardableResult
+    func connect(signal: SignalWith2Arguments<some Any, some Any>, to target: some Object, method: String) -> GodotError {
+        // GD.print("connecting \(self) -> \(signal.name.description) to \(method.name.description) on \(description)")
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+
+    @discardableResult
+    func emit<A: GodotVariant, B: GodotVariant, C: GodotVariant>(
+        signal: SignalWith3Arguments<A, B, C>,
+        _ argument1: A,
+        _ argument2: B,
+        _ argument3: C
+    ) -> GodotError {
+        emitSignal(signal.name, argument1.toVariant(), argument2.toVariant(), argument3.toVariant())
+    }
+
+    @discardableResult
+    func connect(
+        signal: SignalWith3Arguments<some Any, some Any, some Any>,
+        to target: some Object,
+        method: String
+    ) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+
+    @discardableResult
+    func emit<A: GodotVariant, B: GodotVariant, C: GodotVariant, D: GodotVariant>(
+        signal: SignalWith4Arguments<A, B, C, D>,
+        _ argument1: A,
+        _ argument2: B,
+        _ argument3: C,
+        _ argument4: D
+    ) -> GodotError {
+        emitSignal(
+            signal.name,
+            argument1.toVariant(),
+            argument2.toVariant(),
+            argument3.toVariant(),
+            argument4.toVariant()
+        )
+    }
+
+    @discardableResult
+    func connect(
+        signal: SignalWith4Arguments<some Any, some Any, some Any, some Any>,
+        to target: some Object,
+        method: String
+    ) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+}

--- a/Sources/SwiftGodot/Core/SignalRegistration.swift
+++ b/Sources/SwiftGodot/Core/SignalRegistration.swift
@@ -5,168 +5,216 @@
 //  Created by Padraig O Cinneide on 2023-10-18.
 //
 
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
 public struct SignalWithNoArguments {
-    let name: StringName
-
-    public init<Source: SwiftGodot.Object>(
-        _ signalName: String,
-        classType: Source.Type
-    ) {
+    public let name: StringName
+    public let arguments: [PropInfo] = [] // needed for registration in macro, but always []
+    
+    public init(_ signalName: String) {
         name = StringName(signalName)
-        let className = String(describing: classType)
-
-        ClassInfo<Source>(name: StringName(className)).registerSignal(
-            name: name,
-            arguments: []
-        )
     }
 }
 
-extension PropInfo {
-    init(
-        propertyType: (some GodotVariant).Type,
-        propertyName: StringName
-    ) {
-        self.init(
-            propertyType: propertyType.gType,
-            propertyName: propertyName,
-            className: propertyType.gType == .object ? .init(String(describing: propertyType.self)) : "",
-            hint: .none,
-            hintStr: "",
-            usage: .default
-        )
-    }
-}
-
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
 public struct SignalWith1Argument<Argument: GodotVariant> {
-    let name: StringName
-
-    public init<Source: SwiftGodot.Object>(
+    public let name: StringName
+    public let arguments: [PropInfo]
+    
+    public init(
         _ signalName: String,
-        argumentName: String? = nil,
-        classType: Source.Type
+        argument1Name: String? = nil
     ) {
         name = StringName(signalName)
-
-        ClassInfo<Source>(
-            name: StringName(String(describing: classType))
-        ).registerSignal(
-            name: name,
-            arguments: [
-                PropInfo(propertyType: Argument.self, propertyName: .init(argumentName ?? "arg1")),
-            ]
-        )
+        arguments = [
+            PropInfo(propertyType: Argument.self, propertyName: .init(argument1Name ?? "arg1"))
+        ]
     }
 }
 
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
 public struct SignalWith2Arguments<
     Argument1: GodotVariant,
     Argument2: GodotVariant
 > {
-    let name: StringName
-
-    public init<Source: SwiftGodot.Object>(
+    public let name: StringName
+    public let arguments: [PropInfo]
+    
+    public init(
         _ signalName: String,
         argument1Name: String? = nil,
-        argument2Name: String? = nil,
-        classType: Source.Type
+        argument2Name: String? = nil
     ) {
         name = StringName(signalName)
-
-        ClassInfo<Source>(
-            name: StringName(String(describing: classType))
-        ).registerSignal(
-            name: name,
-            arguments: [
-                PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
-                PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
-            ]
-        )
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+        ]
     }
 }
 
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
 public struct SignalWith3Arguments<
     Argument1: GodotVariant,
     Argument2: GodotVariant,
     Argument3: GodotVariant
 > {
-    let name: StringName
+    public let name: StringName
+    public let arguments: [PropInfo]
 
-    public init<Source: SwiftGodot.Object>(
+    public init(
         _ signalName: String,
         argument1Name: String? = nil,
         argument2Name: String? = nil,
-        argument3Name: String? = nil,
-        classType: Source.Type
+        argument3Name: String? = nil
     ) {
         name = StringName(signalName)
-
-        ClassInfo<Source>(
-            name: StringName(String(describing: classType))
-        ).registerSignal(
-            name: name,
-            arguments: [
-                PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
-                PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
-                PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
-            ]
-        )
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+        ]
     }
 }
 
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
 public struct SignalWith4Arguments<
     Argument1: GodotVariant,
     Argument2: GodotVariant,
     Argument3: GodotVariant,
     Argument4: GodotVariant
 > {
-    let name: StringName
+    public let name: StringName
+    public let arguments: [PropInfo]
 
-    public init<Source: SwiftGodot.Object>(
+    public init(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        argument3Name: String? = nil,
+        argument4Name: String? = nil
+    ) {
+        name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4"))
+        ]
+    }
+}
+
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWith5Arguments<
+    Argument1: GodotVariant,
+    Argument2: GodotVariant,
+    Argument3: GodotVariant,
+    Argument4: GodotVariant,
+    Argument5: GodotVariant
+> {
+    public let name: StringName
+    public let arguments: [PropInfo]
+
+    public init(
         _ signalName: String,
         argument1Name: String? = nil,
         argument2Name: String? = nil,
         argument3Name: String? = nil,
         argument4Name: String? = nil,
-        classType: Source.Type
+        argument5Name: String? = nil
     ) {
         name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4")),
+            PropInfo(propertyType: Argument5.self, propertyName: .init(argument5Name ?? "arg5"))
+        ]
+    }
+}
 
-        ClassInfo<Source>(
-            name: StringName(String(describing: classType))
-        ).registerSignal(
-            name: name,
-            arguments: [
-                PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
-                PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
-                PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
-                PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4")),
-            ]
-        )
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWith6Arguments<
+    Argument1: GodotVariant,
+    Argument2: GodotVariant,
+    Argument3: GodotVariant,
+    Argument4: GodotVariant,
+    Argument5: GodotVariant,
+    Argument6: GodotVariant
+> {
+    public let name: StringName
+    public let arguments: [PropInfo]
+
+    public init(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        argument3Name: String? = nil,
+        argument4Name: String? = nil,
+        argument5Name: String? = nil,
+        argument6Name: String? = nil
+    ) {
+        name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4")),
+            PropInfo(propertyType: Argument5.self, propertyName: .init(argument5Name ?? "arg5")),
+            PropInfo(propertyType: Argument6.self, propertyName: .init(argument6Name ?? "arg6"))
+        ]
     }
 }
 
 public extension Object {
+    /// Emits a signal that was previously defined with the #signal macro.
+    ///
+    ///  - Example: emit(signal: Player.scored)
     @discardableResult
     func emit(signal: SignalWithNoArguments) -> GodotError {
         emitSignal(signal.name)
     }
 
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
     func connect(signal: SignalWithNoArguments, to target: some Object, method: String) -> GodotError {
         connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
     }
 
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12)
     @discardableResult
     func emit<A: GodotVariant>(signal: SignalWith1Argument<A>, _ argument: A) -> GodotError {
         emitSignal(signal.name, argument.toVariant())
     }
 
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
     func connect(signal: SignalWith1Argument<some Any>, to target: some Object, method: String) -> GodotError {
         connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
     }
-
+    
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray")
     @discardableResult
     func emit<A: GodotVariant, B: GodotVariant>(
         signal: SignalWith2Arguments<A, B>,
@@ -176,12 +224,20 @@ public extension Object {
         emitSignal(signal.name, argument1.toVariant(), argument2.toVariant())
     }
 
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
     func connect(signal: SignalWith2Arguments<some Any, some Any>, to target: some Object, method: String) -> GodotError {
-        // GD.print("connecting \(self) -> \(signal.name.description) to \(method.name.description) on \(description)")
         connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
     }
 
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray", self)
     @discardableResult
     func emit<A: GodotVariant, B: GodotVariant, C: GodotVariant>(
         signal: SignalWith3Arguments<A, B, C>,
@@ -192,6 +248,12 @@ public extension Object {
         emitSignal(signal.name, argument1.toVariant(), argument2.toVariant(), argument3.toVariant())
     }
 
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
     func connect(
         signal: SignalWith3Arguments<some Any, some Any, some Any>,
@@ -201,6 +263,9 @@ public extension Object {
         connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
     }
 
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4)
     @discardableResult
     func emit<A: GodotVariant, B: GodotVariant, C: GodotVariant, D: GodotVariant>(
         signal: SignalWith4Arguments<A, B, C, D>,
@@ -218,6 +283,12 @@ public extension Object {
         )
     }
 
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
     func connect(
         signal: SignalWith4Arguments<some Any, some Any, some Any, some Any>,
@@ -225,5 +296,97 @@ public extension Object {
         method: String
     ) -> GodotError {
         connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+    
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4, "another_one")
+    @discardableResult
+    func emit<A: GodotVariant, B: GodotVariant, C: GodotVariant, D: GodotVariant, E: GodotVariant>(
+        signal: SignalWith5Arguments<A, B, C, D, E>,
+        _ argument1: A,
+        _ argument2: B,
+        _ argument3: C,
+        _ argument4: D,
+        _ argument5: E
+    ) -> GodotError {
+        emitSignal(
+            signal.name,
+            argument1.toVariant(),
+            argument2.toVariant(),
+            argument3.toVariant(),
+            argument4.toVariant(),
+            argument5.toVariant()
+        )
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(
+        signal: SignalWith5Arguments<some Any, some Any, some Any, some Any, some Any>,
+        to target: some Object,
+        method: String
+    ) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+    
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4, reason)
+    @discardableResult
+    func emit<A: GodotVariant, B: GodotVariant, C: GodotVariant, D: GodotVariant, E: GodotVariant, F: GodotVariant>(
+        signal: SignalWith6Arguments<A, B, C, D, E, F>,
+        _ argument1: A,
+        _ argument2: B,
+        _ argument3: C,
+        _ argument4: D,
+        _ argument5: E,
+        _ argument6: F
+    ) -> GodotError {
+        emitSignal(
+            signal.name,
+            argument1.toVariant(),
+            argument2.toVariant(),
+            argument3.toVariant(),
+            argument4.toVariant(),
+            argument5.toVariant(),
+            argument6.toVariant()
+        )
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(
+        signal: SignalWith6Arguments<some Any, some Any, some Any, some Any, some Any, some Any>,
+        to target: some Object,
+        method: String
+    ) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+}
+
+private extension PropInfo {
+    init(
+        propertyType: (some GodotVariant).Type,
+        propertyName: StringName
+    ) {
+        self.init(
+            propertyType: propertyType.gType,
+            propertyName: propertyName,
+            className: propertyType.gType == .object ? .init(String(describing: propertyType.self)) : "",
+            hint: .none,
+            hintStr: "",
+            usage: .default
+        )
     }
 }

--- a/Sources/SwiftGodot/Core/StringExtensions.swift
+++ b/Sources/SwiftGodot/Core/StringExtensions.swift
@@ -79,6 +79,8 @@ extension GString: CustomStringConvertible {
 }
 
 extension String: GodotVariant {
+    public static var gType: Variant.GType { .string }
+    
     static func pointer(_ object: AnyObject?) -> String {
         guard let object = object else { return "nil" }
         let opaque: UnsafeMutableRawPointer = Unmanaged.passUnretained(object).toOpaque()

--- a/Sources/SwiftGodot/Core/StringExtensions.swift
+++ b/Sources/SwiftGodot/Core/StringExtensions.swift
@@ -94,15 +94,13 @@ extension String: GodotVariant {
     public init (_ n: StringName) {
         self = n.description
     }
-    
-    public init? (_ fromVariant: Variant) {
-        guard fromVariant.gtype == .string else {
-            return nil
-        }
+
+    public static func unwrap(variant: Variant) -> String? {
+        guard variant.gtype == .string else { return nil }
         var content = GString.zero
         
-        fromVariant.toType(.string, dest: &content)
+        variant.toType(.string, dest: &content)
         let g = GString(content: content)
-        self = g.description
+        return g.description
     }
 }

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -11,6 +11,7 @@
 public protocol GodotVariant {
     func toVariant () -> Variant
     init? (_ fromVariant: Variant)
+    static var gType: Variant.GType { get }
 }
 
 /// This represents a typed array of one of the built-in types from Godot

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -126,4 +126,19 @@ public macro NativeHandleDiscarding() = #externalMacro(module: "SwiftGodotMacroL
 @attached(accessor)
 public macro SceneTree(path: String) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SceneTreeMacro")
 
+
+//public struct SignalArgument<Argument: GodotVariant> {
+//    let name: String
+//    public init(_ name: String) {
+//        self.name = name
+//    }
+//}
+//
+//@freestanding(declaration, names: arbitrary)
+//public macro signal<each T>(_ signalName: String, _ types: repeat SignalArgument<each T>) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SignalMacro")
+//
+
+@freestanding(declaration, names: arbitrary)
+public macro signal(_ signalName: String, arguments: Dictionary<String, Any.Type> = [:]) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SignalMacro")
+
 #endif

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -126,18 +126,27 @@ public macro NativeHandleDiscarding() = #externalMacro(module: "SwiftGodotMacroL
 @attached(accessor)
 public macro SceneTree(path: String) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SceneTreeMacro")
 
-
-//public struct SignalArgument<Argument: GodotVariant> {
-//    let name: String
-//    public init(_ name: String) {
-//        self.name = name
-//    }
-//}
-//
-//@freestanding(declaration, names: arbitrary)
-//public macro signal<each T>(_ signalName: String, _ types: repeat SignalArgument<each T>) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SignalMacro")
-//
-
+/// Defines a Godot signal on a class.
+///
+/// The `@Godot` macro will register any #signal defined signals so that they can be used in the editor.
+///
+/// Usage:
+/// ```swift
+/// @Godot class MyNode: Node2D {
+///     #signal("game_started")
+///     #signal("lives_changed", argument: ["new_lives_count", Int.self])
+///
+///     func startGame() {
+///        emit(MyNode.gameStarted)
+///        emit(MyNode.livesChanged, 5)
+///     }
+/// }
+/// ```
+///
+/// - Parameter signalName: The name of the signal as registered to Godot.
+/// - Parameter arguments: If the signal has arguments, they should be defined here as a dictionary of argument name to type. For
+/// example, ["name" : String.self] declares that the signal takes one argument of string type. The argument name is provided to the godot
+/// editor. Argument types are enforced on the `emit(signal:_argument)` method. Argument types must conform to GodotVariant.
 @freestanding(declaration, names: arbitrary)
 public macro signal(_ signalName: String, arguments: Dictionary<String, Any.Type> = [:]) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SignalMacro")
 

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -349,6 +349,8 @@ extension Int: GodotVariant {
         var value = 0
         from.toType(.int, dest: &value)
         self.init (value)
+    public static var gType: Variant.GType { .int }
+    
     }
     
     public func toVariant () -> Variant { Variant (self) }
@@ -363,12 +365,16 @@ extension Int64: GodotVariant {
         var value = 0
         from.toType(.int, dest: &value)
         self.init (value)
+    public static var gType: Variant.GType { .int }
+    
     }
     
     public func toVariant () -> Variant { Variant (Int (self)) }
 }
 
 extension Bool: GodotVariant {
+    public static var gType: Variant.GType { .bool }
+    
     /// Creates a new instance from the given variant if it contains a boolean
     public init? (_ from: Variant) {
         guard from.gtype == .bool else {
@@ -383,6 +389,8 @@ extension Bool: GodotVariant {
 }
 
 extension Float: GodotVariant {
+    public static var gType: Variant.GType { .float }
+    
     /// Creates a new instance from the given variant if it contains a float
     public init? (_ from: Variant) {
         guard from.gtype == .float else {
@@ -396,7 +404,9 @@ extension Float: GodotVariant {
     public func toVariant () -> Variant { Variant (self) }
 }
 
-extension Double {
+extension Double: GodotVariant {
+    public static var gType: Variant.GType { .float }
+    
     /// Creates a new instance from the given variant if it contains a float
     public init? (_ from: Variant) {
         guard from.gtype == .float else {
@@ -406,4 +416,6 @@ extension Double {
         from.toType(.float, dest: &value)
         self.init (Double (value))
     }
+    
+    public func toVariant() -> Variant { .init(Float(self)) }
 }

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -89,7 +89,7 @@ public class Variant: Hashable, Equatable, ExpressibleByStringLiteral, CustomDeb
         let ret = Variant (false)
         
         gi.variant_evaluate (GDEXTENSION_VARIANT_OP_EQUAL, &lhs.content, &rhs.content, &ret.content, &valid)
-        return Bool (ret) ?? false
+        return Bool.unwrap(variant: ret) ?? false
     }
     
     public func hash(into hasher: inout Hasher) {
@@ -343,78 +343,67 @@ public class Variant: Hashable, Equatable, ExpressibleByStringLiteral, CustomDeb
 extension Int: GodotVariant {
     public static var gType: Variant.GType { .int }
     
-    /// Creates a new instance from the given variant if it contains an integer
-    public init? (_ from: Variant) {
-        guard from.gtype == .int else {
-            return nil
-        }
-        var value = 0
-        from.toType(.int, dest: &value)
-        self.init (value)
+    public static func unwrap(variant: Variant) -> Self? {
+        guard variant.gtype == gType else { return nil }
+        var value: Self = .init()
+        variant.toType(gType, dest: &value)
+        return value
     }
-        
-    public func toVariant () -> Variant { Variant (self) }
+    
+    public func toVariant () -> Variant { .init(self) }
 }
 
 extension Int64: GodotVariant {
-   public static var gType: Variant.GType { .int }
+    public static var gType: Variant.GType { .int }
     
-    /// Creates a new instance from the given variant if it contains an integer
-    public init? (_ from: Variant) {
-        guard from.gtype == .int else {
-            return nil
-        }
-        var value = 0
-        from.toType(.int, dest: &value)
-        self.init (value)
+    public static func unwrap(variant: Variant) -> Self? {
+        guard variant.gtype == gType else { return nil }
+        var value: Self = .init()
+        variant.toType(gType, dest: &value)
+        return value
     }
-     
-    public func toVariant () -> Variant { Variant (Int (self)) }
+    
+    public func toVariant () -> Variant { .init(Int(self)) }
 }
 
 extension Bool: GodotVariant {
     public static var gType: Variant.GType { .bool }
     
     /// Creates a new instance from the given variant if it contains a boolean
-    public init? (_ from: Variant) {
-        guard from.gtype == .bool else {
-            return nil
-        }
-        var v = GDExtensionBool (0)
-        from.toType(.bool, dest: &v)
-        self.init (v == 0 ? false : true)
+    public static func unwrap(variant: Variant) -> Self? {
+        guard variant.gtype == gType else { return nil }
+        var value = GDExtensionBool (0)
+        variant.toType(gType, dest: &value)
+        return value != 0
     }
     
-    public func toVariant () -> Variant { Variant (self) }
+    public func toVariant () -> Variant { .init(self) }
 }
 
 extension Float: GodotVariant {
     public static var gType: Variant.GType { .float }
     
     /// Creates a new instance from the given variant if it contains a float
-    public init? (_ from: Variant) {
-        guard from.gtype == .float else {
-            return nil
-        }
-        var value: Double = 0
-        from.toType(.float, dest: &value)
-        self.init (Float (value))
+    public static func unwrap(variant: Variant) -> Self? {
+        guard variant.gtype == gType else { return nil }
+        var value: Double = .init()
+        variant.toType(gType, dest: &value)
+        return Float(value)
     }
 
-    public func toVariant () -> Variant { Variant (self) }
+    public func toVariant () -> Variant { .init(self) }
 }
 
 extension Double: GodotVariant {
     public static var gType: Variant.GType { .float }
     
     /// Creates a new instance from the given variant if it contains a float
-    public init? (_ from: Variant) {
-        guard from.gtype == .float else {
-            return nil
-        }
-        var value: Double = 0
-        from.toType(.float, dest: &value)
-        self.init (Double (value))
+    /// /// Creates a new instance from the given variant if it contains a float
+    public static func unwrap(variant: Variant) -> Self? {
+        guard variant.gtype == gType else { return nil }
+        var value: Double = .init()
+        variant.toType(gType, dest: &value)
+        return value
     }
     
     public func toVariant() -> Variant { .init(Float(self)) }

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -341,6 +341,8 @@ public class Variant: Hashable, Equatable, ExpressibleByStringLiteral, CustomDeb
 }
 
 extension Int: GodotVariant {
+    public static var gType: Variant.GType { .int }
+    
     /// Creates a new instance from the given variant if it contains an integer
     public init? (_ from: Variant) {
         guard from.gtype == .int else {
@@ -349,14 +351,14 @@ extension Int: GodotVariant {
         var value = 0
         from.toType(.int, dest: &value)
         self.init (value)
-    public static var gType: Variant.GType { .int }
-    
     }
-    
+        
     public func toVariant () -> Variant { Variant (self) }
 }
 
 extension Int64: GodotVariant {
+   public static var gType: Variant.GType { .int }
+    
     /// Creates a new instance from the given variant if it contains an integer
     public init? (_ from: Variant) {
         guard from.gtype == .int else {
@@ -365,10 +367,8 @@ extension Int64: GodotVariant {
         var value = 0
         from.toType(.int, dest: &value)
         self.init (value)
-    public static var gType: Variant.GType { .int }
-    
     }
-    
+     
     public func toVariant () -> Variant { Variant (Int (self)) }
 }
 

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -40,7 +40,7 @@ public struct GodotCallable: PeerMacro {
             if first != "_" {
                 genMethod.append ("\(first): ")
             }
-            genMethod.append ("\(ptype) (args [\(argc)])!")
+            genMethod.append ("\(ptype).unwrap (variant: args [\(argc)])!")
             argc += 1
         }
         

--- a/Sources/SwiftGodotMacroLibrary/SignalMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SignalMacro.swift
@@ -1,0 +1,112 @@
+//
+//  SignalMacro.swift
+//  SwiftGodot
+//
+//  Created by Padraig O Cinneide on 2023-10-19.
+
+import Foundation
+import SwiftCompilerPlugin
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct SignalMacro: DeclarationMacro {
+    
+    enum ProviderDiagnostic: Error, DiagnosticMessage {
+        case tooManyArguments
+        case argumentsInUnexpectedSyntax
+
+        var severity: DiagnosticSeverity { .error }
+
+        var message: String {
+            switch self {
+            case .argumentsInUnexpectedSyntax:
+                "Failed to parse arguments. Define arguments in the form [\"argumentName\": Type.self]"
+            case .tooManyArguments:
+                "Too many arguments in the arguments dictionary. A maximum of 6 are supported."
+            }
+        }
+
+        var diagnosticID: MessageID {
+            MessageID(domain: "SwiftGodotMacros", id: message)
+        }
+    }
+    
+    public static func expansion(
+        of node: some SwiftSyntax.FreestandingMacroExpansionSyntax,
+        in context: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [SwiftSyntax.DeclSyntax] {
+        
+        var signalName: SignalName? = nil
+        var arguments = [(name: String, type: String)]()
+        
+        for (index, argument) in node.argumentList.enumerated() {
+            if index == 0 {
+                signalName = argument.expression.signalName()
+            }
+            if index == 1 {
+                if argument.expression.description == ".init()" {
+                    // its an empty dictionary, so no arguments
+                    continue
+                }
+                
+                guard let dictSyntax = DictionaryExprSyntax(argument.expression) else {
+                    throw ProviderDiagnostic.argumentsInUnexpectedSyntax
+                }
+                
+                if case .colon = dictSyntax.content {
+                    // its an empty dictionary, so no arguments
+                    continue
+                }
+                
+                guard let pairList = DictionaryElementListSyntax(dictSyntax.content) else {
+                    throw ProviderDiagnostic.argumentsInUnexpectedSyntax
+                }
+                
+                for pair in pairList {
+                    guard let typeName = pair.value.typeName() else {
+                        throw ProviderDiagnostic.argumentsInUnexpectedSyntax
+                    }
+                    arguments.append((pair.key.description, typeName))
+                }
+            }
+        }
+        
+        guard let signalName else { return [] }
+        
+        let genericTypeList = arguments.map { $0.type }.joined(separator: ", ")
+        
+        let signalWrapperType = switch arguments.count {
+        case 0: "SignalWithNoArguments"
+        case 1: "SignalWith1Argument<\(genericTypeList)>"
+        case 2: "SignalWith2Arguments<\(genericTypeList)>"
+        case 3: "SignalWith3Arguments<\(genericTypeList)>"
+        case 4: "SignalWith4Arguments<\(genericTypeList)>"
+        case 5: "SignalWith5Arguments<\(genericTypeList)>"
+        case 6: "SignalWith6Arguments<\(genericTypeList)>"
+        default:
+            throw ProviderDiagnostic.tooManyArguments
+        }
+        
+        let argumentList = ["\"" + signalName.godotName + "\""] + arguments
+            .enumerated()
+            .map { index, argument in
+                "argument\(index + 1)Name: \(argument.name)"
+            }
+            
+        let argumentsString = argumentList.joined(separator: ", ")
+        
+        return [
+            DeclSyntax(
+                try VariableDeclSyntax(
+                "static let \(raw: signalName.swiftName) = \(raw: signalWrapperType)(\(raw: argumentsString))"
+                )
+            )
+        ]
+    }
+    
+}
+
+
+


### PR DESCRIPTION
Adds a new freestanding macro that can be used inside a `@Godot` class to register a signal with Godot. 

Signal arguments can be defined and their types will be enforced on new `emit(signal:_argument)` methods.

```swift
@Godot 
class Player: Node2D {
    #signal("game_started")
    #signal("lives_changed", argument: ["new_lives_count": Int.self])

    func startGame() {
       emit(Player.gameStarted)
       emit(Player.livesChanged, 5)
    }
}

class Level: Area2D {
    func _ready() { 
       player.connect(Player.gameStarted, to: self, method: "game_started")
    }
    @Callable func game_started() { 
       GD.print("got game started signal!")
    }
}
```

This all works nicely with the Godot editor too — signals are exposed there and can be connected to GDScripts and well use the argument names provided in the `#signal` invocation. 

---

I did have to change `GodotVariant`'s `init()` requirement to be an `unwrap` so that subclasses of Godot objects could be made to conform to it. This makes the PR a bit more wide-reaching, but it means that it is possible to send a Node object as an argument to a `@Callable` now. 