### PR TITLE
Fix exported resource references

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -50,7 +50,7 @@ public struct GodotExport: PeerMacro {
         func dynamicCast<T, U>(_ value: T, as type: U.Type) -> U? { value as? U }
         let oldRef = dynamicCast (\(varName), as: RefCounted.self)
         if let res: \(typeName) = args [0].asObject () {
-            dynamicCast (\(varName), as: RefCounted.self)?.reference()
+            dynamicCast (res, as: RefCounted.self)?.reference()
             \(varName) = res
         }\(optBody)
         oldRef?.unreference()

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -301,7 +301,7 @@ final class MacroGodotTests: XCTestCase {
                     }
                     let oldRef = dynamicCast (data, as: RefCounted.self)
                     if let res: MyData = args [0].asObject () {
-                        dynamicCast (data, as: RefCounted.self)?.reference()
+                        dynamicCast (res, as: RefCounted.self)?.reference()
                         data = res
                     }
                     oldRef?.unreference()


### PR DESCRIPTION
Fixes #207 again :p

the value in `\(varName)` is always coming in as nil, and so `reference()` is never being called. I think this was supposed to be adding a reference to `res` anyways. 

looks like incorrect use of `\(varName)` was introduced here: https://github.com/migueldeicaza/SwiftGodot/commit/3f3bf924a533039454af43d3d25b284e0c096858

