### PR TITLE
Tidy up initializers

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -54,11 +54,7 @@ func makeDefaultInit (godotType: String, initCollection: String = "") -> String 
     case "void*", "const Glyph*":
         return "nil"
     default:
-        if isCoreType(name: godotType) {
-            return "\(getGodotType(SimpleType (type: godotType))) ()"
-        } else {
-            return "\(getGodotType(SimpleType (type: godotType))) (fast: true)"
-        }
+        return "\(getGodotType(SimpleType (type: godotType))) ()"
     }
 }
 
@@ -651,39 +647,12 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
         if isSingleton {
             p ("/// The shared instance of this class")
             p ("public static var shared: \(cdef.name) =", suffix: "()") {
-                p ("withUnsafePointer (to: &\(cdef.name).className.content)", arg: " ptr in") {
+                p ("withUnsafePointer (to: &\(cdef.name).godotClassName.content)", arg: " ptr in") {
                     p ("\(cdef.name) (nativeHandle: gi.global_get_singleton (ptr)!)")
                 }
             }
         }
-        p ("static private var className = StringName (\"\(cdef.name)\")")
-        p ("/// Creates a \(cdef.name) that wraps the Godot native object pointed to by the nativeHandle")
-        p ("public required init (nativeHandle: UnsafeRawPointer)") {
-            p("super.init (nativeHandle: nativeHandle)")
-        }
-        p ("/// Ths initializer is invoked by derived classes as they chain through their most derived type name that our framework produced")
-        p ("internal override init (name: StringName)") {
-            p("super.init (name: name)")
-        }
-        
-        let fastInitOverrides = cdef.inherits != nil ? "override " : ""
-        
-        p ("internal \(fastInitOverrides)init (fast: Bool)") {
-            p ("super.init (name: \(cdef.name).className)")
-        }
-        if cdef.isInstantiable {
-            p ("/// Initializes a new instance of the type \(cdef.name), call this constructor")
-            p ("/// when you create a subclass of this type.")
-            p ("public required init ()") {
-                p ("super.init (name: StringName (\"\(cdef.name)\"))")
-                p ("let _ = Self.classInitializer")
-            }
-        } else {
-            p ("/// This class can not be instantiated by user code")
-            p ("public required init ()") {
-                p ("fatalError (\"You cannot subclass or instantiate \(cdef.name) directly\")")
-            }
-        }
+        p ("override open class var godotClassName: StringName { \"\(cdef.name)\" }")
         
         var referencedMethods = Set<String>()
         
@@ -711,10 +680,6 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
         // Remove code that we did not want generated
         if okList.count > 0 && !okList.contains (cdef.name) {
             p.result = oResult
-        }
-        
-        if cdef.name == "Object" {
-            p ("open class var classInitializer: Void { () }")
         }
     }
 

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -98,7 +98,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
             p ("\(staticVarVisibility)static var \(bindName): GDExtensionMethodBindPtr =", suffix: "()") {
                 p ("let methodName = StringName (\"\(method.name)\")")
             
-                p ("return withUnsafePointer (to: &\(className).className.content)", arg: " classPtr in") {
+                p ("return withUnsafePointer (to: &\(className).godotClassName.content)", arg: " classPtr in") {
                     p ("withUnsafePointer (to: &methodName.content)", arg: " mnamePtr in") {
                         p ("gi.classdb_get_method_bind (classPtr, mnamePtr, \(methodHash))!")
                     }

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -8,9 +8,7 @@
 @_implementationOnly import GDExtension
 
 /// Protocol implemented by the built-in classes in Godot to allow to be wrapped in a ``Variant``
-public protocol GodotObject {
-    init (nativeHandle: UnsafeRawPointer)
-}
+public protocol GodotObject: Wrapped {}
 
 /// This represents a typed array of one of the built-in types from Godot
 public class ObjectCollection<Element: Object>: Collection {

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -115,14 +115,6 @@ open class Wrapped: Equatable, Identifiable, Hashable {
         free_callback: frameworkTypeBindingFree,
         reference_callback: frameworkTypeBindingReference)
     
-    /// For use by the framework, you should not need to call this.
-    public required init (nativeHandle: UnsafeRawPointer) {
-        handle = nativeHandle
-    }
-    
-    public required init () {
-        fatalError("This constructor should not be called")
-    }
 
     /// Returns the Godot's class name as a `StringName`, returns the empty string on error
     public var godotClassName: StringName {
@@ -135,51 +127,65 @@ open class Wrapped: Equatable, Identifiable, Hashable {
         return ""
     }
     
+    /// For use by the framework, you should not need to call this.
+    public required init (nativeHandle: UnsafeRawPointer) {
+        handle = nativeHandle
+    }
+    
     /// The constructor chain that uses StringName is internal, and is triggered
     /// when a class is initialized with the empty constructor - this means that
-    /// subclasses will have a diffrent name than the subclass.
-    ///
-    /// When subclassing, you should use the name of te l
-    internal init (name: StringName) {
-        let v = gi.classdb_construct_object (&name.content)
-        
-        if let r = UnsafeRawPointer (v) {
-            handle = r
-            let retain = Unmanaged.passRetained(self)
-            
-            // TODO: what happens if the user subclasses but the name conflicts with the Godot type?
-            // say "class Sprite2D: Godot.Sprite2D"
-            let thisTypeName = StringName (stringLiteral: String (describing: Swift.type(of: self)))
-            let frameworkType = thisTypeName == name
-            
-            //print ("SWIFT: Wrapped(StringName) at \(handle) with retain=\(retain.toOpaque()), this is a class of type: \(Swift.type(of: self)) and it is: \(frameworkType ? "Builtin" : "User defined")")
-            
-            // This I believe should only be set for user subclasses, and not anything else.
-            if frameworkType {
-                //print ("SWIFT: Skipping object registration, this is a framework type")
-            } else {
-                //print ("SWIFT: Registering instance with Godot")
-                withUnsafeMutablePointer(to: &thisTypeName.content) { ptr in
-                    gi.object_set_instance (UnsafeMutableRawPointer (mutating: handle),
-                                            ptr, retain.toOpaque())
-                }
-            }
-            
-            var callbacks: GDExtensionInstanceBindingCallbacks
-            if frameworkType {
-                callbacks = Wrapped.frameworkTypeBindingCallback
-                liveFrameworkObjects [r] = self
-            } else {
-                callbacks = Wrapped.userTypeBindingCallback
-                liveSubtypedObjects [r] = self
-            }
-            gi.object_set_instance_binding(UnsafeMutableRawPointer (mutating: handle), token, retain.toOpaque(), &callbacks);
-        } else {
-            fatalError("SWIFT: It was not possible to construct a \(name.description)")
+    /// subclasses will have a different name than the subclass.
+    public required init () {
+        guard let godotObject = gi.classdb_construct_object (&Self.godotClassName.content) else {
+            fatalError("SWIFT: It was not possible to construct a \(Self.godotClassName.description)")
         }
+        
+        handle = UnsafeRawPointer(godotObject)
+        bindGodotInstance(instance: self)
+        let _ = Self.classInitializer
     }
+    
+    open class var godotClassName: StringName {
+        fatalError("Subclasses of Wrapped must override godotClassName")
+    }
+    
+    open class var classInitializer: Void { () }
 }
     
+func bindGodotInstance(instance: some Wrapped) {
+    let handle = instance.handle
+    let name = instance.self.godotClassName
+    let retain = Unmanaged.passRetained(instance)
+    
+    // TODO: what happens if the user subclasses but the name conflicts with the Godot type?
+    // say "class Sprite2D: Godot.Sprite2D"
+    let thisTypeName = StringName (stringLiteral: String (describing: Swift.type(of: instance)))
+    let frameworkType = thisTypeName == name
+    
+    //print ("SWIFT: Wrapped(StringName) at \(handle) with retain=\(retain.toOpaque()), this is a class of type: \(Swift.type(of: self)) and it is: \(frameworkType ? "Builtin" : "User defined")")
+    
+    // This I believe should only be set for user subclasses, and not anything else.
+    if frameworkType {
+        //print ("SWIFT: Skipping object registration, this is a framework type")
+    } else {
+        //print ("SWIFT: Registering instance with Godot")
+        withUnsafeMutablePointer(to: &thisTypeName.content) { ptr in
+            gi.object_set_instance (UnsafeMutableRawPointer (mutating: handle),
+                                    ptr, retain.toOpaque())
+        }
+    }
+    
+    var callbacks: GDExtensionInstanceBindingCallbacks
+    if frameworkType {
+        callbacks = Wrapped.frameworkTypeBindingCallback
+        liveFrameworkObjects [handle] = instance
+    } else {
+        callbacks = Wrapped.userTypeBindingCallback
+        liveSubtypedObjects [handle] = instance
+    }
+    
+    gi.object_set_instance_binding(UnsafeMutableRawPointer (mutating: handle), token, retain.toOpaque(), &callbacks)
+}
 
 func register<T:Wrapped> (type name: StringName, parent: StringName, type: T.Type) {
     func getVirtual(_ userData: UnsafeMutableRawPointer?, _ name: GDExtensionConstStringNamePtr?) ->  GDExtensionClassCallVirtual? {


### PR DESCRIPTION
Works around the Swift bug identified in https://github.com/migueldeicaza/SwiftGodot/issues/238 by making the initializers on `Wrapped` public.

I also did some tidying while I was in the area:
* The `init(fast: Bool)` initializer wasn't doing anything, so I removed it. 
* There was no need to generate boilerplate initializers on subclasses, so I removed them all.
* `init (name: StringName)` is reworked a bit; now there's just `init` and it checks a class property for the name. This allows us to make `init()` public and required and remove the `internal` init, which is the thing that triggers the Swift bug in the issue above.  I think this is also a bit cleaner too, since for a given concrete class, there should only be one possible value for the `name` parameter.

The changes in generated code are here: https://gist.github.com/PadraigK/fed5dbc6161017c1df352992e8642503