### PR TITLE
Fix no-op setter being generated by @Export macro

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -64,7 +64,6 @@ public struct GodotExport: PeerMacro {
         \(varName) = \(typeName)(args [0])!
     """
             }
-            return "func \(name) (args: [Variant]) -> Variant? {\n\treturn nil\n}"
         }
         return "func \(name) (args: [Variant]) -> Variant? {\n\t\(body)\n\treturn nil\n}"
     }


### PR DESCRIPTION
Closes #197 

In all cases where `godotVariants [typeName] != nil`, the resulting code generated by the macro had no operation, and does not set any value. 

For now I have just removed this. I'm not sure if there was a reason for this functionality but this change has fixed the issue I was having. Happy to discuss alternatives if there was a reason for this.