### PR TITLE
adds `GD.printDebug`, which outputs the .swift file name, as well as the function and line of the caller.

### DIFF
--- a/Sources/SwiftGodot/Extensions/GD+Utils.swift
+++ b/Sources/SwiftGodot/Extensions/GD+Utils.swift
@@ -69,6 +69,18 @@ extension GD {
         GD.print(arg1: Variant(GString(stringLiteral: finalMessage)))
     }
 
+    /// Converts one or more arguments of any type to string in the best way possible and prints them to the console, with fileID, line, and function name of the calling function.
+    /// - Parameter items: The items to print into the Godot console.
+    /// - Parameter separator: The separator to insert between items. The default is a single space (" ").
+    /// - Parameter fileID: the module/file of the caller
+    /// - Parameter function: the calling function
+    /// - Parameter line: the calling line
+    public static func printDebug(_ items: Any..., separator: String = " ", fileID: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) {
+        let transformedItems = items.map(String.init(describing:))
+        let finalMessage = transformedItems.joined(separator: separator) + "\n   At: \(fileID):\(line):\(function)"
+        GD.print(arg1: Variant(GString(stringLiteral: finalMessage)))
+    }
+
     /// Converts one or more arguments of any type to string in the best way possible and prints them to the console.
     /// - Parameter items: The items to print into the Godot console.
     /// - Parameter separator: The separator to insert between items. The default is a single space (" ").

--- a/Sources/SwiftGodot/Extensions/GD+Utils.swift
+++ b/Sources/SwiftGodot/Extensions/GD+Utils.swift
@@ -76,6 +76,7 @@ extension GD {
     /// - Parameter function: the calling function
     /// - Parameter line: the calling line
     public static func printDebug(_ items: Any..., separator: String = " ", fileID: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) {
+        guard OS.isDebugBuild() else { return }
         let transformedItems = items.map(String.init(describing:))
         let finalMessage = transformedItems.joined(separator: separator) + "\n   At: \(fileID):\(line):\(function)"
         GD.print(arg1: Variant(GString(stringLiteral: finalMessage)))

--- a/Sources/SwiftGodot/Extensions/GD+Utils.swift
+++ b/Sources/SwiftGodot/Extensions/GD+Utils.swift
@@ -78,7 +78,7 @@ extension GD {
     public static func printDebug(_ items: Any..., separator: String = " ", fileID: StaticString = #fileID, function: StaticString = #function, line: UInt = #line) {
         guard OS.isDebugBuild() else { return }
         let transformedItems = items.map(String.init(describing:))
-        let finalMessage = transformedItems.joined(separator: separator) + "\n   At: \(fileID):\(line):\(function)"
+        let finalMessage = transformedItems.joined(separator: separator) + "\n   At: \(fileID):\(line) in \(function)"
         GD.print(arg1: Variant(GString(stringLiteral: finalMessage)))
     }
 


### PR DESCRIPTION
This duplicates the `print_debug` command in Godot, which prints a message, but inserts a new line with debug info, such as the file, line, and function

Here is the example gdscript output
```
Hello World
   At: res://folder/node.gd:50:_ready()
```

- new line below the print message
- indented 3 spaces (we could add a param for this indentation width)
- includes the folder/file name, relative to the res folder (we will use `#fileID` for this)
- includes line number (use `#line`) for this
- includes function name (use `#function` for this)

Here is the usage:
```swift
import SwiftGodot

@Godot
class ArrayTest: Node {
	override func _ready() {
		GD.printDebug("Hello World")
	}
}
```

Here is the output in the godot console:
```
Hello World
   At: BulletHellper/ArrayTest.swift:6 in _ready()
```