### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,4 @@
 version: 1
-external_links:
-  documentation: "https://migueldeicaza.github.io/SwiftGodotDocs/documentation/swiftgodot/"
+builder:
+  configs:
+    - documentation_targets: [SwiftGodot, ExtensionApi]

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,6 @@
 version: 1
+external_links:
+  documentation: "https://migueldeicaza.github.io/SwiftGodotDocs/documentation/swiftgodot/"
 builder:
   configs:
     - documentation_targets: [SwiftGodot, ExtensionApi]


### PR DESCRIPTION
This updates the `.spi.yml` file to move to hosted documentation at swiftpackageindex.com. As I mentioned on Mastodon, the advantage is that we support versioned docs:

<img width="636" alt="Screenshot 2023-11-07 at 19 10 56" src="https://github.com/migueldeicaza/SwiftGodot/assets/65520/1604780e-9abf-4c9f-b8b3-d87c85d057b6">

But no worries if you'd rather keep the self-hosted docs and just close the PR if so!