### PR TITLE
iOS 15 support

### DIFF
--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -114,8 +114,14 @@ extension String {
         let pattern = #"\b[a-zA-Z_][a-zA-Z0-9_]*\b"#
 
         do {
-            let regex = try Regex(pattern)
-            return wholeMatch(of: regex) != nil
+            let regex = try NSRegularExpression(pattern: pattern)
+            let range = NSRange(self.startIndex..<self.endIndex, in: self)
+            
+            if let match = regex.firstMatch(in: self, range: range) {
+                return match.range == range
+            } else {
+                return false
+            }
         } catch {
             fatalError("Invalid regex pattern: \(error)")
         }

--- a/Package.swift
+++ b/Package.swift
@@ -165,7 +165,7 @@ let package = Package(
     name: "SwiftGodot",
     platforms: [
         .macOS(.v13),
-        .iOS ("16.0")
+        .iOS (.v15)
     ],
     products: products,
     dependencies: [


### PR DESCRIPTION
This PR adds support for iOS 15 by using `NSRegularExpression` instead of the new `Regex` that was introduced for iOS 16.

We had to make these changes on our end to support older versions and figured it would be helpful to share.