### PR TITLE
Fixes inheritance when using `@Godot` macro

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -676,6 +676,7 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
             p ("/// when you create a subclass of this type.")
             p ("public required init ()") {
                 p ("super.init (name: StringName (\"\(cdef.name)\"))")
+                p ("let _ = Self.classInitializer")
             }
         } else {
             p ("/// This class can not be instantiated by user code")
@@ -710,6 +711,10 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
         // Remove code that we did not want generated
         if okList.count > 0 && !okList.contains (cdef.name) {
             p.result = oResult
+        }
+        
+        if cdef.name == "Object" {
+            p ("open class var classInitializer: Void { () }")
         }
     }
 

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -15,7 +15,7 @@
 /// methods to godot
 ///
 @attached(member,
-          names: named (init(nativeHandle:)), named (init()), named(_initClass), named (implementedOverrides))
+          names: named (_initializeClass), named(classInitializer), named (implementedOverrides))
 public macro Godot() = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacro")
 
 /// Exposes the function to the Godot runtime

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -248,7 +248,7 @@ public struct GodotMacro: MemberMacro {
             
             let classInitProperty = DeclSyntax(
             """
-            override class var classInitializer: Void {
+            override open class var classInitializer: Void {
                 let _ = super.classInitializer
                 return _initializeClass
             }

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -183,7 +183,7 @@ class GodotMacroProcessor {
     func processType () throws -> String {
         ctor =
     """
-    static var _initClass: Void = {
+    private static var _initializeClass: Void = {
         let className = StringName("\(className)")
         let classInfo = ClassInfo<\(className)> (name: className)\n
     """
@@ -245,13 +245,17 @@ public struct GodotMacro: MemberMacro {
         let processor = GodotMacroProcessor(classDecl: classDecl)
         do {
             let classInit = try processor.processType ()
-            let initRawHandleSyntax = try InitializerDeclSyntax("required init(nativeHandle _: UnsafeRawPointer)") {
-                StmtSyntax("\n\tfatalError(\"init(nativeHandle:) called, it is a sign that something is wrong, as these objects should not be re-hydrated\")")
+            
+            let classInitProperty = DeclSyntax(
+            """
+            override class var classInitializer: Void {
+                let _ = super.classInitializer
+                return _initializeClass
             }
-            let initSyntax = try InitializerDeclSyntax("required init()") {
-                StmtSyntax("\n\t_ = \(classDecl.name)._initClass\n\tsuper.init ()")
-            }
-            var decls = [DeclSyntax (initRawHandleSyntax), DeclSyntax (initSyntax), DeclSyntax(stringLiteral: classInit)]
+            """
+            )
+            
+            var decls = [classInitProperty, DeclSyntax(stringLiteral: classInit)]
 
             // Now look for overrides of Godot functions
             let functions = classDecl.memberBlock.members

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -269,7 +269,7 @@ public struct GodotMacro: MemberMacro {
                     return stringName
                 }
                 
-                var implementedOverridesDecl = "override class func implementedOverrides() -> [StringName] {\nsuper.implementedOverrides() + [\n"
+                var implementedOverridesDecl = "override open class func implementedOverrides() -> [StringName] {\nsuper.implementedOverrides() + [\n"
                 for name in stringNames {
                     implementedOverridesDecl.append("\t\(name),\n")
                 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -45,6 +45,38 @@ final class MacroGodotTests: XCTestCase {
             macros: testMacros
         )
     }
+    
+    func testGodotVirtualMethodsMacro() {
+        assertMacroExpansion(
+            """
+            @Godot class Hi: Control {
+                override func _hasPoint(_ point: Vector2) -> Bool { false }
+            }
+            """,
+            expandedSource: """
+            class Hi: Control {
+                override func _hasPoint(_ point: Vector2) -> Bool { false }
+            
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
+            
+                private static var _initializeClass: Void = {
+                    let className = StringName("Hi")
+                    let classInfo = ClassInfo<Hi> (name: className)
+                } ()
+            
+                override open class func implementedOverrides() -> [StringName] {
+                    super.implementedOverrides() + [
+                    	StringName("_has_point"),
+                    ]
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
 	
 	func testGodotMacroWithNonCallableFunc() {
 		// Note when editing: Xcode loves to change all indentation to be consistent as either tabs or spaces, but the macro expansion produces a mix.

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -31,7 +31,7 @@ final class MacroGodotTests: XCTestCase {
             expandedSource: """
             class Hi: Node {
             
-                override class var classInitializer: Void {
+                override open class var classInitializer: Void {
                     let _ = super.classInitializer
                     return _initializeClass
                 }
@@ -61,7 +61,7 @@ final class MacroGodotTests: XCTestCase {
             	func hi() {
             	}
             
-                override class var classInitializer: Void {
+                override open class var classInitializer: Void {
                     let _ = super.classInitializer
                     return _initializeClass
                 }
@@ -94,7 +94,7 @@ final class MacroGodotTests: XCTestCase {
                 static let differentInit = SignalWithNoArguments("different_init")
                 static let differentInit2 = SignalWithNoArguments("different_init2")
 
-                override class var classInitializer: Void {
+                override open class var classInitializer: Void {
                     let _ = super.classInitializer
                     return _initializeClass
                 }
@@ -133,7 +133,7 @@ final class MacroGodotTests: XCTestCase {
             		return nil
             	}
             
-                override class var classInitializer: Void {
+                override open class var classInitializer: Void {
                     let _ = super.classInitializer
                     return _initializeClass
                 }
@@ -170,7 +170,7 @@ final class MacroGodotTests: XCTestCase {
             	    return Variant (goodName)
             	}
             
-                override class var classInitializer: Void {
+                override open class var classInitializer: Void {
                     let _ = super.classInitializer
                     return _initializeClass
                 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -30,17 +30,13 @@ final class MacroGodotTests: XCTestCase {
             """,
             expandedSource: """
             class Hi: Node {
-
-                required init(nativeHandle _: UnsafeRawPointer) {
-                	fatalError("init(nativeHandle:) called, it is a sign that something is wrong, as these objects should not be re-hydrated")
+            
+                override class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
                 }
-
-                required init() {
-                	_ = Hi._initClass
-                	super.init ()
-                }
-
-                static var _initClass: Void = {
+            
+                private static var _initializeClass: Void = {
                     let className = StringName("Hi")
                     let classInfo = ClassInfo<Hi> (name: className)
                 } ()
@@ -65,16 +61,12 @@ final class MacroGodotTests: XCTestCase {
             	func hi() {
             	}
             
-                required init(nativeHandle _: UnsafeRawPointer) {
-                	fatalError("init(nativeHandle:) called, it is a sign that something is wrong, as these objects should not be re-hydrated")
+                override class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
                 }
-
-                required init() {
-                	_ = Hi._initClass
-                	super.init ()
-                }
-
-                static var _initClass: Void = {
+            
+                private static var _initializeClass: Void = {
                     let className = StringName("Hi")
                     let classInfo = ClassInfo<Hi> (name: className)
                 } ()
@@ -102,16 +94,12 @@ final class MacroGodotTests: XCTestCase {
                 static let differentInit = SignalWithNoArguments("different_init")
                 static let differentInit2 = SignalWithNoArguments("different_init2")
 
-                required init(nativeHandle _: UnsafeRawPointer) {
-                	fatalError("init(nativeHandle:) called, it is a sign that something is wrong, as these objects should not be re-hydrated")
+                override class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
                 }
-
-                required init() {
-                	_ = Hi._initClass
-                	super.init ()
-                }
-
-                static var _initClass: Void = {
+            
+                private static var _initializeClass: Void = {
                     let className = StringName("Hi")
                     let classInfo = ClassInfo<Hi> (name: className)
                     classInfo.registerSignal(name: Hi.pickedUpItem.name, arguments: Hi.pickedUpItem.arguments)
@@ -145,16 +133,12 @@ final class MacroGodotTests: XCTestCase {
             		return nil
             	}
             
-                required init(nativeHandle _: UnsafeRawPointer) {
-                	fatalError("init(nativeHandle:) called, it is a sign that something is wrong, as these objects should not be re-hydrated")
+                override class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
                 }
-
-                required init() {
-                	_ = Castro._initClass
-                	super.init ()
-                }
-
-                static var _initClass: Void = {
+            
+                private static var _initializeClass: Void = {
                     let className = StringName("Castro")
                     let classInfo = ClassInfo<Castro> (name: className)
                 	classInfo.registerMethod(name: StringName("deleteEpisode"), flags: .default, returnValue: nil, arguments: [], function: Castro._mproxy_deleteEpisode)
@@ -186,16 +170,12 @@ final class MacroGodotTests: XCTestCase {
             	    return Variant (goodName)
             	}
             
-                required init(nativeHandle _: UnsafeRawPointer) {
-                	fatalError("init(nativeHandle:) called, it is a sign that something is wrong, as these objects should not be re-hydrated")
+                override class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
                 }
             
-                required init() {
-                	_ = Hi._initClass
-                	super.init ()
-                }
-            
-                static var _initClass: Void = {
+                private static var _initializeClass: Void = {
                     let className = StringName("Hi")
                     let classInfo = ClassInfo<Hi> (name: className)
                     let _pgoodName = PropInfo (


### PR DESCRIPTION
Fixes https://github.com/migueldeicaza/SwiftGodot/issues/168

This changes the macro to stop generating `init` methods which were making inheritance a challenge. 

Instead the root class calls an overridable class var with a getter that calls a static method that does the one-time initialization. 

This might look a bit round-about at first glance but works around two limitations in Swift: 
1. Class Initializers are not a supported language thing, so we're approximating them here.
2. class properties can only be calculated properties, not blocks as we would like, so we use a computed class property to call the `static` property that actually does the work. This allows us to support inheritance and ensures that the class initializer is called only once per class.


