### PR TITLE
Fix #initSwiftExtension failing on empty types

### DIFF
--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -60,7 +60,7 @@ public macro Export(_ hint: PropertyHint = .none, _ hintStr: String? = nil) = #e
 /// - Parameter types: The node types that should be registered with Godot.
 @freestanding(declaration, names: named(enterExtension), named(setupExtension))
 public macro initSwiftExtension(cdecl: String,
-                                types: [Wrapped.Type]) = #externalMacro(module: "SwiftGodotMacroLibrary",
+                                types: [Wrapped.Type] = []) = #externalMacro(module: "SwiftGodotMacroLibrary",
                                                                         type: "InitSwiftExtensionMacro")
 
 /// A macro that instantiates a `Texture2D` from a specified resource path. If the texture cannot be created, a

--- a/Sources/SwiftGodotMacroLibrary/InitSwiftExtensionMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/InitSwiftExtensionMacro.swift
@@ -19,9 +19,13 @@ public struct InitSwiftExtensionMacro: DeclarationMacro {
         guard let cDecl = node.argumentList.first?.expression else {
             fatalError("compiler bug: the macro does not have any arguments")
         }
-        guard let types = node.argumentList.last?.expression else {
-            fatalError("compiler bug: the macro does not have any arguments")
-        }
+		
+		let types: ExprSyntax
+		if node.argumentList.count >= 2 {
+			types = node.argumentList.last!.expression
+		} else {
+			types = "[]"
+		}
 
         let initModule: DeclSyntax = """
         @_cdecl(\(raw: cDecl.description)) public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
@@ -37,7 +41,7 @@ public struct InitSwiftExtensionMacro: DeclarationMacro {
 
         let setupModule: DeclSyntax = """
         func setupExtension(level: GDExtension.InitializationLevel) {
-            let types = \(types)
+            let types: [Wrapped.Type] = \(types)
             switch level {
             case .scene:
                 types.forEach(register)

--- a/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
@@ -16,6 +16,66 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
         "initSwiftExtension": InitSwiftExtensionMacro.self
     ]
 
+    func testInitSwiftExtensionMacroWithUnspecifiedTypes() {
+        assertMacroExpansion(
+            """
+            #initSwiftExtension(cdecl: "libchrysalis_entry_point")
+            """,
+            expandedSource: """
+            @_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+                guard let library, let interface, let `extension` else {
+                    print("Error: Not all parameters were initialized.")
+                    return 0
+                }
+                let deinitHook: (GDExtension.InitializationLevel) -> Void = { _ in
+                }
+                initializeSwiftModule(interface, library, `extension`, initHook: setupExtension, deInitHook: deinitHook)
+                return 1
+            }
+            func setupExtension(level: GDExtension.InitializationLevel) {
+                let types: [Wrapped.Type] = []
+                switch level {
+                case .scene:
+                    types.forEach(register)
+                default:
+                    break
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testInitSwiftExtensionMacroWithEmptyTypes() {
+        assertMacroExpansion(
+            """
+            #initSwiftExtension(cdecl: "libchrysalis_entry_point", types: [])
+            """,
+            expandedSource: """
+            @_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+                guard let library, let interface, let `extension` else {
+                    print("Error: Not all parameters were initialized.")
+                    return 0
+                }
+                let deinitHook: (GDExtension.InitializationLevel) -> Void = { _ in
+                }
+                initializeSwiftModule(interface, library, `extension`, initHook: setupExtension, deInitHook: deinitHook)
+                return 1
+            }
+            func setupExtension(level: GDExtension.InitializationLevel) {
+                let types: [Wrapped.Type] = []
+                switch level {
+                case .scene:
+                    types.forEach(register)
+                default:
+                    break
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
     func testInitSwiftExtensionMacro() {
         assertMacroExpansion(
             """
@@ -33,7 +93,7 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                 return 1
             }
             func setupExtension(level: GDExtension.InitializationLevel) {
-                let types = [ChrysalisNode.self]
+                let types: [Wrapped.Type] = [ChrysalisNode.self]
                 switch level {
                 case .scene:
                     types.forEach(register)


### PR DESCRIPTION
In the [Your First Extension](https://migueldeicaza.github.io/SwiftGodotDocs/tutorials/swiftgodot/your-first-extension) tutorial, section 1, step 6, the documentation suggests the following line:
```swift
#initSwiftExtension(cdecl: "swift_entry_point", types: [])
```
However, this currently causes an error: `Empty collection literal requires an explicit type`, due to the resulting line in the macro expansion `let types = []`.

As the easiest way to fix this, I simply added `: [Wrapped.Type]` into the macro expansion. But while doing this, I thought it could be a nice addition to give the `types` parameter a default value of `[]`. This way, the above macro with no types can be simplified to:
```swift
#initSwiftExtension(cdecl: "swift_entry_point")
```
This has the effect of allowing `types` to be introduced slightly later, which is a fun little bit of progressive disclosure!

And of course, I've added the appropriate test cases. ^-^