### PR TITLE
Export collection improvements

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -136,10 +136,9 @@ class GodotMacroProcessor {
             throw GodotMacroError.unsupportedType(varDecl)
         }
         let exportAttr = varDecl.attributes.first?.as(AttributeSyntax.self)
-        let lel = exportAttr?.arguments?.as(LabeledExprListSyntax.self)
-        let f = lel?.first?.expression.as(MemberAccessExprSyntax.self)?.declName
-        
-        let s = lel?.dropFirst().first
+        let labeledExpressionList = exportAttr?.arguments?.as(LabeledExprListSyntax.self)
+        let firstLabeledExpression = labeledExpressionList?.first?.expression.as(MemberAccessExprSyntax.self)?.declName
+        let secondLabeledExpression = labeledExpressionList?.dropFirst().first
         
         for singleVar in varDecl.bindings {
             guard let ips = singleVar.pattern.as(IdentifierPatternSyntax.self) else {
@@ -196,8 +195,8 @@ class GodotMacroProcessor {
         propertyType: \(propType),
         propertyName: "\(prefix ?? "")\(varNameWithoutPrefix)",
         className: className,
-        hint: .\(f?.description ?? "none"),
-        hintStr: \(s?.description ?? "\"\""),
+        hint: .\(firstLabeledExpression?.description ?? "none"),
+        hintStr: \(secondLabeledExpression?.description ?? "\"\""),
         usage: .default)
     
     """)
@@ -227,12 +226,6 @@ class GodotMacroProcessor {
         guard let elementTypeName = varDecl.gArrayCollectionElementTypeName else {
             return
         }
-        
-        let exportAttr = varDecl.attributes.first?.as(AttributeSyntax.self)
-        let lel = exportAttr?.arguments?.as(LabeledExprListSyntax.self)
-        let f = lel?.first?.expression.as(MemberAccessExprSyntax.self)?.declName
-        
-        let s = lel?.dropFirst().first
         
         for singleVar in varDecl.bindings {
             guard let ips = singleVar.pattern.as(IdentifierPatternSyntax.self) else {
@@ -297,9 +290,9 @@ class GodotMacroProcessor {
         propertyType: \(godotTypeToProp(typeName: "Array")),
         propertyName: "\(prefix ?? "")\(varNameWithoutPrefix.camelCaseToSnakeCase())",
         className: StringName("\(godotArrayTypeName)"),
-        hint: .\(f?.description ?? "none"),
-        hintStr: \(s?.description ?? "\"\""),
-        usage: .default)\n
+        hint: .arrayType),
+        hintStr: "\(godotArrayElementTypeName)"),
+        usage: .array)\n
     """)
             
             ctor.append("\tclassInfo.registerMethod (name: \"\(getterName)\", flags: .default, returnValue: \(pinfo), arguments: [], function: \(className).\(proxyGetterName))\n")

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -290,8 +290,8 @@ class GodotMacroProcessor {
         propertyType: \(godotTypeToProp(typeName: "Array")),
         propertyName: "\(prefix ?? "")\(varNameWithoutPrefix.camelCaseToSnakeCase())",
         className: StringName("\(godotArrayTypeName)"),
-        hint: .arrayType),
-        hintStr: "\(godotArrayElementTypeName)"),
+        hint: .arrayType,
+        hintStr: "\(godotArrayElementTypeName)",
         usage: .array)\n
     """)
             

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -485,9 +485,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "makes",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
     	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
     	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
@@ -495,9 +495,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "model",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
     	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
     	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
@@ -569,9 +569,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "vins",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -580,9 +580,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "years",
             className: StringName("Array[int]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "int",
+            usage: .array)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -653,9 +653,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "vins",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -663,9 +663,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "years",
             className: StringName("Array[int]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "int",
+            usage: .array)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -774,9 +774,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "vins",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -785,9 +785,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "years",
             className: StringName("Array[int]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "int",
+            usage: .array)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -795,9 +795,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "makes",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
     	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
     	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
@@ -805,9 +805,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "models",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
     	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
     	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
@@ -882,9 +882,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "makes",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
     	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
     	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
@@ -892,9 +892,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "model",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
     	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
     	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
@@ -965,9 +965,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "vins",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -976,9 +976,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "years",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -1049,9 +1049,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "vins",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -1059,9 +1059,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "years",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -1170,9 +1170,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "vins",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -1181,9 +1181,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "years",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -1191,9 +1191,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "makes",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
     	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
     	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
@@ -1201,9 +1201,9 @@ class Car: Node {
             propertyType: .array,
             propertyName: "models",
             className: StringName("Array[Node]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node",
+            usage: .array)
     	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
     	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
     	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
@@ -1383,9 +1383,9 @@ class Garage: Node {
             propertyType: .array,
             propertyName: "reviews",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_reviews", flags: .default, returnValue: _previews, arguments: [], function: Garage._mproxy_get_reviews)
     	classInfo.registerMethod (name: "set_reviews", flags: .default, returnValue: nil, arguments: [_previews], function: Garage._mproxy_set_reviews)
     	classInfo.registerProperty (_previews, getter: "get_reviews", setter: "set_reviews")
@@ -1393,9 +1393,9 @@ class Garage: Node {
             propertyType: .array,
             propertyName: "check_ins",
             className: StringName("Array[CheckIn]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "CheckIn",
+            usage: .array)
     	classInfo.registerMethod (name: "get_check_ins", flags: .default, returnValue: _pcheckIns, arguments: [], function: Garage._mproxy_get_checkIns)
     	classInfo.registerMethod (name: "set_check_ins", flags: .default, returnValue: nil, arguments: [_pcheckIns], function: Garage._mproxy_set_checkIns)
     	classInfo.registerProperty (_pcheckIns, getter: "get_check_ins", setter: "set_check_ins")
@@ -1414,9 +1414,9 @@ class Garage: Node {
             propertyType: .array,
             propertyName: "days_of_operation",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_days_of_operation", flags: .default, returnValue: _pdaysOfOperation, arguments: [], function: Garage._mproxy_get_daysOfOperation)
     	classInfo.registerMethod (name: "set_days_of_operation", flags: .default, returnValue: nil, arguments: [_pdaysOfOperation], function: Garage._mproxy_set_daysOfOperation)
     	classInfo.registerProperty (_pdaysOfOperation, getter: "get_days_of_operation", setter: "set_days_of_operation")
@@ -1424,9 +1424,9 @@ class Garage: Node {
             propertyType: .array,
             propertyName: "hours",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_hours", flags: .default, returnValue: _phours, arguments: [], function: Garage._mproxy_get_hours)
     	classInfo.registerMethod (name: "set_hours", flags: .default, returnValue: nil, arguments: [_phours], function: Garage._mproxy_set_hours)
     	classInfo.registerProperty (_phours, getter: "get_hours", setter: "set_hours")
@@ -1434,9 +1434,9 @@ class Garage: Node {
             propertyType: .array,
             propertyName: "insurance_providers_accepted",
             className: StringName("Array[InsuranceProvider]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "InsuranceProvider",
+            usage: .array)
     	classInfo.registerMethod (name: "get_insurance_providers_accepted", flags: .default, returnValue: _pinsuranceProvidersAccepted, arguments: [], function: Garage._mproxy_get_insuranceProvidersAccepted)
     	classInfo.registerMethod (name: "set_insurance_providers_accepted", flags: .default, returnValue: nil, arguments: [_pinsuranceProvidersAccepted], function: Garage._mproxy_set_insuranceProvidersAccepted)
     	classInfo.registerProperty (_pinsuranceProvidersAccepted, getter: "get_insurance_providers_accepted", setter: "set_insurance_providers_accepted")

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -100,9 +100,9 @@ class SomeNode: Node {
             propertyType: .array,
             propertyName: "greetings",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
     	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
     	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
@@ -253,9 +253,9 @@ class SomeNode: Node {
             propertyType: .array,
             propertyName: "some_numbers",
             className: StringName("Array[int]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "int",
+            usage: .array)
     	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
     	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
     	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
@@ -325,9 +325,9 @@ class SomeNode: Node {
             propertyType: .array,
             propertyName: "some_numbers",
             className: StringName("Array[int]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "int",
+            usage: .array)
     	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
     	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
     	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
@@ -335,9 +335,9 @@ class SomeNode: Node {
             propertyType: .array,
             propertyName: "some_other_numbers",
             className: StringName("Array[int]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "int",
+            usage: .array)
     	classInfo.registerMethod (name: "get_some_other_numbers", flags: .default, returnValue: _psomeOtherNumbers, arguments: [], function: SomeNode._mproxy_get_someOtherNumbers)
     	classInfo.registerMethod (name: "set_some_other_numbers", flags: .default, returnValue: nil, arguments: [_psomeOtherNumbers], function: SomeNode._mproxy_set_someOtherNumbers)
     	classInfo.registerProperty (_psomeOtherNumbers, getter: "get_some_other_numbers", setter: "set_some_other_numbers")
@@ -409,9 +409,9 @@ class ArrayTest: Node {
             propertyType: .array,
             propertyName: "first_names",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_first_names", flags: .default, returnValue: _pfirstNames, arguments: [], function: ArrayTest._mproxy_get_firstNames)
     	classInfo.registerMethod (name: "set_first_names", flags: .default, returnValue: nil, arguments: [_pfirstNames], function: ArrayTest._mproxy_set_firstNames)
     	classInfo.registerProperty (_pfirstNames, getter: "get_first_names", setter: "set_first_names")
@@ -419,9 +419,9 @@ class ArrayTest: Node {
             propertyType: .array,
             propertyName: "last_names",
             className: StringName("Array[String]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "String",
+            usage: .array)
     	classInfo.registerMethod (name: "get_last_names", flags: .default, returnValue: _plastNames, arguments: [], function: ArrayTest._mproxy_get_lastNames)
     	classInfo.registerMethod (name: "set_last_names", flags: .default, returnValue: nil, arguments: [_plastNames], function: ArrayTest._mproxy_set_lastNames)
     	classInfo.registerProperty (_plastNames, getter: "get_last_names", setter: "set_last_names")
@@ -502,9 +502,9 @@ class SomeNode: Node {
             propertyType: .array,
             propertyName: "greetings",
             className: StringName("Array[Node3D]"),
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+            hint: .arrayType,
+            hintStr: "Node3D",
+            usage: .array)
     	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
     	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
     	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")


### PR DESCRIPTION
I noticed while working on #316 that for an array type, setting the `className: StringName("Array[Element]")` on the property is not enough for GDScript to be able to infer the type hinting.

For example when used as a param the auto complete showed the type as `Array` even though the className was `Array[int]`

I've also learned more about hint, and hintStr, so this PR updates the Export and Godot macros to take fuller advantage of the property info params.

I don't think `className: StringName("Array[Element]")` is actually needed anymore, but it doesn't seem to cause harm to. leave it either.

also usage is set to `.array` instead of `.default`