### PR TITLE
Fix support for final classes when using the Godot macro

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -244,11 +244,17 @@ public struct GodotMacro: MemberMacro {
         
         let processor = GodotMacroProcessor(classDecl: classDecl)
         do {
-            let classInit = try processor.processType ()
-            
+            let classInit = try processor.processType()
+
+            let isFinal = classDecl.modifiers
+                .map(\.name.tokenKind)
+                .contains(.keyword(.final))
+
+            let accessControlLevel = isFinal ? "public" : "open"
+
             let classInitProperty = DeclSyntax(
             """
-            override open class var classInitializer: Void {
+            override \(raw: accessControlLevel) class var classInitializer: Void {
                 let _ = super.classInitializer
                 return _initializeClass
             }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -45,7 +45,31 @@ final class MacroGodotTests: XCTestCase {
             macros: testMacros
         )
     }
-    
+
+    func testGodotMacroWithFinalClass() {
+        assertMacroExpansion(
+            """
+            @Godot final class Hi: Node {
+            }
+            """,
+            expandedSource: """
+            final class Hi: Node {
+
+                override public class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
+
+                private static var _initializeClass: Void = {
+                    let className = StringName("Hi")
+                    let classInfo = ClassInfo<Hi> (name: className)
+                } ()
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
     func testGodotVirtualMethodsMacro() {
         assertMacroExpansion(
             """


### PR DESCRIPTION
Fixes: #244 

Use appropriate access control on `classInitializer` for final classes
Uses `public` for `final class` and `open` otherwise