### PR TITLE
Add ExpressibleByStringInterpolation conformance

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -480,6 +480,7 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
 
         if bc.name == "String" || bc.name == "StringName" || bc.name == "NodePath" {
             conformances.append ("ExpressibleByStringLiteral")
+            conformances.append ("ExpressibleByStringInterpolation")
         }
         if bc.name.starts(with: "Packed") {
             conformances.append ("Collection")


### PR DESCRIPTION
to StringName, NodePath and GString

Meaning that in addition to creating these from a string literal:
```
let str : StringName = "value"
let node = Node3D("NodeName")
```

You can now also create them from string literals with interpolations:
```
let value = 1
let str : StringName = "value: \(value)"
let node = Node3D("NodeName \(value)")
```