### PR TITLE
Further fix to support for final classes when using the Godot macro

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -275,7 +275,7 @@ public struct GodotMacro: MemberMacro {
                     return stringName
                 }
                 
-                var implementedOverridesDecl = "override open class func implementedOverrides() -> [StringName] {\nsuper.implementedOverrides() + [\n"
+                var implementedOverridesDecl = "override \(accessControlLevel) class func implementedOverrides() -> [StringName] {\nsuper.implementedOverrides() + [\n"
                 for name in stringNames {
                     implementedOverridesDecl.append("\t\(name),\n")
                 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -50,10 +50,12 @@ final class MacroGodotTests: XCTestCase {
         assertMacroExpansion(
             """
             @Godot final class Hi: Node {
+                override func _hasPoint(_ point: Vector2) -> Bool { false }
             }
             """,
             expandedSource: """
             final class Hi: Node {
+                override func _hasPoint(_ point: Vector2) -> Bool { false }
 
                 override public class var classInitializer: Void {
                     let _ = super.classInitializer
@@ -64,6 +66,12 @@ final class MacroGodotTests: XCTestCase {
                     let className = StringName("Hi")
                     let classInfo = ClassInfo<Hi> (name: className)
                 } ()
+
+                override public class func implementedOverrides() -> [StringName] {
+                    super.implementedOverrides() + [
+                    	StringName("_has_point"),
+                    ]
+                }
             }
             """,
             macros: testMacros


### PR DESCRIPTION
PR #245 fixed `final class` when there were no method overrides

This PR ensures that `implementedOverrides` also uses the correct access modifier

Without this fix final classes with overrides produce errors in the form of:
<img width="1207" alt="Screenshot 2023-11-21 at 7 59 03 am" src="https://github.com/migueldeicaza/SwiftGodot/assets/5327203/87f1e3d6-132f-4565-8506-76efee39fc21">
