### PR TITLE
Add @Callable macro explainer in the documentation.

### DIFF
--- a/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
@@ -201,9 +201,7 @@ convenience methods that you might have come to expect from the Godot String
 
 ## Callable
 
-In SwiftGodot, you can create `Callable` instances, either by using a StringName
-that binds a method that you have exported (via, the `@Callable` macro), or you
-can pass directly a Swift function that takes an array of `Variant` arguments,
+In SwiftGodot, you can create `Callable` instances by directly passing a Swift function that takes an array of `Variant` arguments,
 and returns an optional `Variant` result, like this:
 
 ```swift
@@ -213,6 +211,18 @@ func myCallback(args: [Variant])-> Variant? {
 }
 
 let myCallable = Callable(myCallback)
+```
+
+Alternatively, you can use a StringName that binds a method that you have exported (via, the `@Callable` macro), like this:
+
+```swift
+@Callable func myCallback(message: String) {
+	GD.print(message)
+}
+```
+
+```GDScript
+MySwiftNode.myCallback.call("Hello from Swift!")
 ```
 
 ## Async/Await

--- a/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
@@ -221,6 +221,8 @@ Alternatively, you can use a StringName that binds a method that you have export
 }
 ```
 
+You can call the callable in GDScript by invoking call() method of the exported Swift type.
+
 ```GDScript
 MySwiftNode.myCallback.call("Hello from Swift!")
 ```


### PR DESCRIPTION
I had a hard time figuring out why my Callable made with the macro was making the game freeze, turns out you have to call `<callable>.call()` method instead of just using `<callable>()`

I don't know if this behavior is a bug or not, but I think it might be worth it to include GDScript snippet to let the users know how to do this.