### PR TITLE
Create Native Godot functions

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -347,7 +347,11 @@ func generateBuiltinMethods (_ p: Printer,
             // TODO: Avoid clash for now
             continue
         }
-
+        
+        if omittedMethodsList[typeName]?.contains(m.name) == true {
+            continue
+        }
+        
         let ret = getGodotType(SimpleType (type: m.returnType ?? ""), kind: .builtIn)
         
         // TODO: problem caused by gobject_object being defined as "void", so it is not possible to create storage to that.

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -202,7 +202,7 @@ func generateVirtualProxy (_ p: Printer,
 }
 
 // Dictioanry of Godot Type Name to array of method names that can get a @discardableResult
-var discardableResultList: [String: Set<String>] = [
+let discardableResultList: [String: Set<String>] = [
     "Object": ["emit_signal"],
     "GArray": ["append"],
     "PackedByteArray": ["append"],
@@ -219,9 +219,24 @@ var discardableResultList: [String: Set<String>] = [
     "RefCounted": ["reference", "unreference"]
 ]
 
-func generateMethod (_ p: Printer, method: MethodDefinition) {
-    
-}
+// Dictionary used to tell the generator to _not_ generate specific functionality since
+// Source/Native has a better alternative that avoids having to access Godot pointers.
+let omittedMethodsList: [String: Set<String>] = [
+    "Color": ["lerp"],
+    "Vector2": ["lerp", "snapped"],
+    "Vector2i": ["snapped"],
+    "Vector3": ["lerp", "snapped"],
+    "Vector3i": ["snapped"],
+    "Vector4": ["lerp", "snapped"],
+    "Vector4i": ["snapped"],
+    "utility_functions": [
+        "absf", "absi", "absi", "acos", "acosh", "asbs", "asin", "asinh", "atan", "atan2", "atanh", "ceil", "ceilf",
+        "ceili", "cos", "cosh", "deg_to_rad", "exp", "floor", "floor", "floorf", "floorf", "floori", "floori",
+        "fmod", "fposmod", "inverse_lerp", "lerp", "lerpf", "log", "posmod", "pow", "rad_to_deg", "round", "roundf",
+        "roundi", "sin", "snapped", "snappedf", "sqrt", "tan", "tanh",
+    ],
+]
+
 ///
 /// Returns a hashtable mapping a godot method name to a Swift Name + its definition
 /// this list is used to generate later the proxies outside the class
@@ -235,7 +250,7 @@ func generateMethods (_ p: Printer,
     
     var virtuals: [String:(String, JGodotClassMethod)] = [:]
    
-    for method in methods {
+    for method in methods {        
         if let virtualMethodName = methodGen (p, method: method, className: cdef.name, cdef: cdef, usedMethods: usedMethods, kind: .class, asSingleton: asSingleton) {
             virtuals [method.name] = (virtualMethodName, method)
         }

--- a/Generator/Generator/UtilityGen.swift
+++ b/Generator/Generator/UtilityGen.swift
@@ -22,9 +22,11 @@ func generateUtility(values: [JGodotUtilityFunction], outputDir: String?) async 
     p ("public class GD") {
         for method in values {
             // We ignore the request for virtual methods, should not happen for these
+            if omittedMethodsList["utility_functions"]?.contains(method.name) == true {
+                continue
+            }
             
             _ = methodGen (p, method: method, className: "Godot", cdef: nil, usedMethods: emptyUsedMethods, kind: .utility, asSingleton: false)
-            
         }
     }
 }

--- a/Sources/SwiftGodot/Native/LinearInterpolation.swift
+++ b/Sources/SwiftGodot/Native/LinearInterpolation.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+public protocol LinearInterpolation {
+    /// Linearly interpolate from self to the given value considering the weight.
+    /// '0' would return 'self'
+    /// '1' would return the 'to' value
+    ///
+    /// - parameter to:     The initial value.
+    /// - parameter weight: The value the interpolate the value by.
+    ///
+    /// - returns: The interpolated value.
+    func lerp(to: Self, weight: any BinaryFloatingPoint) -> Self
+}
+
+public protocol InverseLinearInterpolation {
+    /// Inverse linear interpolation. 'self' is the result of a lerp from - to of an unknown weight
+    /// Calling this function calculates the weight value that was used.
+    ///
+    /// - parameter from: The first value in the lerp function.
+    /// - parameter to:   The second value of the lerp function.
+    ///
+    /// - returns: The weight that corresponds to the inverse linear interpolation.
+    func inverseLerp(from: Self, to: Self) -> any BinaryFloatingPoint
+}
+
+public protocol Multiplicative {
+    /// Multiply the value by a floating point value.
+    ///
+    /// - parameter lhs: The value to be multiplied.
+    /// - parameter rhs: The value to multiply by.
+    ///
+    /// - returns: The multiplied value.
+    static func * (lhs: Self, rhs: any BinaryFloatingPoint) -> Self
+}
+
+extension LinearInterpolation where Self: AdditiveArithmetic, Self: Multiplicative {
+    public func lerp(to: Self, weight: any BinaryFloatingPoint) -> Self {
+        let clampedWeight = max(0.0, min(1.0, Double(weight)))
+        let result = self + (to - self) * clampedWeight
+        return result
+    }
+}
+
+extension InverseLinearInterpolation where Self: BinaryFloatingPoint {
+    public func inverseLerp(from: Self, to: Self) -> any BinaryFloatingPoint {
+        guard from != to else {
+            // Avoid division by zero when from and to are equal
+            return 0
+        }
+        
+        let clampedSelf = max(min(self, to), from)
+        let result = (clampedSelf - from) / (to - from)
+        return result
+    }
+}
+
+extension Multiplicative {
+    public static func * (lhs: Self, rhs: any BinaryFloatingPoint) -> Self {
+        return lhs * Double(rhs)
+    }
+}
+
+extension Double: LinearInterpolation, Multiplicative {}
+
+extension Float: LinearInterpolation, Multiplicative {}
+
+extension Int: LinearInterpolation, Multiplicative {}
+
+extension Vector2: LinearInterpolation {
+    public func lerp(to: Self, weight: any BinaryFloatingPoint) -> Self {
+        return Vector2(x: self.x.lerp(to: to.x, weight: weight),
+                       y: self.y.lerp(to: to.y, weight: weight))
+    }
+}
+
+extension Vector3: LinearInterpolation {
+    public func lerp(to: Self, weight: any BinaryFloatingPoint) -> Self {
+        return Vector3(x: self.x.lerp(to: to.x, weight: weight),
+                       y: self.y.lerp(to: to.y, weight: weight),
+                       z: self.z.lerp(to: to.z, weight: weight))
+    }
+}
+
+extension Vector4: LinearInterpolation {
+    public func lerp(to: Self, weight: any BinaryFloatingPoint) -> Self {
+        return Vector4(x: self.x.lerp(to: to.x, weight: weight),
+                       y: self.y.lerp(to: to.y, weight: weight),
+                       z: self.z.lerp(to: to.z, weight: weight),
+                       w: self.w.lerp(to: to.w, weight: weight))
+    }
+}
+
+extension Color: LinearInterpolation {
+    public func lerp(to: Self, weight: any BinaryFloatingPoint) -> Self {
+        return Color(r: self.red.lerp(to: to.red, weight: weight),
+                     g: self.green.lerp(to: to.green, weight: weight),
+                     b: self.blue.lerp(to: to.blue, weight: weight),
+                     a: self.alpha.lerp(to: to.alpha, weight: weight))
+    }
+}

--- a/Sources/SwiftGodot/Native/RotationConversion.swift
+++ b/Sources/SwiftGodot/Native/RotationConversion.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension BinaryFloatingPoint {
+    /// Convert given degrees value to radians.
+    public var degreesToRadians: Self {
+        return self / 180 * .pi
+    }
+    
+    /// Convert given radians value to degrees.
+    public var radiansToDegreess: Self {
+        return self * 180 / .pi
+    }
+}

--- a/Sources/SwiftGodot/Native/Snapped.swift
+++ b/Sources/SwiftGodot/Native/Snapped.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public protocol Snappable {
+    /// Returns a new value snapped to the nearest multiple of the specified step.
+    func snapped(step: Self) -> Self
+}
+
+extension Numeric where Self: FloatingPoint {
+    public func snapped(step: Self) -> Self {
+        return self - self.truncatingRemainder(dividingBy: step)
+    }
+}
+
+extension Numeric where Self: SignedInteger {
+    public func snapped(step: Self) -> Self {
+        return self - self % step
+    }
+}
+
+extension Vector2: Snappable {
+    public func snapped(step: Self) -> Self {
+        return Self(x: self.x.snapped(step: step.x),
+                    y: self.y.snapped(step: step.y))
+    }
+}
+
+extension Vector3: Snappable {
+    public func snapped(step: Self) -> Self {
+        return Self(x: self.x.snapped(step: step.x),
+                    y: self.y.snapped(step: step.y),
+                    z: self.z.snapped(step: step.z))
+    }
+}
+
+extension Vector4: Snappable {
+    public func snapped(step: Self) -> Self {
+        return Self(x: self.x.snapped(step: step.x),
+                    y: self.y.snapped(step: step.y),
+                    z: self.z.snapped(step: step.z),
+                    w: self.w.snapped(step: step.w))
+    }
+}
+
+extension Vector2i: Snappable {
+    public func snapped(step: Self) -> Self {
+        return Self(x: self.x.snapped(step: step.x),
+                    y: self.y.snapped(step: step.y))
+    }
+}
+
+extension Vector3i: Snappable {
+    public func snapped(step: Self) -> Self {
+        return Self(x: self.x.snapped(step: step.x),
+                    y: self.y.snapped(step: step.y),
+                    z: self.z.snapped(step: step.z))
+    }
+}
+
+extension Vector4i: Snappable {
+    public func snapped(step: Self) -> Self {
+        return Self(x: self.x.snapped(step: step.x),
+                    y: self.y.snapped(step: step.y),
+                    z: self.z.snapped(step: step.z),
+                    w: self.w.snapped(step: step.w))
+    }
+}
+


### PR DESCRIPTION
This is the preliminary addition to replace some of the existing functions from Godot with native ones as well as filtering out some un-needed ones.
- Removes a lot of math functions like sin, cos, tan from being generated. These are unecessary because Swift already has those
- Removes lerp and inverse_lerp and implements a native version
- Removes snapped and implements a native version
- Removes angle calculations and implements a native one