### PR TITLE
Make `Nil` initializer on Variant public

### DIFF
--- a/Sources/SwiftGodot/Core/VariantRepresentable.swift
+++ b/Sources/SwiftGodot/Core/VariantRepresentable.swift
@@ -198,3 +198,7 @@ extension PackedColorArray: VariantRepresentable {
 extension Object: VariantRepresentable {
     public static var godotType: Variant.GType { .object }
 }
+
+extension Nil: VariantRepresentable {
+    public static var godotType: Variant.GType { .nil }
+}

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -71,11 +71,6 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
         //gi.variant_destroy (&content)
     }
     
-    /// Creates a nil variant
-    public convenience init (_ value: Nil) {
-        self.init()
-    }
-    
     public init () {
         withUnsafeMutablePointer(to: &content) { ptr in
             gi.variant_new_nil (ptr)

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -72,7 +72,7 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
     }
     
     /// Creates a nil variant
-    convenience init (_ value: Nil) {
+    public convenience init (_ value: Nil) {
         self.init()
     }
     


### PR DESCRIPTION
Fixes an issue where it was not possible to init Variant with `Nil`