### PR TITLE
support `VariantCollection` and `ObjectCollection` return types for `@Callable` macro

### DIFF
--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -7,6 +7,13 @@
 
 @_implementationOnly import GDExtension
 
+extension ObjectCollection: VariantStorable {
+    public typealias Representable = GArray
+    public func toVariantRepresentable() -> GArray {
+        array
+    }
+}
+
 /// Protocol implemented by the built-in classes in Godot to allow to be wrapped in a ``Variant``
 public protocol GodotObject: Wrapped {}
 
@@ -50,7 +57,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     }
     
     /// Creates a new instance from the given variant if it contains a GArray
-    public init? (_ variant: Variant) {
+    public required init? (_ variant: Variant) {
         if let array = GArray (variant) {
             self.array = array
             initType()

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -7,6 +7,13 @@
 
 @_implementationOnly import GDExtension
 
+extension VariantCollection: VariantStorable {
+    public typealias Representable = GArray
+    public func toVariantRepresentable() -> GArray {
+        array
+    }
+}
+
 /// This represents a typed array of one of the built-in types from Godot
 public class VariantCollection<Element: VariantStorable>: Collection, ExpressibleByArrayLiteral, GArrayCollection {
     public typealias ArrayLiteralElement = Element
@@ -39,7 +46,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     }
     
     /// Creates a new instance from the given variant if it contains a GArray
-    public init? (_ variant: Variant) {
+    public required init? (_ variant: Variant) {
         if let array = GArray (variant) {
             self.array = array
         } else {

--- a/Sources/SwiftGodotMacroLibrary/Extensions/SwiftSyntax+MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/Extensions/SwiftSyntax+MacroExport.swift
@@ -1,5 +1,5 @@
 //
-//  TypeSyntax+MacroExport.swift
+//  SwiftSyntax+MacroExport.swift
 //
 //
 //  Created by Estevan Hernandez on 11/22/23.
@@ -82,6 +82,22 @@ private extension VariableDeclSyntax {
     }
 }
 
+private extension IdentifierTypeSyntax {
+    var genericElementName: String? {
+        guard let elementTypeName = genericArgumentClause?
+            .arguments
+            .first?
+            .argument
+            .as(IdentifierTypeSyntax.self)?
+            .name
+            .text else {
+            return nil
+        }
+        
+        return elementTypeName
+    }
+}
+
 extension TypeSyntax {
     var isArray: Bool {
         isSquareArray || isGenericArray
@@ -149,18 +165,11 @@ private extension TypeSyntax {
     }
 }
 
-private extension IdentifierTypeSyntax {
-    var genericElementName: String? {
-        guard let elementTypeName = genericArgumentClause?
-            .arguments
-            .first?
-            .argument
-            .as(IdentifierTypeSyntax.self)?
-            .name
-            .text else {
-            return nil
-        }
-        
-        return elementTypeName
+extension FunctionDeclSyntax {
+    var returnTypeIsGArrayCollection: Bool {
+        signature
+            .returnClause?
+            .type
+            .isGArrayCollection == true
     }
 }

--- a/Sources/SwiftGodotMacroLibrary/Extensions/VariableDeclSyntax+MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/Extensions/VariableDeclSyntax+MacroExport.swift
@@ -14,15 +14,11 @@ extension VariableDeclSyntax {
     }
     
     var isGArrayCollection: Bool {
-        isVariantCollection || isObjectCollection
+        type?.isGArrayCollection == true
     }
     
     var gArrayCollectionElementTypeName: String? {
-        [
-            variantCollectionElementTypeName,
-            objectCollectionElementTypeName
-        ]	.compactMap { $0 }
-            .first
+        type?.gArrayCollectionElementTypeName
     }
 }
 
@@ -87,16 +83,20 @@ private extension VariableDeclSyntax {
 }
 
 extension TypeSyntax {
-    var isGArrayCollection: Bool {
-        isVariantCollection || isObjectCollection
-    }
-}
-
-private extension TypeSyntax {
     var isArray: Bool {
         isSquareArray || isGenericArray
     }
     
+    var isGArrayCollection: Bool {
+        isVariantCollection || isObjectCollection
+    }
+    
+    var gArrayCollectionElementTypeName: String? {
+        variantCollectionElementTypeName ?? objectCollectionElementTypeName
+    }
+}
+
+private extension TypeSyntax {
     var isSquareArray: Bool {
         self.is(ArrayTypeSyntax.self)
     }

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -28,11 +28,7 @@ public struct GodotCallable: PeerMacro {
         }
         //     let result = computeGodot (String (args [0]), Int (args [1]))
         
-        if funcDecl
-            .signature
-            .returnClause?
-            .type
-            .isGArrayCollection == true {
+        if funcDecl.returnTypeIsGArrayCollection {
             retProp = ".array"
         }
         

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -19,7 +19,7 @@ public struct GodotCallable: PeerMacro {
         var retProp: String? = nil
         var retOptional: Bool = false
         
-        if let (retType, ro) = getIdentifier (funcDecl.signature.returnClause?.type) {
+        if let (retType, _, ro) = getIdentifier (funcDecl.signature.returnClause?.type) {
             retProp = godotTypeToProp (typeName: retType)
             genMethod.append ("\tlet result = \(funcName) (")
             retOptional = ro

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -28,6 +28,14 @@ public struct GodotCallable: PeerMacro {
         }
         //     let result = computeGodot (String (args [0]), Int (args [1]))
         
+        if funcDecl
+            .signature
+            .returnClause?
+            .type
+            .isGArrayCollection == true {
+            retProp = ".array"
+        }
+        
         var argc = 0
         for parameter in funcDecl.signature.parameterClause.parameters {
             guard let ptype = getTypeName(parameter) else {

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -47,13 +47,35 @@ class GodotMacroProcessor {
         if let v = propertyDeclarations [key] {
             return v
         }
-        let propType = godotTypeToProp (typeName: parameterTypeName)
+        
+        let type = TypeSyntax(stringLiteral: parameterTypeName)
+        
+        let propType: String
+        let className: String
+        
+        if let gArrayCollectionElementTypeName = type.gArrayCollectionElementTypeName {
+            let godotArrayElementTypeName: String
+            if let gType = godotVariants[gArrayCollectionElementTypeName], let fromGType = godotArrayElementType(gType: gType) {
+                godotArrayElementTypeName = fromGType
+            } else {
+                godotArrayElementTypeName = gArrayCollectionElementTypeName
+            }
+            
+            propType = godotTypeToProp (typeName: "Array")
+            className = "Array[\(godotArrayElementTypeName)]"
+        } else {
+            propType = godotTypeToProp (typeName: parameterTypeName)
+            switch propType {
+            case ".object": className = parameterTypeName
+            default: className = ""
+            }
+        }
         
         let name = "prop_\(propertyDeclarations.count)"
         
         // TODO: perhaps for these prop infos that are parameters to functions, we should not bother making them unique
         // and instead share all the Ints, all the Floats and so on.
-        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(propType == ".object" ? parameterTypeName : "")\"), hint: .none, hintStr: \"\", usage: .default)\n")
+        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(className)\"), hint: .none, hintStr: \"\", usage: .default)\n")
         propertyDeclarations [key] = name
         return name
     }

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -21,7 +21,7 @@ func getIdentifier (_ x: TypeSyntax?) -> (String, Bool)? {
         x = optSyntax.wrappedType
         opt = true
     }
-    if let txt = x.as (IdentifierTypeSyntax.self)?.name.text {
+    if let txt = x.as (IdentifierTypeSyntax.self)?.description.trimmingCharacters(in: .whitespaces) {
         return (txt, opt)
     }
     return nil

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -13,16 +13,22 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 
-// Given a TypeSyntax, returns the type and whether it is an optional type or not
-func getIdentifier (_ x: TypeSyntax?) -> (String, Bool)? {
-    guard var x else { return nil }
+/// Given a TypeSyntax, returns the type, the list of generics associated with it, and whether it is an optional type or not
+func getIdentifier (_ typeSyntax: TypeSyntax?) -> (typeName: String, generics: [String], isOptional: Bool)? {
+    guard var typeSyntax else { return nil }
     var opt = false
-    if let optSyntax = x.as (OptionalTypeSyntax.self) {
-        x = optSyntax.wrappedType
+    if let optSyntax = typeSyntax.as (OptionalTypeSyntax.self) {
+        typeSyntax = optSyntax.wrappedType
         opt = true
     }
-    if let txt = x.as (IdentifierTypeSyntax.self)?.description.trimmingCharacters(in: .whitespaces) {
-        return (txt, opt)
+    if let identifier = typeSyntax.as(IdentifierTypeSyntax.self) {
+        let genericTypeNames: [String] = identifier
+            .genericArgumentClause?
+            .arguments
+            .compactMap { $0.as(GenericArgumentSyntax.self) }
+            .compactMap { $0.argument.as(IdentifierTypeSyntax.self) }
+            .map { $0.name.text } ?? []
+        return (typeName: identifier.name.text, generics: genericTypeNames, isOptional: opt)
     }
     return nil
 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -342,7 +342,7 @@ final class MacroGodotTests: XCTestCase {
         assertMacroExpansion(
             """
             @Godot
-            class Node: Node {
+            class SomeNode: Node {
                 @Callable
                 func getIntegerCollection() -> VariantCollection<Int> {
                     let result: VariantCollection<Int> = [0, 1, 1, 2, 3, 5, 8]
@@ -358,7 +358,7 @@ final class MacroGodotTests: XCTestCase {
             """,
             expandedSource:
                 """
-                class Node: Node {
+                class SomeNode: Node {
                     func getIntegerCollection() -> VariantCollection<Int> {
                         let result: VariantCollection<Int> = [0, 1, 1, 2, 3, 5, 8]
                         return result

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -338,6 +338,89 @@ final class MacroGodotTests: XCTestCase {
         )
     }
     
+    func testGodotMacroWithCallableFuncsWithVariantCollectionAndObjectCollectionReturnTypes() {
+        assertMacroExpansion(
+            """
+            @Godot
+            class Node: Node {
+                @Callable
+                func getIntegerCollection() -> VariantCollection<Int> {
+                    let result: VariantCollection<Int> = [0, 1, 1, 2, 3, 5, 8]
+                    return result
+                }
+            
+                @Callable
+                func getNodeCollection() -> ObjectCollection<Node> {
+                    let result: ObjectCollection<Node> = [Node(), Node()]
+                    return result
+                }
+            }
+            """,
+            expandedSource:
+"""
+class Node: Node {
+    func getIntegerCollection() -> VariantCollection<Int> {
+        let result: VariantCollection<Int> = [0, 1, 1, 2, 3, 5, 8]
+        return result
+    }
+
+    func _mproxy_getIntegerCollection (args: [Variant]) -> Variant? {
+    	let result = getIntegerCollection ()
+    	return Variant (result)
+    }
+    func getNodeCollection() -> ObjectCollection<Node> {
+        let result: ObjectCollection<Node> = [Node(), Node()]
+        return result
+    }
+
+    func _mproxy_getNodeCollection (args: [Variant]) -> Variant? {
+    	let result = getNodeCollection ()
+    	return Variant (result)
+    }
+
+    override open class var classInitializer: Void {
+        let _ = super.classInitializer
+        return _initializeClass
+    }
+
+    private static var _initializeClass: Void = {
+        let className = StringName("Node")
+        assert(ClassDB.classExists(class: className))
+        let classInfo = ClassInfo<Node> (name: className)
+    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .none, hintStr: "", usage: .default)
+    	classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: Node._mproxy_getIntegerCollection)
+    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .none, hintStr: "", usage: .default)
+    	classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_1, arguments: [], function: Node._mproxy_getNodeCollection)
+    } ()
+}
+""",
+            macros: testMacros
+        )
+    }
+    
+//    func testGodotMacroWithCallableFuncsWithVariantCollectionAndObjectCollectionArgs() {
+//        assertMacroExpansion(
+//            """
+//            @Godot
+//            class Node: Node {
+//                @Callable
+//                func printIntegerCollection(integers: VariantCollection<Int>) {
+//                    print(integers)
+//                }
+//            
+//                @Callable
+//                func printNodeCollection(nodes: ObjectCollection<Node>) {
+//                    print(nodes)
+//                }
+//            }
+//            """,
+//            expandedSource:
+//"""
+//""",
+//            macros: testMacros
+//        )
+//    }
+    
     func testGodotMacroWithCallableFuncWithValueParams() {
         assertMacroExpansion(
             """

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -398,29 +398,6 @@ class Node: Node {
         )
     }
     
-//    func testGodotMacroWithCallableFuncsWithVariantCollectionAndObjectCollectionArgs() {
-//        assertMacroExpansion(
-//            """
-//            @Godot
-//            class Node: Node {
-//                @Callable
-//                func printIntegerCollection(integers: VariantCollection<Int>) {
-//                    print(integers)
-//                }
-//            
-//                @Callable
-//                func printNodeCollection(nodes: ObjectCollection<Node>) {
-//                    print(nodes)
-//                }
-//            }
-//            """,
-//            expandedSource:
-//"""
-//""",
-//            macros: testMacros
-//        )
-//    }
-    
     func testGodotMacroWithCallableFuncWithValueParams() {
         assertMacroExpansion(
             """

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -357,43 +357,43 @@ final class MacroGodotTests: XCTestCase {
             }
             """,
             expandedSource:
-"""
-class Node: Node {
-    func getIntegerCollection() -> VariantCollection<Int> {
-        let result: VariantCollection<Int> = [0, 1, 1, 2, 3, 5, 8]
-        return result
-    }
+                """
+                class Node: Node {
+                    func getIntegerCollection() -> VariantCollection<Int> {
+                        let result: VariantCollection<Int> = [0, 1, 1, 2, 3, 5, 8]
+                        return result
+                    }
 
-    func _mproxy_getIntegerCollection (args: [Variant]) -> Variant? {
-    	let result = getIntegerCollection ()
-    	return Variant (result)
-    }
-    func getNodeCollection() -> ObjectCollection<Node> {
-        let result: ObjectCollection<Node> = [Node(), Node()]
-        return result
-    }
+                    func _mproxy_getIntegerCollection (args: [Variant]) -> Variant? {
+                    	let result = getIntegerCollection ()
+                    	return Variant (result)
+                    }
+                    func getNodeCollection() -> ObjectCollection<Node> {
+                        let result: ObjectCollection<Node> = [Node(), Node()]
+                        return result
+                    }
 
-    func _mproxy_getNodeCollection (args: [Variant]) -> Variant? {
-    	let result = getNodeCollection ()
-    	return Variant (result)
-    }
+                    func _mproxy_getNodeCollection (args: [Variant]) -> Variant? {
+                    	let result = getNodeCollection ()
+                    	return Variant (result)
+                    }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
+                    override open class var classInitializer: Void {
+                        let _ = super.classInitializer
+                        return _initializeClass
+                    }
 
-    private static var _initializeClass: Void = {
-        let className = StringName("Node")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Node> (name: className)
-    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .none, hintStr: "", usage: .default)
-    	classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: Node._mproxy_getIntegerCollection)
-    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .none, hintStr: "", usage: .default)
-    	classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_1, arguments: [], function: Node._mproxy_getNodeCollection)
-    } ()
-}
-""",
+                    private static var _initializeClass: Void = {
+                        let className = StringName("Node")
+                        assert(ClassDB.classExists(class: className))
+                        let classInfo = ClassInfo<Node> (name: className)
+                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .none, hintStr: "", usage: .default)
+                    	classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: Node._mproxy_getIntegerCollection)
+                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .none, hintStr: "", usage: .default)
+                    	classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_1, arguments: [], function: Node._mproxy_getNodeCollection)
+                    } ()
+                }
+                """,
             macros: testMacros
         )
     }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -384,13 +384,13 @@ final class MacroGodotTests: XCTestCase {
                     }
 
                     private static var _initializeClass: Void = {
-                        let className = StringName("Node")
+                        let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
-                        let classInfo = ClassInfo<Node> (name: className)
+                        let classInfo = ClassInfo<SomeNode> (name: className)
                     	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .none, hintStr: "", usage: .default)
-                    	classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: Node._mproxy_getIntegerCollection)
+                    	classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getIntegerCollection)
                     	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .none, hintStr: "", usage: .default)
-                    	classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_1, arguments: [], function: Node._mproxy_getNodeCollection)
+                    	classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_1, arguments: [], function: SomeNode._mproxy_getNodeCollection)
                     } ()
                 }
                 """,


### PR DESCRIPTION
simplify macro by having VariantCollection and ObjectCollection conform to VariantStorable
move isArray computed var
resolves #310 