### PR TITLE
Add Signal Macro

### DIFF
--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -23,7 +23,11 @@ class Rigid: RigidBody2D {
 class SwiftSprite: Sprite2D {
     var time_passed: Double = 0
     var count: Int = 0
-
+    
+    #signal("picked_up_item", arguments: ["kind": String.self, "isGroovy": Bool.self, "count": Int.self])
+    #signal("scored")
+    #signal("lives_changed", arguments: ["count": Int.self])
+    
     @Callable
     public func computeGodot (x: String, y: Int) -> Double {
         return 1.0

--- a/Sources/SwiftGodot/Core/SignalRegistration.swift
+++ b/Sources/SwiftGodot/Core/SignalRegistration.swift
@@ -1,0 +1,392 @@
+//
+//  SignalRegistration.swift
+//
+//
+//  Created by Padraig O Cinneide on 2023-10-18.
+//
+
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWithNoArguments {
+    public let name: StringName
+    public let arguments: [PropInfo] = [] // needed for registration in macro, but always []
+    
+    public init(_ signalName: String) {
+        name = StringName(signalName)
+    }
+}
+
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWith1Argument<Argument: VariantStorable> {
+    public let name: StringName
+    public let arguments: [PropInfo]
+    
+    public init(
+        _ signalName: String,
+        argument1Name: String? = nil
+    ) {
+        name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument.self, propertyName: .init(argument1Name ?? "arg1"))
+        ]
+    }
+}
+
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWith2Arguments<
+    Argument1: VariantStorable,
+    Argument2: VariantStorable
+> {
+    public let name: StringName
+    public let arguments: [PropInfo]
+    
+    public init(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil
+    ) {
+        name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+        ]
+    }
+}
+
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWith3Arguments<
+    Argument1: VariantStorable,
+    Argument2: VariantStorable,
+    Argument3: VariantStorable
+> {
+    public let name: StringName
+    public let arguments: [PropInfo]
+
+    public init(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        argument3Name: String? = nil
+    ) {
+        name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+        ]
+    }
+}
+
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWith4Arguments<
+    Argument1: VariantStorable,
+    Argument2: VariantStorable,
+    Argument3: VariantStorable,
+    Argument4: VariantStorable
+> {
+    public let name: StringName
+    public let arguments: [PropInfo]
+
+    public init(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        argument3Name: String? = nil,
+        argument4Name: String? = nil
+    ) {
+        name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4"))
+        ]
+    }
+}
+
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWith5Arguments<
+    Argument1: VariantStorable,
+    Argument2: VariantStorable,
+    Argument3: VariantStorable,
+    Argument4: VariantStorable,
+    Argument5: VariantStorable
+> {
+    public let name: StringName
+    public let arguments: [PropInfo]
+
+    public init(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        argument3Name: String? = nil,
+        argument4Name: String? = nil,
+        argument5Name: String? = nil
+    ) {
+        name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4")),
+            PropInfo(propertyType: Argument5.self, propertyName: .init(argument5Name ?? "arg5"))
+        ]
+    }
+}
+
+/// Describes a signal and its arguments.
+/// - note: It is recommended to use the #signal macro instead of using this directly.
+public struct SignalWith6Arguments<
+    Argument1: VariantStorable,
+    Argument2: VariantStorable,
+    Argument3: VariantStorable,
+    Argument4: VariantStorable,
+    Argument5: VariantStorable,
+    Argument6: VariantStorable
+> {
+    public let name: StringName
+    public let arguments: [PropInfo]
+
+    public init(
+        _ signalName: String,
+        argument1Name: String? = nil,
+        argument2Name: String? = nil,
+        argument3Name: String? = nil,
+        argument4Name: String? = nil,
+        argument5Name: String? = nil,
+        argument6Name: String? = nil
+    ) {
+        name = StringName(signalName)
+        arguments = [
+            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4")),
+            PropInfo(propertyType: Argument5.self, propertyName: .init(argument5Name ?? "arg5")),
+            PropInfo(propertyType: Argument6.self, propertyName: .init(argument6Name ?? "arg6"))
+        ]
+    }
+}
+
+public extension Object {
+    /// Emits a signal that was previously defined with the #signal macro.
+    ///
+    ///  - Example: emit(signal: Player.scored)
+    @discardableResult
+    func emit(signal: SignalWithNoArguments) -> GodotError {
+        emitSignal(signal.name)
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(signal: SignalWithNoArguments, to target: some Object, method: String) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12)
+    @discardableResult
+    func emit<A: VariantStorable>(signal: SignalWith1Argument<A>, _ argument: A) -> GodotError {
+        emitSignal(signal.name, .init(argument))
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(signal: SignalWith1Argument<some Any>, to target: some Object, method: String) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+    
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray")
+    @discardableResult
+    func emit<A: VariantStorable, B: VariantStorable>(
+        signal: SignalWith2Arguments<A, B>,
+        _ argument1: A,
+        _ argument2: B
+    ) -> GodotError {
+        emitSignal(signal.name, .init(argument1), .init(argument2))
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(signal: SignalWith2Arguments<some Any, some Any>, to target: some Object, method: String) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray", self)
+    @discardableResult
+    func emit<A: VariantStorable, B: VariantStorable, C: VariantStorable>(
+        signal: SignalWith3Arguments<A, B, C>,
+        _ argument1: A,
+        _ argument2: B,
+        _ argument3: C
+    ) -> GodotError {
+        emitSignal(signal.name, .init(argument1), .init(argument2), .init(argument3))
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(
+        signal: SignalWith3Arguments<some Any, some Any, some Any>,
+        to target: some Object,
+        method: String
+    ) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4)
+    @discardableResult
+    func emit<A: VariantStorable, B: VariantStorable, C: VariantStorable, D: VariantStorable>(
+        signal: SignalWith4Arguments<A, B, C, D>,
+        _ argument1: A,
+        _ argument2: B,
+        _ argument3: C,
+        _ argument4: D
+    ) -> GodotError {
+        emitSignal(
+            signal.name,
+            .init(argument1),
+            .init(argument2),
+            .init(argument3),
+            .init(argument4)
+        )
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(
+        signal: SignalWith4Arguments<some Any, some Any, some Any, some Any>,
+        to target: some Object,
+        method: String
+    ) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+    
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4, "another_one")
+    @discardableResult
+    func emit<A: VariantStorable, B: VariantStorable, C: VariantStorable, D: VariantStorable, E: VariantStorable>(
+        signal: SignalWith5Arguments<A, B, C, D, E>,
+        _ argument1: A,
+        _ argument2: B,
+        _ argument3: C,
+        _ argument4: D,
+        _ argument5: E
+    ) -> GodotError {
+        emitSignal(
+            signal.name,
+            .init(argument1),
+            .init(argument2),
+            .init(argument3),
+            .init(argument4),
+            .init(argument5)
+        )
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(
+        signal: SignalWith5Arguments<some Any, some Any, some Any, some Any, some Any>,
+        to target: some Object,
+        method: String
+    ) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+    
+    /// Emits a signal that was previously defined with the #signal macro.
+    /// The argument must match the type of the argument at that position in the signal.
+    ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4, reason)
+    @discardableResult
+    func emit<A: VariantStorable, B: VariantStorable, C: VariantStorable, D: VariantStorable, E: VariantStorable, F: VariantStorable>(
+        signal: SignalWith6Arguments<A, B, C, D, E, F>,
+        _ argument1: A,
+        _ argument2: B,
+        _ argument3: C,
+        _ argument4: D,
+        _ argument5: E,
+        _ argument6: F
+    ) -> GodotError {
+        emitSignal(
+            signal.name,
+            .init(argument1),
+            .init(argument2),
+            .init(argument3),
+            .init(argument4),
+            .init(argument5),
+            .init(argument6)
+        )
+    }
+
+    /// Connects a signal to a callable method
+    /// - parameters:
+    ///     - signal: a signal that was previously defined with the #signal macro.
+    ///     - target: an Object that the method will be called on when the signal emits
+    ///     - method: the name of a @Callable method defined on the `target` object.
+    ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
+    @discardableResult
+    func connect(
+        signal: SignalWith6Arguments<some Any, some Any, some Any, some Any, some Any, some Any>,
+        to target: some Object,
+        method: String
+    ) -> GodotError {
+        connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
+    }
+}
+
+private extension PropInfo {
+    init(
+        propertyType: (some VariantStorable).Type,
+        propertyName: StringName
+    ) {
+        self.init(
+            propertyType: propertyType.Representable.godotType,
+            propertyName: propertyName,
+            className: propertyType.Representable.godotType == .object ? .init(String(describing: propertyType.self)) : "",
+            hint: .none,
+            hintStr: "",
+            usage: .default
+        )
+    }
+}

--- a/Sources/SwiftGodot/Core/VariantRepresentable.swift
+++ b/Sources/SwiftGodot/Core/VariantRepresentable.swift
@@ -32,6 +32,11 @@ extension VariantRepresentable {
     public init?(_ variant: Variant) {
         guard Self.godotType == variant.gtype else { return nil }
         
+        guard variant.gtype != .object else {
+            GD.print("Attempted to initialize a new `\(Self.self)` with \(variant.description) but it is not possible to initialize a GodotObject in a Swift initializer. Instead, use `\(Self.self).makeOrUnwrap(variant)`.")
+            return nil
+        }
+        
         self.init()
         
         withUnsafeMutablePointer(to: &self) { ptr in

--- a/Sources/SwiftGodot/Core/VariantStorable.swift
+++ b/Sources/SwiftGodot/Core/VariantStorable.swift
@@ -25,6 +25,22 @@ public protocol VariantStorable {
     func toVariantRepresentable() -> Representable
 }
 
+extension VariantStorable {
+    /// Unwraps an object from a variant. This is useful when you want one method to call that
+    /// will return the unwrapped Variant, regardless of whether it is a GodotObject or not.
+    public static func makeOrUnwrap(_ variant: Variant) -> Self? {
+        guard variant.gtype != .object else {
+            return nil
+        }
+        return Self(variant)
+    }
+
+    /// Unwraps an object from a variant.
+    public static func makeOrUnwrap(_ variant: Variant) -> Self? where Self: GodotObject {
+        return variant.asObject()
+    }
+}
+
 extension String: VariantStorable {
     public func toVariantRepresentable() -> GString {
         GString(stringLiteral: self)

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -126,4 +126,28 @@ public macro NativeHandleDiscarding() = #externalMacro(module: "SwiftGodotMacroL
 @attached(accessor)
 public macro SceneTree(path: String) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SceneTreeMacro")
 
+/// Defines a Godot signal on a class.
+///
+/// The `@Godot` macro will register any #signal defined signals so that they can be used in the editor.
+///
+/// Usage:
+/// ```swift
+/// @Godot class MyNode: Node2D {
+///     #signal("game_started")
+///     #signal("lives_changed", argument: ["new_lives_count", Int.self])
+///
+///     func startGame() {
+///        emit(MyNode.gameStarted)
+///        emit(MyNode.livesChanged, 5)
+///     }
+/// }
+/// ```
+///
+/// - Parameter signalName: The name of the signal as registered to Godot.
+/// - Parameter arguments: If the signal has arguments, they should be defined here as a dictionary of argument name to type. For
+/// example, ["name" : String.self] declares that the signal takes one argument of string type. The argument name is provided to the godot
+/// editor. Argument types are enforced on the `emit(signal:_argument)` method. Argument types must conform to GodotVariant.
+@freestanding(declaration, names: arbitrary)
+public macro signal(_ signalName: String, arguments: Dictionary<String, Any.Type> = [:]) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SignalMacro")
+
 #endif

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -40,7 +40,7 @@ public struct GodotCallable: PeerMacro {
             if first != "_" {
                 genMethod.append ("\(first): ")
             }
-            genMethod.append ("\(ptype) (args [\(argc)])!")
+            genMethod.append ("\(ptype).makeOrUnwrap (args [\(argc)])!")
             argc += 1
         }
         

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -42,6 +42,7 @@ class GodotMacroProcessor {
         return name
     }
     
+    
     func classInitSignals(_ declSyntax: MacroExpansionDeclSyntax) throws {
         guard declSyntax.macroName.tokenKind == .identifier("signal") else {
             return

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -41,7 +41,26 @@ class GodotMacroProcessor {
         propertyDeclarations [key] = name
         return name
     }
-
+    
+    func classInitSignals(_ declSyntax: MacroExpansionDeclSyntax) throws {
+        guard declSyntax.macroName.tokenKind == .identifier("signal") else {
+            return
+        }
+        
+        guard let firstArg = declSyntax.arguments.first else {
+            return
+        }
+        
+        guard let signalName = firstArg.expression.signalName() else {
+            return
+        }
+        
+        ctor.append("classInfo.registerSignal(")
+        ctor.append("name: \(className).\(signalName.swiftName).name,")
+        ctor.append("arguments: \(className).\(signalName.swiftName).arguments")
+        ctor.append(")")
+    }
+    
     // Processes a function
     func processFunction (_ funcDecl: FunctionDeclSyntax) throws {
         guard hasCallableAttribute(funcDecl.attributes) else {
@@ -169,11 +188,13 @@ class GodotMacroProcessor {
     """
         for member in classDecl.memberBlock.members.enumerated() {
             let decl = member.element.decl
-            if let funcDecl = decl.as(FunctionDeclSyntax.self) {
+            // MacroExpansionDeclSyntax
+            if let funcDecl = FunctionDeclSyntax(decl) {
                 try processFunction (funcDecl)
-            }
-            else if let varDecl = decl.as (VariableDeclSyntax.self) {
+            } else if let varDecl = VariableDeclSyntax(decl) {
                 try processVariable (varDecl)
+            } else if let macroDecl = MacroExpansionDeclSyntax(decl) {
+                try classInitSignals(macroDecl)
             }
         }
         ctor.append("} ()")
@@ -233,6 +254,7 @@ struct godotMacrosPlugin: CompilerPlugin {
         NativeHandleDiscardingMacro.self,
         PickerNameProviderMacro.self,
         SceneTreeMacro.self,
-        Texture2DLiteralMacro.self
+        Texture2DLiteralMacro.self,
+        SignalMacro.self
     ]
 }

--- a/Sources/SwiftGodotMacroLibrary/SignalMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SignalMacro.swift
@@ -1,0 +1,112 @@
+//
+//  SignalMacro.swift
+//  SwiftGodot
+//
+//  Created by Padraig O Cinneide on 2023-10-19.
+
+import Foundation
+import SwiftCompilerPlugin
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct SignalMacro: DeclarationMacro {
+    
+    enum ProviderDiagnostic: Error, DiagnosticMessage {
+        case tooManyArguments
+        case argumentsInUnexpectedSyntax
+
+        var severity: DiagnosticSeverity { .error }
+
+        var message: String {
+            switch self {
+            case .argumentsInUnexpectedSyntax:
+                "Failed to parse arguments. Define arguments in the form [\"argumentName\": Type.self]"
+            case .tooManyArguments:
+                "Too many arguments in the arguments dictionary. A maximum of 6 are supported."
+            }
+        }
+
+        var diagnosticID: MessageID {
+            MessageID(domain: "SwiftGodotMacros", id: message)
+        }
+    }
+    
+    public static func expansion(
+        of node: some SwiftSyntax.FreestandingMacroExpansionSyntax,
+        in context: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [SwiftSyntax.DeclSyntax] {
+        
+        var signalName: SignalName? = nil
+        var arguments = [(name: String, type: String)]()
+        
+        for (index, argument) in node.argumentList.enumerated() {
+            if index == 0 {
+                signalName = argument.expression.signalName()
+            }
+            if index == 1 {
+                if argument.expression.description == ".init()" {
+                    // its an empty dictionary, so no arguments
+                    continue
+                }
+                
+                guard let dictSyntax = DictionaryExprSyntax(argument.expression) else {
+                    throw ProviderDiagnostic.argumentsInUnexpectedSyntax
+                }
+                
+                if case .colon = dictSyntax.content {
+                    // its an empty dictionary, so no arguments
+                    continue
+                }
+                
+                guard let pairList = DictionaryElementListSyntax(dictSyntax.content) else {
+                    throw ProviderDiagnostic.argumentsInUnexpectedSyntax
+                }
+                
+                for pair in pairList {
+                    guard let typeName = pair.value.typeName() else {
+                        throw ProviderDiagnostic.argumentsInUnexpectedSyntax
+                    }
+                    arguments.append((pair.key.description, typeName))
+                }
+            }
+        }
+        
+        guard let signalName else { return [] }
+        
+        let genericTypeList = arguments.map { $0.type }.joined(separator: ", ")
+        
+        let signalWrapperType = switch arguments.count {
+        case 0: "SignalWithNoArguments"
+        case 1: "SignalWith1Argument<\(genericTypeList)>"
+        case 2: "SignalWith2Arguments<\(genericTypeList)>"
+        case 3: "SignalWith3Arguments<\(genericTypeList)>"
+        case 4: "SignalWith4Arguments<\(genericTypeList)>"
+        case 5: "SignalWith5Arguments<\(genericTypeList)>"
+        case 6: "SignalWith6Arguments<\(genericTypeList)>"
+        default:
+            throw ProviderDiagnostic.tooManyArguments
+        }
+        
+        let argumentList = ["\"" + signalName.godotName + "\""] + arguments
+            .enumerated()
+            .map { index, argument in
+                "argument\(index + 1)Name: \(argument.name)"
+            }
+            
+        let argumentsString = argumentList.joined(separator: ", ")
+        
+        return [
+            DeclSyntax(
+                try VariableDeclSyntax(
+                "static let \(raw: signalName.swiftName) = \(raw: signalWrapperType)(\(raw: argumentsString))"
+                )
+            )
+        ]
+    }
+    
+}
+
+
+


### PR DESCRIPTION
Adds a new freestanding macro that can be used inside a `@Godot` class to register a signal with Godot. 

Signal arguments can be defined and their types will be enforced on new `emit(signal:_argument)` methods.

```swift
@Godot 
class Player: Node2D {
    #signal("game_started")
    #signal("lives_changed", argument: ["new_lives_count": Int.self])

    func startGame() {
       emit(Player.gameStarted)
       emit(Player.livesChanged, 5)
    }
}

class Level: Area2D {
    func _ready() { 
       player.connect(Player.gameStarted, to: self, method: "game_started")
    }
    @Callable func game_started() { 
       GD.print("got game started signal!")
    }
}
```

This all works nicely with the Godot editor too — signals are exposed there and can be connected to GDScripts and well use the argument names provided in the `#signal` invocation. 

---

This PR also fixes an issue where a @Callable functions would not work when called with a GodotObject argument.