### PR TITLE
Add convenience inits for modifying after init

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -246,6 +246,7 @@ func generateMethods (_ p: Printer,
     
     if virtuals.count > 0 {
         p ("override class func getVirtualDispatcher (name: StringName) -> GDExtensionClassCallVirtual?"){
+            p ("guard implementedOverrides().contains(name) else { return nil }")
             p ("switch name.description") {
                 for name in virtuals.keys.sorted() {
                     p ("case \"\(name)\":")

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -678,7 +678,7 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
                 p ("super.init (name: StringName (\"\(cdef.name)\"))")
             }
             p ("/// Modifying initializer. Passes itself to the closure after initialization")
-            p ("public convenience init (modifier: (Self) -> Void") {
+            p ("public convenience init (modifier: (\(cdef.name)) -> Void)") {
                 p ("self.init ()")
                 p ("modifier (self)")
             }

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -677,6 +677,11 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
             p ("public required init ()") {
                 p ("super.init (name: StringName (\"\(cdef.name)\"))")
             }
+            p ("/// Modifying initializer. Passes itself to the closure after initialization")
+            p ("public convenience init (modifier: (Self) -> Void") {
+                p ("self.init ()")
+                p ("modifier (self)")
+            }
         } else {
             p ("/// This class can not be instantiated by user code")
             p ("public required init ()") {

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -80,6 +80,27 @@ open class Wrapped: Equatable, Identifiable, Hashable {
         hasher.combine(handle)
     }
     
+    /// This method returns the list of StringNames for methods that the class overwrites, and
+    /// is necessary to ensure that Godot knows which methods have been overwritten, and which
+    /// ones Godot will provide a default behavior for.
+    ///
+    /// This is necessary because the Godot overwrite method does not surface a "base" behavior
+    /// that can be called into.  Instead Godot relies on the "Is the method implemented or not"
+    /// to make this determination.
+    ///
+    /// If you are not using the `@Godot` macro, you should overwrite this function and return
+    /// the StringNames for the functions you override, like in this example, where we indicate
+    /// that we override the Godot `_has_point` method:
+    ///
+    /// ```
+    /// open override func implementedOverrides() -> [StringName] {
+    ///     return super.implementedOverrides + [StringName ("_has_point")]
+    /// }
+    /// ```
+    open class func implementedOverrides() -> [StringName] {
+        []
+    }
+
     class func getVirtualDispatcher(name: StringName) ->  GDExtensionClassCallVirtual? {
         print ("SWARN: getVirtualDispatcher (\"\(name)\") reached Wrapped on class \(self)")
         return nil

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -15,7 +15,7 @@
 /// methods to godot
 ///
 @attached(member,
-          names: named (init(nativeHandle:)), named (init()), named(_initClass), named (implementedOverrides))
+          names: named (init(nativeHandle:)), named (init()), named(_initClass), named(init(modifier:)), named (implementedOverrides))
 public macro Godot() = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacro")
 
 /// Exposes the function to the Godot runtime

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -15,7 +15,7 @@
 /// methods to godot
 ///
 @attached(member,
-          names: named (init(nativeHandle:)), named (init()), named(_initClass))
+          names: named (init(nativeHandle:)), named (init()), named(_initClass), named (implementedOverrides))
 public macro Godot() = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacro")
 
 /// Exposes the function to the Godot runtime

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -251,7 +251,11 @@ public struct GodotMacro: MemberMacro {
             let initSyntax = try InitializerDeclSyntax("required init()") {
                 StmtSyntax("\n\t_ = \(classDecl.name)._initClass\n\tsuper.init ()")
             }
-            var decls = [DeclSyntax (initRawHandleSyntax), DeclSyntax (initSyntax), DeclSyntax(stringLiteral: classInit)]
+            let modInitSyntax = try InitializerDeclSyntax("convenience init(modifier: (Self) -> Void)") {
+                StmtSyntax("\n\tself.init()")
+                StmtSyntax("\n\tmodifier(self)")
+            }
+            var decls = [DeclSyntax (initRawHandleSyntax), DeclSyntax (initSyntax), DeclSyntax (modInitSyntax), DeclSyntax(stringLiteral: classInit)]
 
             // Now look for overrides of Godot functions
             let functions = classDecl.memberBlock.members


### PR DESCRIPTION
<img width="582" alt="Screenshot 2023-11-10 at 10 22 21 AM" src="https://github.com/migueldeicaza/SwiftGodot/assets/6394475/5217b609-f0e5-4a4a-9f1a-5fbd4ed15281">

Allows for configuration functions to be fed to a class on initialization.