### PR TITLE
Change documentation link to SPI

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,6 +1,4 @@
 version: 1
-external_links:
-  documentation: "https://migueldeicaza.github.io/SwiftGodotDocs/documentation/swiftgodot/"
 builder:
   configs:
     - documentation_targets: [SwiftGodot, ExtensionApi]


### PR DESCRIPTION
The docs have now been generated for SwiftGodot and can be switched over if you like: https://swiftpackageindex.com/builds/5A228EAD-CFE2-4EB1-AE24-B5F26D0A7FD2

This is just for `main` at the moment until there are future releases with the updated `.spi.yml` file, of course.