### PR TITLE
use _ = to suppress warning that shows up in macro expansion on some IDEs

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -48,7 +48,7 @@ public struct GodotExport: PeerMacro {
     		(res as? RefCounted)?.reference()
     		\(varName) = res
     	}\(optBody)
-    	oldRef?.unreference()
+    	_ = oldRef?.unreference()
     """
         } else {
             if isOptional {


### PR DESCRIPTION
<img width="521" alt="image" src="https://github.com/EstevanBR/SwiftGodot/assets/5488655/0dcd2c9d-e697-4fd7-b27d-af4bb8141746">
