### PR TITLE
Simplify method calls generation

### DIFF
--- a/Sources/SwiftGodot/EntryPoint.swift
+++ b/Sources/SwiftGodot/EntryPoint.swift
@@ -282,3 +282,7 @@ public func initializeSwiftModule (
  
  (aka '@convention(c) (GDExtensionVariantType, Int32) -> Optional<@convention(c) (Optional<UnsafeMutableRawPointer>, Optional<UnsafePointer<Optional<UnsafeRawPointer>>>) -> ()>')
  */
+
+func withArgPointers(_ _args: UnsafeMutableRawPointer?..., body: ([UnsafeRawPointer?]) -> Void) {
+    body(unsafeBitCast(_args, to: [UnsafeRawPointer?].self))
+}


### PR DESCRIPTION
Perhaps it would make sense to use a single implementation of `withArgPointers` instead of generating specific ones for each method? It can also be reused to rewrite calls of built-in structs in a similar manner.