### PR TITLE
Fix BindNode crash issue

### DIFF
--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -9,14 +9,16 @@
 /// current container that matches the name of the property.
 ///
 /// For example:
-/// ```
-/// class MyElements: CanvasLayer {
-///     @BindNode var GameOverLabel: Label
-/// }
-/// ```
 ///
-/// The above is equivalent to calling getNode (path: NodeName ("GameOverLabel")) as! Label
+///     class MyElements: CanvasLayer {
+///         @BindNode var GameOverLabel: Label
+///     }
 ///
+///
+/// The above is equivalent to calling
+///
+///     getNode(path: NodeName("GameOverLabel")) as! Label
+
 @propertyWrapper
 public struct BindNode<Value: Node> {
     public static subscript<T: Node>(

--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -27,13 +27,13 @@ public struct BindNode<Value: Node> {
         get {
             if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *){
                 let name: String
-                let fullName = storageKeyPath.debugDescription
+                let fullName = wrappedKeyPath.debugDescription
                 if let namePos = fullName.lastIndex(of: ".") {
                     name = String (fullName [fullName.index(namePos, offsetBy: 1)...])
                 } else {
                     name = fullName
                 }
-                let nodePath = NodePath (from: name)
+                let nodePath = NodePath(from: name)
                 
                 return instance.getNode(path: nodePath) as! Value
             } else {

--- a/Sources/SwiftGodot/SwiftGodot.docc/Info.plist
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>SwiftGodot</string>
+	<key>CFBundleDisplayName</key>
+	<string>SwiftGodot</string>
+	<key>CDDefaultCodeListingLanguage</key>
+	<string>swift</string>
+</dict>
+</plist>


### PR DESCRIPTION
Close #289

<img width="1057" alt="image" src="https://github.com/migueldeicaza/SwiftGodot/assets/43724855/ad8104c4-f876-447e-9260-681ce84a0d91">

Use `wrappedKeyPath` instead of `storageKeyPath` as name

## Future Plan

Refactor `BindNode` as a macro

1. `_enclosingInstance` is not officially supported.

See https://forums.swift.org/t/question-about-enclosinginstance-function-in-property-wrappers/59206

2. Add support for custom name mapping from Godot name to Swift name