### PR TITLE
add param `_ type: T.Type = T.self` to `Variant.asObject` method

### DIFF
--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -152,9 +152,10 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
     
     ///
     /// Attempts to cast the Variant into a GodotObject, this requires that the Variant value be of type `.object`.
+    /// - Parameter type: the desired type eg. `.asObject(Node.self)`
     /// - Returns: nil on error, or the type on success
     ///
-    public func asObject<T:GodotObject> () -> T? {
+    public func asObject<T:GodotObject> (_ type: T.Type = T.self) -> T? {
         guard gtype == .object else {
             return nil
         }


### PR DESCRIPTION
Just a small quality of life improvement. it's a bit swifty too.

Allows for example:
```swift
let someNode = variant.asObject(SomeNode.self)
let someNodes = garray.compactMap { $0.asObject(SomeNode.self) }
```