### PR TITLE
Assert that a class has been registered before use

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -185,6 +185,7 @@ class GodotMacroProcessor {
     """
     private static var _initializeClass: Void = {
         let className = StringName("\(className)")
+        assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<\(className)> (name: className)\n
     """
         for member in classDecl.memberBlock.members.enumerated() {


### PR DESCRIPTION
This catches the problem of forgetting to call register(type:) on a class marked with the @Godot macro.