### PR TITLE
Add fallback for builtin constants with missing plain constructors

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -12,7 +12,7 @@ import ExtensionApi
 ///
 func getInitializer (_ bc: JGodotBuiltinClass, _ val: String) -> String? {
     if let pstart = val.firstIndex(of: "("), let pend = val.lastIndex(of: ")"){
-        let splitArgs = val [val.index(pstart, offsetBy: 1)..<pend].split(separator: ",")
+        let splitArgs = val [val.index(pstart, offsetBy: 1)..<pend].split(separator: ", ")
         // Find a constructor with that number of arguments
         for constructor in bc.constructors {
             
@@ -33,6 +33,24 @@ func getInitializer (_ bc: JGodotBuiltinClass, _ val: String) -> String? {
                 }
                 return String (val [val.startIndex..<pstart]) + " (" + prefixedArgs + ")"
             }
+        }
+        
+        // Fallback for missing constructors
+        let format: String?
+        switch (bc.name, splitArgs.count) {
+        case ("Transform2D", 6):
+            format = "Transform2D (xAxis: Vector2 (x: %@, y: %@), yAxis: Vector2 (x: %@, y: %@), origin: Vector2 (x: %@, y: %@))"
+        case ("Basis", 9):
+            format = "Basis (xAxis: Vector3 (x: %@, y: %@, z: %@), yAxis: Vector3 (x: %@, y: %@, z: %@), zAxis: Vector3 (x: %@, y: %@, z: %@))"
+        case ("Transform3D", 12):
+            format = "Transform3D (basis: Basis (xAxis: Vector3 (x: %@, y: %@, z: %@), yAxis: Vector3 (x: %@, y: %@, z: %@), zAxis: Vector3 (x: %@, y: %@, z: %@)), origin: Vector3(x: %@, y: %@, z: %@))"
+        case ("Projection", 16):
+            format = "Projection (xAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), yAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), zAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), wAxis: Vector4 (x: %@, y: %@, z: %@, w: %@))"
+        default:
+            format = nil
+        }
+        if let format {
+            return String (format: format, arguments: splitArgs.map ({ $0.trimmingCharacters(in: CharacterSet.whitespaces) }))
         }
         return nil
     }
@@ -55,6 +73,7 @@ func generateBuiltinConstants (_ p: Printer,
     for constant in constants {
         // Check if we need to inject parameter names
         guard let val = getInitializer (bc, constant.value) else {
+            print ("Generator: no constructor matching constant \(bc.name).\(constant.name) = \(constant.value)")
             continue
         }
         

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -50,7 +50,7 @@ func getInitializer (_ bc: JGodotBuiltinClass, _ val: String) -> String? {
             format = nil
         }
         if let format {
-            return String (format: format, arguments: splitArgs.map ({ $0.trimmingCharacters(in: CharacterSet.whitespaces) }))
+            return String (format: format, arguments: splitArgs.map (String.init))
         }
         return nil
     }


### PR DESCRIPTION
Fixes #225. Though I don't think Extension API's way of describing constant values has anything to do with constructors. It looks more like a memory dump. Anyway, this workaround should patch the existing solution.