### PR TITLE
Allow `@Callable` functions to be overriden in derived classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ You would create something like this in a file called
 ```yml
 [configuration]
 entry_symbol = "swift_entry_point"
+compatibility_minimum = 4.1
 
 [libraries]
 macos.debug = "res://bin/MyFirstGame"

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -26,7 +26,7 @@ public struct GodotCallable: PeerMacro {
     static func process (funcDecl: FunctionDeclSyntax) throws -> String {
         let funcName = funcDecl.name.text
 
-        var genMethod = "\(funcDecl.isOverriding ? "override" : "") func _mproxy_\(funcName) (args: [Variant]) -> Variant? {\n"
+        var genMethod = "\(funcDecl.isOverriding ? "override " : "")func _mproxy_\(funcName) (args: [Variant]) -> Variant? {\n"
         var retProp: String? = nil
         var retOptional: Bool = false
         

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -12,10 +12,21 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
+private extension FunctionDeclSyntax {
+    var isOverriding: Bool {
+        modifiers
+            .as(DeclModifierListSyntax.self)?
+            .tokens(viewMode: .sourceAccurate)
+            .filter({ $0.text == "override" })
+            .count == 1
+    }
+}
+
 public struct GodotCallable: PeerMacro {
     static func process (funcDecl: FunctionDeclSyntax) throws -> String {
         let funcName = funcDecl.name.text
-        var genMethod = "func _mproxy_\(funcName) (args: [Variant]) -> Variant? {\n"
+
+        var genMethod = "\(funcDecl.isOverriding ? "override" : "") func _mproxy_\(funcName) (args: [Variant]) -> Variant? {\n"
         var retProp: String? = nil
         var retOptional: Bool = false
         

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -223,7 +223,47 @@ final class MacroGodotTests: XCTestCase {
                 } ()
             }
             """,
-			macros: testMacros
-		)
-	}
+            macros: testMacros
+        )
+    }
+    
+    func testCallableGodotMacro() {
+        assertMacroExpansion(
+			"""
+			@Callable
+			func someCallable() -> Void {
+			}
+			""",
+			expandedSource:
+            """
+            func someCallable() -> Void {
+            }
+            
+            func _mproxy_someCallable (args: [Variant]) -> Variant? {
+            	let result = someCallable ()
+            	return Variant (result)
+            }
+            """,
+            macros: testMacros
+        )
+    }
+    
+    func testOverridenCallableGodotMacro() {
+        assertMacroExpansion(
+			"""
+			@Callable
+			override func someCallable() -> Void {}
+			""",
+			expandedSource:
+            """
+            override func someCallable() -> Void {}
+            
+            override func _mproxy_someCallable (args: [Variant]) -> Variant? {
+            	let result = someCallable ()
+            	return Variant (result)
+            }
+            """,
+            macros: testMacros
+        )
+    }
 }


### PR DESCRIPTION
#234 is merged, but I had recently ran into the same problem, and while working on a fix for it I noticed that you couldn't override a `@Callable` func.