### PR TITLE
Add engine tests for AABB, Basis, Plane and Quaternion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -137,6 +137,14 @@ targets.append(contentsOf: [
             "SwiftGodotTestability",
         ]
     ),
+    
+    // Runtime dependant tests based on the engine tests from Godot's repository
+    .testTarget(
+        name: "SwiftGodotEngineTests",
+        dependencies: [
+            "SwiftGodotTestability",
+        ]
+    ),
 ])
 #endif
 

--- a/Sources/SwiftGodotTestability/GodotTestCase.swift
+++ b/Sources/SwiftGodotTestability/GodotTestCase.swift
@@ -59,3 +59,32 @@ open class GodotTestCase: XCTestCase {
     }
     
 }
+
+public extension GodotTestCase {
+    
+    /// Asserts approximate equality of two floating point values based on `Math::is_equal_approx` implementation in Godot
+    func assertApproxEqual<T: FloatingPoint & ExpressibleByFloatLiteral> (_ a: T, _ b: T, epsilon: T = 0.00001, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+        // Check for exact equality first, required to handle "infinity" values.
+        guard a != b else { return }
+        
+        // Then check for approximate equality.
+        let tolerance: T = max (epsilon * abs (a), epsilon)
+        XCTAssertEqual (a, b, accuracy: tolerance, message, file: file, line: line)
+    }
+    
+    /// Asserts approximate equality of two vectors by comparing approximately each component
+    func assertApproxEqual (_ a: Vector3, _ b: Vector3, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual (a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
+    }
+    
+    /// Asserts approximate equality of two quaternions by comparing approximately each component
+    func assertApproxEqual (_ a: Quaternion, _ b: Quaternion, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual (a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
+        assertApproxEqual (a.w, b.w, "Fail due to W. " + message, file: file, line: line)
+    }
+    
+}

--- a/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
@@ -1,0 +1,219 @@
+// Based on godot/tests/core/math/test_aabb.h
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class AABBTests: GodotTestCase {
+    
+    func testConstructorMethods () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        let aabbCopy: AABB = AABB (from: aabb)
+        XCTAssertEqual (aabb, aabbCopy, "AABBs created with the same dimensions but by different methods should be equal.")
+    }
+    
+    func testStringConversion () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (Variant (aabb).description, "[P: (-1.5, 2, -2.5), S: (4, 5, 6)]", "The string representation should match the expected value.")
+    }
+    
+    func testBasicGetters () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.position, Vector3 (x: -1.5, y: 2, z: -2.5), "position getter should return the expected value.")
+        XCTAssertEqual (aabb.size, Vector3 (x: 4, y: 5, z: 6), "size getter should return the expected value.")
+        XCTAssertEqual (aabb.end, Vector3 (x: 2.5, y: 7, z: 3.5), "end getter should return the expected value.")
+        XCTAssertEqual (aabb.getCenter (), Vector3 (x: 0.5, y: 4.5, z: 0.5), "getCenter() should return the expected value.")
+    }
+    
+    func testBasicSetters () {
+        var aabb: AABB
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        aabb.end = Vector3 (x: 100, y: 0, z: 100)
+        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 101.5, y: -2, z: 102.5)), "Setting end should result in the expected AABB.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        aabb.position = Vector3 (x: -1000, y: -2000, z: -3000)
+        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1000, y: -2000, z: -3000), size: Vector3 (x: 4, y: 5, z: 6)), "Setting position should result in the expected AABB.")
+
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        aabb.size = Vector3 (x: 0, y: 0, z: -50)
+        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 0, y: 0, z: -50)), "Setting position should result in the expected AABB.")
+    }
+    
+    func testVolumeGetters () {
+        var aabb: AABB
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getVolume (), 120, "getVolume() should return the expected value with positive size.")
+        XCTAssertTrue (aabb.hasVolume (), "Non-empty volumetric AABB should have a volume.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getVolume (), -120, "getVolume() should return the expected value with negative size (1 component).")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: -5, z: 6))
+        XCTAssertEqual (aabb.getVolume (), 120, "getVolume() should return the expected value with positive size (2 components).")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: -5, z: -6))
+        XCTAssertEqual (aabb.getVolume (), -120, "getVolume() should return the expected value with negative size (3 components).")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 6))
+        XCTAssertFalse (aabb.hasVolume (), "Non-empty flat AABB should not have a volume.")
+        
+        aabb = AABB ()
+        XCTAssertFalse (aabb.hasVolume (), "Empty AABB should not have a volume.")
+    }
+    
+    func testSurfaceGetters () {
+        var aabb: AABB
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertTrue (aabb.hasSurface (), "Non-empty volumetric AABB should have an surface.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 6))
+        XCTAssertTrue (aabb.hasSurface (), "Non-empty flat AABB should have a surface.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 0))
+        XCTAssertTrue (aabb.hasSurface (), "Non-empty linear AABB should have a surface.")
+        
+        aabb = AABB ()
+        XCTAssertFalse (aabb.hasSurface (), "Empty AABB should not have an surface.")
+    }
+    
+    func testIntersection () {
+        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        var aabbSmall: AABB
+        
+        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertTrue (aabbBig.intersects (with: aabbSmall), "intersects() with fully contained AABB (touching the edge) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertTrue (aabbBig.intersects (with: aabbSmall), "intersects() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertFalse (aabbBig.intersects (with: aabbSmall), "intersects() with non-contained AABB should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), aabbSmall, "intersection() with fully contained AABB (touching the edge) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), AABB (position: Vector3 (x: 0.5, y: 2, z: -2), size: Vector3 (x: 1, y: 0.5, z: 1)), "intersection() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), AABB (), "intersection() with non-contained AABB should return the expected result.")
+        
+        XCTAssertTrue (aabbBig.intersectsPlane (plane: Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 4)), "intersectsPlane() should return the expected result.")
+        XCTAssertTrue (aabbBig.intersectsPlane (plane: Plane (normal: Vector3 (x: 0, y: -1, z: 0), d: -4)), "intersectsPlane() should return the expected result.")
+        XCTAssertFalse (aabbBig.intersectsPlane (plane: Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 200)), "intersectsPlane() should return the expected result.")
+        
+        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 1, y: 3, z: 0), to: Vector3 (x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 3, z: 0), to: Vector3 (x: 0, y: -300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: -50, y: 3, z: -50), to: Vector3 (x: 50, y: 3, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertEqual (aabbBig.intersectsSegment (from: Vector3 (x: -50, y: 25, z: -50), to: Vector3 (x: 50, y: 25, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 3, z: 0), to: Vector3 (x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result with segment of length 0.")
+        XCTAssertEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 300, z: 0), to: Vector3 (x: 0, y: 300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result with segment of length 0.")
+    }
+    
+    func testMerging () {
+        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        var aabbSmall: AABB
+        
+        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.merge (with: aabbSmall), aabbBig, "merge() with fully contained AABB (touching the edge) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.merge (with: aabbSmall), AABB (position: Vector3 (x: -1.5, y: 1.5, z: -2.5), size: Vector3 (x: 4, y: 5.5, z: 6)), "merge() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.merge (with: aabbSmall), AABB (position: Vector3 (x: -1.5, y: -10, z: -10), size: Vector3 (x: 12.5, y: 17, z: 13.5)), "merge() with non-contained AABB should return the expected result.")
+    }
+    
+    func testEncloses () {
+        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        var aabbSmall: AABB
+        
+        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertTrue (aabbBig.encloses (with: aabbSmall), "encloses() with fully contained AABB (touching the edge) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertFalse (aabbBig.encloses (with: aabbSmall), "encloses() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertFalse (aabbBig.encloses (with: aabbSmall), "encloses() with non-contained AABB should return the expected result.")
+    }
+    
+    func testGetEndpoints () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getEndpoint (idx: 0), Vector3 (x: -1.5, y: 2, z: -2.5), "The endpoint at index 0 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 1), Vector3 (x: -1.5, y: 2, z: 3.5), "The endpoint at index 1 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 2), Vector3 (x: -1.5, y: 7, z: -2.5), "The endpoint at index 2 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 3), Vector3 (x: -1.5, y: 7, z: 3.5), "The endpoint at index 3 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 4), Vector3 (x: 2.5, y: 2, z: -2.5), "The endpoint at index 4 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 5), Vector3 (x: 2.5, y: 2, z: 3.5), "The endpoint at index 5 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 6), Vector3 (x: 2.5, y: 7, z: -2.5), "The endpoint at index 6 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 7), Vector3 (x: 2.5, y: 7, z: 3.5), "The endpoint at index 7 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 8), Vector3 (), "The endpoint at invalid index 8 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: -1), Vector3 (), "The endpoint at invalid index -1 should match the expected value.")
+    }
+    
+    func testGetLongestShortestAxis () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getLongestAxis (), Vector3 (x: 0, y: 0, z: 1), "getLongestAxis() should return the expected value.")
+        XCTAssertEqual (aabb.getLongestAxisIndex (), Int64 (Vector3.Axis.z.rawValue), "getLongestAxisIndex() should return the expected value.")
+        XCTAssertEqual (aabb.getLongestAxisSize (), 6, "getLongestAxisSize() should return the expected value.")
+        XCTAssertEqual (aabb.getShortestAxis (), Vector3 (x: 1, y: 0, z: 0), "getShortestAxis() should return the expected value.")
+        XCTAssertEqual (aabb.getShortestAxisIndex (), Int64 (Vector3.Axis.x.rawValue), "getShortestAxisIndex() should return the expected value.")
+        XCTAssertEqual (aabb.getShortestAxisSize (), 4, "getShortestAxisSize() should return the expected value.")
+    }
+    
+    func testGetSupport () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 1, y: 0, z: 0)), Vector3 (x: 2.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0.5, y: 1, z: 0)), Vector3 (x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0.5, y: 1, z: -400)), Vector3 (x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0, y: -1, z: 0)), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0, y: -0.1, z: 0)), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 ()), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value with a null vector.")
+    }
+    
+    func testGrow () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.grow (by: 0.25), AABB (position: Vector3 (x: -1.75, y: 1.75, z: -2.75), size: Vector3 (x: 4.5, y: 5.5, z: 6.5)), "grow() with positive value should return the expected AABB.")
+        XCTAssertEqual (aabb.grow (by: -0.25), AABB (position: Vector3 (x: -1.25, y: 2.25, z: -2.25), size: Vector3 (x: 3.5, y: 4.5, z: 5.5)), "grow() with negative value should return the expected AABB.")
+        XCTAssertEqual (aabb.grow (by: -10), AABB (position: Vector3 (x: 8.5, y: 12, z: 7.5), size: Vector3 (x: -16, y: -15, z: -14)), "grow() with large negative value should return the expected AABB.")
+    }
+    
+    func testHasPoint () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        
+        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: -1, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
+        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 2, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
+        XCTAssertFalse (aabb.hasPoint (point: Vector3 (x: -20, y: 0, z: 0)), "hasPoint() with non-contained point should return the expected value.")
+        
+        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: -1.5, y: 3, z: 0)), "hasPoint() with positive size should include point on near face (X axis).")
+        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 2.5, y: 3, z: 0)), "hasPoint() with positive size should include point on far face (X axis).")
+        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 0, y: 2, z: 0)), "hasPoint() with positive size should include point on near face (Y axis).")
+        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 0, y: 7, z: 0)), "hasPoint() with positive size should include point on far face (Y axis).")
+        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 0, y: 3, z: -2.5)), "hasPoint() with positive size should include point on near face (Z axis).")
+        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 0, y: 3, z: 3.5)), "hasPoint() with positive size should include point on far face (Z axis).")
+    }
+    
+    func testExpanding () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -1, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: 2, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -1.5, y: 3, z: 0)), aabb, "expand() with contained point on negative edge should return the expected AABB.")
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: 2.5, y: 3, z: 0)), aabb, "expand() with contained point on positive edge should return the expected AABB.")
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -20, y: 0, z: 0)), AABB (position: Vector3 (x: -20, y: 0, z: -2.5), size: Vector3 (x: 22.5, y: 7, z: 6)), "expand() with non-contained point should return the expected AABB.")
+    }
+    
+    func testFiniteNumberChecks () {
+        let x: Vector3 = Vector3 (x: 0, y: 1, z: 2)
+        let infinite: Vector3 = Vector3 (x: .nan, y: .nan, z: .nan)
+        XCTAssertTrue (AABB (position: x, size: x).isFinite (), "AABB with all components finite should be finite")
+        XCTAssertFalse (AABB (position: infinite, size: x).isFinite (), "AABB with one component infinite should not be finite.")
+        XCTAssertFalse (AABB (position: x, size: infinite).isFinite (), "AABB with one component infinite should not be finite.")
+        XCTAssertFalse (AABB (position: infinite, size: infinite).isFinite (), "AABB with two components infinite should not be finite.")
+    }
+    
+}

--- a/Tests/SwiftGodotEngineTests/Math/BasisTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/BasisTests.swift
@@ -35,9 +35,9 @@ final class BasisTests: GodotTestCase {
         
         var res: Basis = toRotation.inverse () * rotationFromComputedEuler
         
-        XCTAssert ((res.x - Vector3 (x: 1, y: 0, z: 0)).length () <= 0.1, "Fail due to X \(res.x)")
-        XCTAssert ((res.y - Vector3 (x: 0, y: 1, z: 0)).length () <= 0.1, "Fail due to Y \(res.y)")
-        XCTAssert ((res.z - Vector3 (x: 0, y: 0, z: 1)).length () <= 0.1, "Fail due to Z \(res.z)")
+        XCTAssert ((res.x - Vector3 (x: 1, y: 0, z: 0)).length () <= 0.1, "Fail due to X \(res.x)", file: file, line: line)
+        XCTAssert ((res.y - Vector3 (x: 0, y: 1, z: 0)).length () <= 0.1, "Fail due to Y \(res.y)", file: file, line: line)
+        XCTAssert ((res.z - Vector3 (x: 0, y: 0, z: 1)).length () <= 0.1, "Fail due to Z \(res.z)", file: file, line: line)
         
         // Double check `toRotation` decomposing with XYZ rotation order.
         
@@ -149,7 +149,6 @@ final class BasisTests: GodotTestCase {
     func testGetAxisAngle () {
         var basis: Basis
         var axis: Vector3
-        let accuracy: Float = 0.0001
         
         // Testing the singularity when the angle is 0°.
         basis = Basis (xAxis: Vector3 (x: 1, y: 0, z: 0), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
@@ -157,7 +156,7 @@ final class BasisTests: GodotTestCase {
         
         // Testing the singularity when the angle is 180°.
         basis = Basis (xAxis: Vector3 (x: -1, y: 0, z: 0), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: 0, y: 0, z: -1))
-        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi, accuracy: accuracy)
+        assertApproxEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi)
         
         // Testing reversing the an axis (of an 30° angle).
         
@@ -165,46 +164,46 @@ final class BasisTests: GodotTestCase {
         let cos30: Float = cos (rad30)
         
         basis = Basis (xAxis: Vector3 (x: cos30, y: -0.5, z: 0), yAxis: Vector3 (x: 0.5, y: cos30, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
-        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), rad30, accuracy: accuracy)
+        assertApproxEqual (Float (basis.getRotationQuaternion ().getAngle ()), rad30)
         axis = basis.getRotationQuaternion ().getAxis ()
-        XCTAssertEqual (axis.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (axis.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (axis.z, 1.0, accuracy: accuracy)
+        assertApproxEqual (axis.x, 0.0)
+        assertApproxEqual (axis.y, 0.0)
+        assertApproxEqual (axis.z, 1.0)
         
         basis = Basis (xAxis: Vector3 (x: cos30, y: 0.5, z: 0), yAxis: Vector3 (x: -0.5, y: cos30, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
-        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), rad30, accuracy: accuracy)
+        assertApproxEqual (Float (basis.getRotationQuaternion ().getAngle ()), rad30)
         axis = basis.getRotationQuaternion ().getAxis ()
-        XCTAssertEqual (axis.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (axis.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (axis.z, -1.0, accuracy: accuracy)
+        assertApproxEqual (axis.x, 0.0)
+        assertApproxEqual (axis.y, 0.0)
+        assertApproxEqual (axis.z, -1.0)
         
         // Testing a rotation of 90° on x-y-z.
         
         basis = Basis (xAxis: Vector3 (x: 1, y: 0, z: 0), yAxis: Vector3 (x: 0, y: 0, z: -1), zAxis: Vector3 (x: 0, y: 1, z: 0))
-        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2, accuracy: accuracy)
+        assertApproxEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2)
         axis = basis.getRotationQuaternion ().getAxis ()
-        XCTAssertEqual (axis.x, 1.0, accuracy: accuracy)
-        XCTAssertEqual (axis.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (axis.z, 0.0, accuracy: accuracy)
+        assertApproxEqual (axis.x, 1.0)
+        assertApproxEqual (axis.y, 0.0)
+        assertApproxEqual (axis.z, 0.0)
         
         basis = Basis (xAxis: Vector3 (x: 0, y: 0, z: 1), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: -1, y: 0, z: 0))
-        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2, accuracy: accuracy)
+        assertApproxEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2)
         axis = basis.getRotationQuaternion ().getAxis ()
-        XCTAssertEqual (axis.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (axis.y, 1.0, accuracy: accuracy)
-        XCTAssertEqual (axis.z, 0.0, accuracy: accuracy)
+        assertApproxEqual (axis.x, 0.0)
+        assertApproxEqual (axis.y, 1.0)
+        assertApproxEqual (axis.z, 0.0)
         
         basis = Basis (xAxis: Vector3 (x: 0, y: -1, z: 0), yAxis: Vector3 (x: 1, y: 0, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
-        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2, accuracy: accuracy)
+        assertApproxEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2)
         axis = basis.getRotationQuaternion ().getAxis ()
-        XCTAssertEqual (axis.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (axis.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (axis.z, 1.0, accuracy: accuracy)
+        assertApproxEqual (axis.x, 0.0)
+        assertApproxEqual (axis.y, 0.0)
+        assertApproxEqual (axis.z, 1.0)
         
         // Regression test: checks that the method returns a small angle (not 0).
         // The min angle possible with float is 0.001rad.
         basis = Basis (xAxis: Vector3 (x: 1, y: 0, z: 0), yAxis: Vector3 (x: 0, y: 0.9999995, z: -0.001), zAxis: Vector3 (x: 0, y: 0.001, z: 0.9999995))
-        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), 0.001, accuracy: accuracy)
+        assertApproxEqual (Float (basis.getRotationQuaternion ().getAngle ()), 0.001, epsilon: 0.0001)
         
         // Regression test: checks that the method returns an angle which is a number (not NaN)
         basis = Basis (xAxis: Vector3 (x: 1.00000024, y: 0, z: 0.000100001693), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: -0.000100009143, y: 0, z: 1.00000024))

--- a/Tests/SwiftGodotEngineTests/Math/BasisTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/BasisTests.swift
@@ -1,0 +1,262 @@
+// Based on godot/tests/core/math/test_basis.h
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class BasisTests: GodotTestCase {
+    
+    /// This test:
+    /// 1. Converts the rotation vector from deg to rad.
+    /// 2. Converts euler to basis.
+    /// 3. Converts the above basis back into euler.
+    /// 4. Converts the above euler into basis again.
+    /// 5. Compares the basis obtained in step 2 with the basis of step 4
+    ///
+    /// The conversion "basis to euler", done in the step 3, may be different from
+    /// the original euler, even if the final rotation are the same.
+    /// This happens because there are more ways to represents the same rotation,
+    /// both valid, using eulers.
+    /// For this reason is necessary to convert that euler back to basis and finally
+    /// compares it.
+    ///
+    /// In this way we can assert that both functions: basis to euler / euler to basis
+    /// are correct.
+    private func assertRotation (eulerDegrees: Vector3, eulerOrder: EulerOrder, file: StaticString = #file, line: UInt = #line) {
+        let rawEulerOrder: Int64 = Int64 (eulerOrder.rawValue)
+        
+        // Euler to rotation
+        let originalEuler: Vector3 = Vector3 (x: eulerDegrees.x.degreesToRadians, y: eulerDegrees.y.degreesToRadians, z: eulerDegrees.z.degreesToRadians)
+        let toRotation: Basis = Basis.fromEuler (euler: originalEuler)
+
+        // Euler from rotation
+        let eulerFromRotation: Vector3 = toRotation.getEuler (order: rawEulerOrder)
+        let rotationFromComputedEuler: Basis = Basis.fromEuler (euler: eulerFromRotation, order: rawEulerOrder)
+        
+        var res: Basis = toRotation.inverse () * rotationFromComputedEuler
+        
+        XCTAssert ((res.x - Vector3 (x: 1, y: 0, z: 0)).length () <= 0.1, "Fail due to X \(res.x)")
+        XCTAssert ((res.y - Vector3 (x: 0, y: 1, z: 0)).length () <= 0.1, "Fail due to Y \(res.y)")
+        XCTAssert ((res.z - Vector3 (x: 0, y: 0, z: 1)).length () <= 0.1, "Fail due to Z \(res.z)")
+        
+        // Double check `toRotation` decomposing with XYZ rotation order.
+        
+        let rawXyzEulerOrder: Int64 = Int64 (EulerOrder.xyz.rawValue)
+        let eulerXyzFromRotation: Vector3 = toRotation.getEuler (order: rawXyzEulerOrder)
+        let rotationFromXyzComputedEuler: Basis = Basis.fromEuler (euler: eulerXyzFromRotation, order: rawXyzEulerOrder)
+        
+        res = toRotation.inverse () * rotationFromXyzComputedEuler
+        
+        XCTAssert ((res.x - Vector3 (x: 1, y: 0, z: 0)).length () <= 0.1, "Double check with XYZ rot order failed, due to X \(res.x)")
+        XCTAssert ((res.y - Vector3 (x: 0, y: 1, z: 0)).length () <= 0.1, "Double check with XYZ rot order failed, due to Y \(res.y)")
+        XCTAssert ((res.z - Vector3 (x: 0, y: 0, z: 1)).length () <= 0.1, "Double check with XYZ rot order failed, due to Z \(res.z)")
+    }
+    
+    func testEulerConversions () {
+        let eulerOrders: [EulerOrder] = [
+            EulerOrder.xyz,
+            EulerOrder.xzy,
+            EulerOrder.yzx,
+            EulerOrder.yxz,
+            EulerOrder.zxy,
+            EulerOrder.zyx,
+        ]
+        let vectors: [Vector3] = [
+            Vector3 (x: 0.0, y: 0.0, z: 0.0),
+            Vector3 (x: 0.5, y: 0.5, z: 0.5),
+            Vector3 (x: -0.5, y: -0.5, z: -0.5),
+            Vector3 (x: 40.0, y: 40.0, z: 40.0),
+            Vector3 (x: -40.0, y: -40.0, z: -40.0),
+            Vector3 (x: 0.0, y: 0.0, z: -90.0),
+            Vector3 (x: 0.0, y: -90.0, z: 0.0),
+            Vector3 (x: -90.0, y: 0.0, z: 0.0),
+            Vector3 (x: 0.0, y: 0.0, z: 90.0),
+            Vector3 (x: 0.0, y: 90.0, z: 0.0),
+            Vector3 (x: 90.0, y: 0.0, z: 0.0),
+            Vector3 (x: 0.0, y: 0.0, z: -30.0),
+            Vector3 (x: 0.0, y: -30.0, z: 0.0),
+            Vector3 (x: -30.0, y: 0.0, z: 0.0),
+            Vector3 (x: 0.0, y: 0.0, z: 30.0),
+            Vector3 (x: 0.0, y: 30.0, z: 0.0),
+            Vector3 (x: 30.0, y: 0.0, z: 0.0),
+            Vector3 (x: 0.5, y: 50.0, z: 20.0),
+            Vector3 (x: -0.5, y: -50.0, z: -20.0),
+            Vector3 (x: 0.5, y: 0.0, z: 90.0),
+            Vector3 (x: 0.5, y: 0.0, z: -90.0),
+            Vector3 (x: 360.0, y: 360.0, z: 360.0),
+            Vector3 (x: -360.0, y: -360.0, z: -360.0),
+            Vector3 (x: -90.0, y: 60.0, z: -90.0),
+            Vector3 (x: 90.0, y: 60.0, z: -90.0),
+            Vector3 (x: 90.0, y: -60.0, z: -90.0),
+            Vector3 (x: -90.0, y: -60.0, z: -90.0),
+            Vector3 (x: -90.0, y: 60.0, z: 90.0),
+            Vector3 (x: 90.0, y: 60.0, z: 90.0),
+            Vector3 (x: 90.0, y: -60.0, z: 90.0),
+            Vector3 (x: -90.0, y: -60.0, z: 90.0),
+            Vector3 (x: 60.0, y: 90.0, z: -40.0),
+            Vector3 (x: 60.0, y: -90.0, z: -40.0),
+            Vector3 (x: -60.0, y: -90.0, z: -40.0),
+            Vector3 (x: -60.0, y: 90.0, z: 40.0),
+            Vector3 (x: 60.0, y: 90.0, z: 40.0),
+            Vector3 (x: 60.0, y: -90.0, z: 40.0),
+            Vector3 (x: -60.0, y: -90.0, z: 40.0),
+            Vector3 (x: -90.0, y: 90.0, z: -90.0),
+            Vector3 (x: 90.0, y: 90.0, z: -90.0),
+            Vector3 (x: 90.0, y: -90.0, z: -90.0),
+            Vector3 (x: -90.0, y: -90.0, z: -90.0),
+            Vector3 (x: -90.0, y: 90.0, z: 90.0),
+            Vector3 (x: 90.0, y: 90.0, z: 90.0),
+            Vector3 (x: 90.0, y: -90.0, z: 90.0),
+            Vector3 (x: 20.0, y: 150.0, z: 30.0),
+            Vector3 (x: 20.0, y: -150.0, z: 30.0),
+            Vector3 (x: -120.0, y: -150.0, z: 30.0),
+            Vector3 (x: -120.0, y: -150.0, z: -130.0),
+            Vector3 (x: 120.0, y: -150.0, z: -130.0),
+            Vector3 (x: 120.0, y: 150.0, z: -130.0),
+            Vector3 (x: 120.0, y: 150.0, z: 130.0),
+        ]
+        for eulerOrder in eulerOrders {
+            for vector in vectors {
+                assertRotation (eulerDegrees: vector, eulerOrder: eulerOrder)
+            }
+        }
+    }
+    
+    func testEulerConversionsRandom () {
+        let eulerOrders: [EulerOrder] = [
+            EulerOrder.xyz,
+            EulerOrder.xzy,
+            EulerOrder.yzx,
+            EulerOrder.yxz,
+            EulerOrder.zxy,
+            EulerOrder.zyx,
+        ]
+        var vectors: [Vector3] = []
+        let rng = RandomNumberGenerator ()
+        for _ in 0..<100 {
+            vectors.append (Vector3 (
+                x: Float (rng.randfRange (from: -1800, to: 1800)),
+                y: Float (rng.randfRange (from: -1800, to: 1800)),
+                z: Float (rng.randfRange (from: -1800, to: 1800))))
+        }
+        for eulerOrder in eulerOrders {
+            for vector in vectors {
+                assertRotation (eulerDegrees: vector, eulerOrder: eulerOrder)
+            }
+        }
+    }
+    
+    func testGetAxisAngle () {
+        var basis: Basis
+        var axis: Vector3
+        let accuracy: Float = 0.0001
+        
+        // Testing the singularity when the angle is 0°.
+        basis = Basis (xAxis: Vector3 (x: 1, y: 0, z: 0), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
+        XCTAssertEqual (basis.getRotationQuaternion ().getAngle (), 0)
+        
+        // Testing the singularity when the angle is 180°.
+        basis = Basis (xAxis: Vector3 (x: -1, y: 0, z: 0), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: 0, y: 0, z: -1))
+        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi, accuracy: accuracy)
+        
+        // Testing reversing the an axis (of an 30° angle).
+        
+        let rad30: Float = Float (30).degreesToRadians
+        let cos30: Float = cos (rad30)
+        
+        basis = Basis (xAxis: Vector3 (x: cos30, y: -0.5, z: 0), yAxis: Vector3 (x: 0.5, y: cos30, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
+        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), rad30, accuracy: accuracy)
+        axis = basis.getRotationQuaternion ().getAxis ()
+        XCTAssertEqual (axis.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (axis.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (axis.z, 1.0, accuracy: accuracy)
+        
+        basis = Basis (xAxis: Vector3 (x: cos30, y: 0.5, z: 0), yAxis: Vector3 (x: -0.5, y: cos30, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
+        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), rad30, accuracy: accuracy)
+        axis = basis.getRotationQuaternion ().getAxis ()
+        XCTAssertEqual (axis.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (axis.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (axis.z, -1.0, accuracy: accuracy)
+        
+        // Testing a rotation of 90° on x-y-z.
+        
+        basis = Basis (xAxis: Vector3 (x: 1, y: 0, z: 0), yAxis: Vector3 (x: 0, y: 0, z: -1), zAxis: Vector3 (x: 0, y: 1, z: 0))
+        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2, accuracy: accuracy)
+        axis = basis.getRotationQuaternion ().getAxis ()
+        XCTAssertEqual (axis.x, 1.0, accuracy: accuracy)
+        XCTAssertEqual (axis.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (axis.z, 0.0, accuracy: accuracy)
+        
+        basis = Basis (xAxis: Vector3 (x: 0, y: 0, z: 1), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: -1, y: 0, z: 0))
+        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2, accuracy: accuracy)
+        axis = basis.getRotationQuaternion ().getAxis ()
+        XCTAssertEqual (axis.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (axis.y, 1.0, accuracy: accuracy)
+        XCTAssertEqual (axis.z, 0.0, accuracy: accuracy)
+        
+        basis = Basis (xAxis: Vector3 (x: 0, y: -1, z: 0), yAxis: Vector3 (x: 1, y: 0, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
+        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), Float.pi / 2, accuracy: accuracy)
+        axis = basis.getRotationQuaternion ().getAxis ()
+        XCTAssertEqual (axis.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (axis.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (axis.z, 1.0, accuracy: accuracy)
+        
+        // Regression test: checks that the method returns a small angle (not 0).
+        // The min angle possible with float is 0.001rad.
+        basis = Basis (xAxis: Vector3 (x: 1, y: 0, z: 0), yAxis: Vector3 (x: 0, y: 0.9999995, z: -0.001), zAxis: Vector3 (x: 0, y: 0.001, z: 0.9999995))
+        XCTAssertEqual (Float (basis.getRotationQuaternion ().getAngle ()), 0.001, accuracy: accuracy)
+        
+        // Regression test: checks that the method returns an angle which is a number (not NaN)
+        basis = Basis (xAxis: Vector3 (x: 1.00000024, y: 0, z: 0.000100001693), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: -0.000100009143, y: 0, z: 1.00000024))
+        XCTAssertFalse (basis.getRotationQuaternion ().getAngle ().isNaN)
+    }
+    
+    func testFiniteNumberChecks () {
+        let x: Vector3 = Vector3 (x: 0, y: 1, z: 2)
+        let infinite: Vector3 = Vector3 (x: .nan, y: .nan, z: .nan)
+
+        XCTAssertTrue (Basis (xAxis: x, yAxis: x, zAxis: x).isFinite (), "Basis with all components finite should be finite")
+        
+        XCTAssertFalse (Basis (xAxis: infinite, yAxis: x, zAxis: x).isFinite (), "Basis with one component infinite should not be finite.")
+        XCTAssertFalse (Basis (xAxis: x, yAxis: infinite, zAxis: x).isFinite (), "Basis with one component infinite should not be finite.")
+        XCTAssertFalse (Basis (xAxis: x, yAxis: x, zAxis: infinite).isFinite (), "Basis with one component infinite should not be finite.")
+
+        XCTAssertFalse (Basis (xAxis: infinite, yAxis: infinite, zAxis: x).isFinite (), "Basis with two components infinite should not be finite.")
+        XCTAssertFalse (Basis (xAxis: infinite, yAxis: x, zAxis: infinite).isFinite (), "Basis with two components infinite should not be finite.")
+        XCTAssertFalse (Basis (xAxis: x, yAxis: infinite, zAxis: infinite).isFinite (), "Basis with two components infinite should not be finite.")
+        
+        XCTAssertFalse (Basis (xAxis: infinite, yAxis: infinite, zAxis: infinite).isFinite (), "Basis with three components infinite should not be finite.")
+    }
+    
+    func testIsConformalChecks () {
+        var basis: Basis
+        
+        basis = Basis ()
+        XCTAssertTrue (basis.isConformal (), "Identity Basis should be conformal.")
+        
+        basis = Basis.fromEuler (euler: Vector3 (x: 1.2, y: 3.4, z: 5.6))
+        XCTAssertTrue (basis.isConformal (), "Basis with only rotation should be conformal.")
+        
+        basis = Basis.fromScale (scale: Vector3 (x: -1, y: -1, z: -1))
+        XCTAssertTrue (basis.isConformal (), "Basis with only a flip should be conformal.")
+        
+        basis = Basis.fromScale (scale: Vector3 (x: 1.2, y: 1.2, z: 1.2))
+        XCTAssertTrue (basis.isConformal (), "Basis with only uniform scale should be conformal.")
+        
+        basis = Basis (xAxis: Vector3 (x: 3, y: 4, z: 0), yAxis: Vector3 (x: 4, y: -3, z: 0.0), zAxis: Vector3 (x: 0, y: 0, z: 5))
+        XCTAssertTrue (basis.isConformal (), "Basis with a flip, rotation, and uniform scale should be conformal.")
+        
+        basis = Basis.fromScale (scale: Vector3 (x: 1.2, y: 3.4, z: 5.6))
+        XCTAssertFalse (basis.isConformal (), "Basis with non-uniform scale should not be conformal.")
+        
+        basis = Basis (xAxis: Vector3 (x: Float (0.5.squareRoot ()), y: Float (0.5.squareRoot ()), z: 0), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))
+        XCTAssertFalse (basis.isConformal (), "Basis with the X axis skewed 45 degrees should not be conformal.")
+    }
+    
+}
+
+extension FloatingPoint {
+    
+    var degreesToRadians: Self { self * .pi / 180 }
+    
+}

--- a/Tests/SwiftGodotEngineTests/Math/BasisTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/BasisTests.swift
@@ -254,9 +254,3 @@ final class BasisTests: GodotTestCase {
     }
     
 }
-
-extension FloatingPoint {
-    
-    var degreesToRadians: Self { self * .pi / 180 }
-    
-}

--- a/Tests/SwiftGodotEngineTests/Math/PlaneTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/PlaneTests.swift
@@ -1,0 +1,109 @@
+// Based on godot/tests/core/math/test_plane.h
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class PlaneTests: GodotTestCase {
+    
+    func testConstructorMethods () {
+        let plane: Plane = Plane (a: 32, b: 22, c: 16, d: 3)
+        let planeVector: Plane  = Plane (normal: Vector3 (x: 32, y: 22, z: 16), d: 3)
+        let planeCopyPlane: Plane = Plane (from: plane)
+        XCTAssertEqual (plane, planeVector, "Planes created with same values but different methods should be equal.")
+        XCTAssertEqual (plane, planeCopyPlane, "Planes created with same values but different methods should be equal.")
+    }
+    
+    func testBasicGetters () {        
+        let plane: Plane = Plane (a: 32, b: 22, c: 16, d: 3)
+        let planeNormalized: Plane = Plane (a: 32.0 / 42, b: 22.0 / 42, c: 16.0 / 42, d: 3.0 / 42)
+        XCTAssertEqual (plane.normal, Vector3 (x: 32, y: 22, z: 16), "normal getter should return the expected value.")
+        XCTAssertEqual (plane.normalized (), planeNormalized, "normalized() should return a copy of the normalized value.")
+    }
+    
+    func testBasicSetters () {
+        var plane: Plane = Plane (a: 32, b: 22, c: 16, d: 3)
+        plane.normal = Vector3 (x: 4, y: 2, z: 3)
+        XCTAssertEqual (plane, Plane (a: 4, b: 2, c: 3, d: 3), "Setting normal should result in the expected plane.")
+        plane = Plane (a: 32, b: 22, c: 16, d: 3).normalized ()
+        XCTAssertEqual (plane, Plane (a: 32.0 / 42, b: 22.0 / 42, c: 16.0 / 42, d: 3.0 / 42), "normalize() should result in the expected plane.")
+    }
+    
+    func testPlanePointOperations () {
+        let plane: Plane = Plane (a: 32, b: 22, c: 16, d: 3)
+        let yFacingPlane: Plane = Plane (a: 0, b: 1, c: 0, d: 4)
+        XCTAssertEqual (plane.getCenter (), Vector3 (x: 32 * 3, y: 22 * 3, z: 16 * 3), "getCenter() should return a vector pointing to the center of the plane.")
+        XCTAssertTrue (yFacingPlane.isPointOver (point: Vector3 (x: 0, y: 5, z: 0)), "isPointOver() should return the expected result.")
+        XCTAssertEqual (yFacingPlane.getAnyPerpendicularNormal (), Vector3 (x: 1, y: 0, z: 0), "getAnyPerpendicularNormal() should return the expected result.")
+    }
+    
+    func testHasPoint () {
+        let xFacingPlane: Plane = Plane (a: 1, b: 0, c: 0, d: 0)
+        let yFacingPlane: Plane = Plane (a: 0, b: 1, c: 0, d: 0)
+        let zFacingPlane: Plane = Plane (a: 0, b: 0, c: 1, d: 0)
+        
+        let xAxisPoint: Vector3 = Vector3 (x: 10, y: 0, z: 0)
+        let yAxisPoint: Vector3 = Vector3 (x: 0, y: 10, z: 0)
+        let zAxisPoint: Vector3 = Vector3 (x: 0, y: 0, z: 10)
+        
+        let xFacingPlaneWithDOffset: Plane = Plane (a: 1, b: 0, c: 0, d: 1)
+        let yXxisPointWithDOffset: Vector3 = Vector3 (x: 1, y: 10, z: 0)
+        
+        XCTAssertTrue (xFacingPlane.hasPoint (point: yAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (xFacingPlane.hasPoint (point: zAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        
+        XCTAssertTrue (yFacingPlane.hasPoint (point: xAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (yFacingPlane.hasPoint (point: zAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        
+        XCTAssertTrue (zFacingPlane.hasPoint (point: yAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (zFacingPlane.hasPoint (point: xAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        
+        XCTAssertTrue (xFacingPlaneWithDOffset.hasPoint (point: yXxisPointWithDOffset), "hasPoint () with passed Vector3 should return the expected result.")
+    }
+    
+    func testIntersection () {
+        let xFacingPlane: Plane = Plane (a: 1, b: 0, c: 0, d: 1)
+        let yFacingPlane: Plane = Plane (a: 0, b: 1, c: 0, d: 2)
+        let zFacingPlane: Plane = Plane (a: 0, b: 0, c: 1, d: 3)
+        
+        var varOut: Variant
+        var vecOut: Vector3?
+        
+        varOut = xFacingPlane.intersect3 (b: yFacingPlane, c: zFacingPlane)
+        vecOut = Vector3 (varOut)
+        XCTAssertEqual (varOut.gtype, .vector3, "intersect3() should return the expected result.")
+        XCTAssertEqual (vecOut, Vector3 (x: 1, y: 2, z: 3), "intersect3() should return the expected result.")
+        
+        varOut = xFacingPlane.intersectsRay (from: Vector3 (x: 0, y: 1, z: 1), dir: Vector3 (x: 2, y: 0, z: 0))
+        vecOut = Vector3 (varOut)
+        XCTAssertEqual (varOut.gtype, .vector3, "intersectsRay() should return the expected result.")
+        XCTAssertEqual (vecOut, Vector3 (x: 1, y: 1, z: 1), "intersectsRay() should return the expected result.")
+        
+        varOut = xFacingPlane.intersectsSegment (from: Vector3 (x: 0, y: 1, z: 1), to: Vector3 (x: 2, y: 1, z: 1))
+        vecOut = Vector3 (varOut)
+        XCTAssertEqual (varOut.gtype, .vector3, "intersectsSegment() should return the expected result.")
+        XCTAssertEqual (vecOut, Vector3 (x: 1, y: 1, z: 1), "intersectsSegment() should return the expected result.")
+    }
+    
+    func testFiniteNumberChecks () {
+        let x: Vector3 = Vector3 (x: 0, y: 1, z: 2)
+        let infinite: Vector3 = Vector3 (x: .nan, y: .nan, z: .nan)
+        XCTAssertTrue (Plane (normal: x, point: .zero).isFinite (), "Plane with all components finite should be finite")
+        XCTAssertFalse (Plane (normal: x, d: .nan).isFinite (), "Plane with one component infinite should not be finite.")
+        XCTAssertFalse (Plane (normal: infinite, d: .zero).isFinite (), "Plane with one component infinite should not be finite.")
+        XCTAssertFalse (Plane (normal: infinite, d: .nan).isFinite (), "Plane with two components infinite should not be finite.")
+    }
+    
+}
+
+extension Plane {
+    
+    func getAnyPerpendicularNormal () -> Vector3 {
+        let p1: Vector3 = SwiftGodot.Vector3 (x: 1, y: 0, z: 0)
+        let p2: Vector3 = Vector3 (x: 0, y: 1, z: 0)
+        var p: Vector3 = normal.dot (with: p1) > 0.99 ? p2 : p1
+        p -= normal * normal.dot (with: p)
+        return p.normalized ()
+    }
+    
+}

--- a/Tests/SwiftGodotEngineTests/Math/QuaternionTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/QuaternionTests.swift
@@ -6,8 +6,6 @@ import SwiftGodotTestability
 
 final class QuaternionTests: GodotTestCase {
     
-    private let accuracy: Float = 0.0001
-    
     func testDefaultConstruct () {
         let q: Quaternion = Quaternion ()
         XCTAssertEqual (q.x, 0)
@@ -30,43 +28,43 @@ final class QuaternionTests: GodotTestCase {
         
         // Easy to visualize: 120 deg about X-axis.
         q = Quaternion (axis: Vector3 (x: 1.0, y: 0.0, z: 0.0), angle: Float (120).degreesToRadians)
-        XCTAssertEqual (q.x, 0.866025, accuracy: accuracy) // Sine of half the angle.
-        XCTAssertEqual (q.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (q.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (q.w, 0.5, accuracy: accuracy) // Cosine of half the angle.
+        assertApproxEqual (q.x, 0.866025) // Sine of half the angle.
+        assertApproxEqual (q.y, 0.0)
+        assertApproxEqual (q.z, 0.0)
+        assertApproxEqual (q.w, 0.5) // Cosine of half the angle.
         
         // Easy to visualize: 30 deg about Y-axis.
         q = Quaternion (axis: Vector3 (x: 0.0, y: 1.0, z: 0.0), angle: Float (30).degreesToRadians)
-        XCTAssertEqual (q.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (q.y, 0.258819, accuracy: accuracy) // Sine of half the angle.
-        XCTAssertEqual (q.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (q.w, 0.965926, accuracy: accuracy) // Cosine of half the angle.
+        assertApproxEqual (q.x, 0.0)
+        assertApproxEqual (q.y, 0.258819) // Sine of half the angle.
+        assertApproxEqual (q.z, 0.0)
+        assertApproxEqual (q.w, 0.965926) // Cosine of half the angle.
         
         // Easy to visualize: 60 deg about Z-axis.
         q = Quaternion (axis: Vector3 (x: 0.0, y: 0.0, z: 1.0), angle: Float (60).degreesToRadians)
-        XCTAssertEqual (q.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (q.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (q.z, 0.5, accuracy: accuracy) // Sine of half the angle.
-        XCTAssertEqual (q.w, 0.866025, accuracy: accuracy) // Cosine of half the angle.
+        assertApproxEqual (q.x, 0.0)
+        assertApproxEqual (q.y, 0.0)
+        assertApproxEqual (q.z, 0.5) // Sine of half the angle.
+        assertApproxEqual (q.w, 0.866025) // Cosine of half the angle.
         
         
         // More complex & hard to visualize, so test w/ data from online calculator.
         let axis: Vector3 = Vector3 (x: 1.0, y: 2.0, z: 0.5)
         q = Quaternion (axis: axis.normalized (), angle: Float (35).degreesToRadians)
-        XCTAssertEqual (q.x, 0.131239, accuracy: accuracy)
-        XCTAssertEqual (q.y, 0.262478, accuracy: accuracy)
-        XCTAssertEqual (q.z, 0.0656194, accuracy: accuracy)
-        XCTAssertEqual (q.w, 0.953717, accuracy: accuracy)
+        assertApproxEqual (q.x, 0.131239)
+        assertApproxEqual (q.y, 0.262478)
+        assertApproxEqual (q.z, 0.0656194)
+        assertApproxEqual (q.w, 0.953717)
     }
     
     func testConstructFromQuaternion () {
         let axis: Vector3 = Vector3 (x: 1.0, y: 2.0, z: 0.5)
         let qSrc: Quaternion = Quaternion (axis: axis.normalized (), angle: Float (35).degreesToRadians)
         let q: Quaternion = Quaternion (from: qSrc)
-        XCTAssertEqual (q.x, 0.131239, accuracy: accuracy)
-        XCTAssertEqual (q.y, 0.262478, accuracy: accuracy)
-        XCTAssertEqual (q.z, 0.0656194, accuracy: accuracy)
-        XCTAssertEqual (q.w, 0.953717, accuracy: accuracy)
+        assertApproxEqual (q.x, 0.131239)
+        assertApproxEqual (q.y, 0.262478)
+        assertApproxEqual (q.z, 0.0656194)
+        assertApproxEqual (q.w, 0.953717)
     }
     
     func testConstructEulerSingleAxis () {
@@ -76,24 +74,24 @@ final class QuaternionTests: GodotTestCase {
 
         let eulerY: Vector3 = Vector3 (x: 0.0, y: yaw, z: 0.0)
         let qY: Quaternion = Quaternion.fromEuler (euler: eulerY)
-        XCTAssertEqual (qY.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qY.y, 0.382684, accuracy: accuracy)
-        XCTAssertEqual (qY.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qY.w, 0.923879, accuracy: accuracy)
+        assertApproxEqual (qY.x, 0.0)
+        assertApproxEqual (qY.y, 0.382684)
+        assertApproxEqual (qY.z, 0.0)
+        assertApproxEqual (qY.w, 0.923879)
         
         let eulerP: Vector3 = Vector3 (x: pitch, y: 0.0, z: 0.0)
         let qP: Quaternion = Quaternion.fromEuler (euler: eulerP)
-        XCTAssertEqual (qP.x, 0.258819, accuracy: accuracy)
-        XCTAssertEqual (qP.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qP.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qP.w, 0.965926, accuracy: accuracy)
+        assertApproxEqual (qP.x, 0.258819)
+        assertApproxEqual (qP.y, 0.0)
+        assertApproxEqual (qP.z, 0.0)
+        assertApproxEqual (qP.w, 0.965926)
         
         let eulerR: Vector3 = Vector3 (x: 0.0, y: 0.0, z: roll)
         let qR: Quaternion = Quaternion.fromEuler (euler: eulerR)
-        XCTAssertEqual (qR.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qR.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qR.z, 0.0871558, accuracy: accuracy)
-        XCTAssertEqual (qR.w, 0.996195, accuracy: accuracy)
+        assertApproxEqual (qR.x, 0.0)
+        assertApproxEqual (qR.y, 0.0)
+        assertApproxEqual (qR.z, 0.0871558)
+        assertApproxEqual (qR.w, 0.996195)
     }
     
     func testConstructEulerYXZDynamicAxes () {
@@ -117,10 +115,7 @@ final class QuaternionTests: GodotTestCase {
         // Test construction from YXZ Euler angles.
         let eulerYxz: Vector3 = Vector3 (x: pitch, y: yaw, z: roll)
         let q: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
-        XCTAssertEqual (q.x, checkYxz.x, accuracy: accuracy)
-        XCTAssertEqual (q.y, checkYxz.y, accuracy: accuracy)
-        XCTAssertEqual (q.z, checkYxz.z, accuracy: accuracy)
-        XCTAssertEqual (q.w, checkYxz.w, accuracy: accuracy)
+        assertApproxEqual (q, checkYxz)
     }
     
     func testConstructBasisEuler () {
@@ -131,10 +126,7 @@ final class QuaternionTests: GodotTestCase {
         let qYxz: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
         let basisAxes: Basis = Basis.fromEuler (euler: eulerYxz)
         let q: Quaternion = basisAxes.getRotationQuaternion ()
-        XCTAssertEqual (q.x, qYxz.x, accuracy: accuracy)
-        XCTAssertEqual (q.y, qYxz.y, accuracy: accuracy)
-        XCTAssertEqual (q.z, qYxz.z, accuracy: accuracy)
-        XCTAssertEqual (q.w, qYxz.w, accuracy: accuracy)
+        assertApproxEqual (q, qYxz)
     }
     
     func testConstructBasisAxes () {
@@ -166,14 +158,8 @@ final class QuaternionTests: GodotTestCase {
         let qLocal: Quaternion = quatEulerYxzDeg (angle: Vector3 (x: 31.41, y: -49.16, z: 12.34))
         // Quaternion from Euler angles constructor.
         let qEuler: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
-        XCTAssertEqual (qCalc.x, qLocal.x, accuracy: accuracy)
-        XCTAssertEqual (qCalc.y, qLocal.y, accuracy: accuracy)
-        XCTAssertEqual (qCalc.z, qLocal.z, accuracy: accuracy)
-        XCTAssertEqual (qCalc.w, qLocal.w, accuracy: accuracy)
-        XCTAssertEqual (qLocal.x, qEuler.x, accuracy: accuracy)
-        XCTAssertEqual (qLocal.y, qEuler.y, accuracy: accuracy)
-        XCTAssertEqual (qLocal.z, qEuler.z, accuracy: accuracy)
-        XCTAssertEqual (qLocal.w, qEuler.w, accuracy: accuracy)
+        assertApproxEqual (qCalc, qLocal)
+        assertApproxEqual (qLocal, qEuler)
 
         // Calculate Basis and construct Quaternion.
         // When this is written, C++ Basis class does not construct from basis vectors.
@@ -182,32 +168,23 @@ final class QuaternionTests: GodotTestCase {
         // basis_axes = Basis (i_unit, j_unit, k_unit);
         let basisAxes: Basis = Basis.fromEuler (euler: eulerYxz)
         let q: Quaternion = basisAxes.getRotationQuaternion ()
-        XCTAssertEqual (basisAxes.x.x, iUnit.x, accuracy: accuracy)
-        XCTAssertEqual (basisAxes.y.x, iUnit.y, accuracy: accuracy)
-        XCTAssertEqual (basisAxes.z.x, iUnit.z, accuracy: accuracy)
-        XCTAssertEqual (basisAxes.x.y, jUnit.x, accuracy: accuracy)
-        XCTAssertEqual (basisAxes.y.y, jUnit.y, accuracy: accuracy)
-        XCTAssertEqual (basisAxes.z.y, jUnit.z, accuracy: accuracy)
-        XCTAssertEqual (basisAxes.x.z, kUnit.x, accuracy: accuracy)
-        XCTAssertEqual (basisAxes.y.z, kUnit.y, accuracy: accuracy)
-        XCTAssertEqual (basisAxes.z.z, kUnit.z, accuracy: accuracy)
+        assertApproxEqual (basisAxes.x.x, iUnit.x)
+        assertApproxEqual (basisAxes.y.x, iUnit.y)
+        assertApproxEqual (basisAxes.z.x, iUnit.z)
+        assertApproxEqual (basisAxes.x.y, jUnit.x)
+        assertApproxEqual (basisAxes.y.y, jUnit.y)
+        assertApproxEqual (basisAxes.z.y, jUnit.z)
+        assertApproxEqual (basisAxes.x.z, kUnit.x)
+        assertApproxEqual (basisAxes.y.z, kUnit.y)
+        assertApproxEqual (basisAxes.z.z, kUnit.z)
         
-        XCTAssertEqual (q.x, qCalc.x, accuracy: accuracy)
-        XCTAssertEqual (q.y, qCalc.y, accuracy: accuracy)
-        XCTAssertEqual (q.z, qCalc.z, accuracy: accuracy)
-        XCTAssertEqual (q.w, qCalc.w, accuracy: accuracy)
-        XCTAssertEqual (q.x, qLocal.x, accuracy: accuracy)
-        XCTAssertEqual (q.y, qLocal.y, accuracy: accuracy)
-        XCTAssertEqual (q.z, qLocal.z, accuracy: accuracy)
-        XCTAssertEqual (q.w, qLocal.w, accuracy: accuracy)
-        XCTAssertEqual (q.x, qEuler.x, accuracy: accuracy)
-        XCTAssertEqual (q.y, qEuler.y, accuracy: accuracy)
-        XCTAssertEqual (q.z, qEuler.z, accuracy: accuracy)
-        XCTAssertEqual (q.w, qEuler.w, accuracy: accuracy)
-        XCTAssertEqual (q.x, 0.2016913, accuracy: accuracy)
-        XCTAssertEqual (q.y, -0.4245716, accuracy: accuracy)
-        XCTAssertEqual (q.z, 0.206033, accuracy: accuracy)
-        XCTAssertEqual (q.w, 0.8582598, accuracy: accuracy)
+        assertApproxEqual (q, qCalc)
+        assertApproxEqual (q, qLocal)
+        assertApproxEqual (q, qEuler)
+        assertApproxEqual (q.x, 0.2016913)
+        assertApproxEqual (q.y, -0.4245716)
+        assertApproxEqual (q.z, 0.206033)
+        assertApproxEqual (q.w, 0.8582598)
     }
     
     func testGetEulerOrders () {
@@ -220,13 +197,13 @@ final class QuaternionTests: GodotTestCase {
             let basis: Basis = Basis.fromEuler (euler: euler, order: order)
             let q: Quaternion = basis.getRotationQuaternion ()
             let check: Vector3 = q.getEuler (order: order)
-            XCTAssertEqual (check.x, euler.x, accuracy: accuracy, "Quaternion getEuler() method should return the original angles.")
-            XCTAssertEqual (check.y, euler.y, accuracy: accuracy, "Quaternion getEuler() method should return the original angles.")
-            XCTAssertEqual (check.z, euler.z, accuracy: accuracy, "Quaternion getEuler() method should return the original angles.")
+            assertApproxEqual (check.x, euler.x, "Quaternion getEuler() method should return the original angles.")
+            assertApproxEqual (check.y, euler.y, "Quaternion getEuler() method should return the original angles.")
+            assertApproxEqual (check.z, euler.z, "Quaternion getEuler() method should return the original angles.")
             let basisEuler: Vector3 = basis.getEuler (order: order)
-            XCTAssertEqual (check.x, basisEuler.x, accuracy: accuracy, "Quaternion getEuler() method should behave the same as Basis get_euler.")
-            XCTAssertEqual (check.y, basisEuler.y, accuracy: accuracy, "Quaternion getEuler() method should behave the same as Basis get_euler.")
-            XCTAssertEqual (check.z, basisEuler.z, accuracy: accuracy, "Quaternion getEuler() method should behave the same as Basis get_euler.")
+            assertApproxEqual (check.x, basisEuler.x, "Quaternion getEuler() method should behave the same as Basis get_euler.")
+            assertApproxEqual (check.y, basisEuler.y, "Quaternion getEuler() method should behave the same as Basis get_euler.")
+            assertApproxEqual (check.z, basisEuler.z, "Quaternion getEuler() method should behave the same as Basis get_euler.")
         }
     }
     
@@ -235,10 +212,10 @@ final class QuaternionTests: GodotTestCase {
         let p: Quaternion = Quaternion (x: 1.0, y: -2.0, z: 1.0, w: 3.0)
         let q: Quaternion = Quaternion (x: -1.0, y: 2.0, z: 3.0, w: 2.0)
         let pq: Quaternion = p * q
-        XCTAssertEqual (pq.x, -9.0, accuracy: accuracy)
-        XCTAssertEqual (pq.y, -2.0, accuracy: accuracy)
-        XCTAssertEqual (pq.z, 11.0, accuracy: accuracy)
-        XCTAssertEqual (pq.w, 8.0, accuracy: accuracy)
+        assertApproxEqual (pq.x, -9.0)
+        assertApproxEqual (pq.y, -2.0)
+        assertApproxEqual (pq.z, 11.0)
+        assertApproxEqual (pq.w, 8.0)
     }
     
     func testProduct () {
@@ -248,39 +225,39 @@ final class QuaternionTests: GodotTestCase {
         
         let eulerY: Vector3 = Vector3 (x: 0.0, y: yaw, z: 0.0)
         let qY: Quaternion = Quaternion.fromEuler (euler: eulerY)
-        XCTAssertEqual (qY.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qY.y, 0.382684, accuracy: accuracy)
-        XCTAssertEqual (qY.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qY.w, 0.923879, accuracy: accuracy)
+        assertApproxEqual (qY.x, 0.0)
+        assertApproxEqual (qY.y, 0.382684)
+        assertApproxEqual (qY.z, 0.0)
+        assertApproxEqual (qY.w, 0.923879)
         
         let eulerP: Vector3 = Vector3 (x: pitch, y: 0.0, z: 0.0)
         let qP: Quaternion = Quaternion.fromEuler (euler: eulerP)
-        XCTAssertEqual (qP.x, 0.258819, accuracy: accuracy)
-        XCTAssertEqual (qP.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qP.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qP.w, 0.965926, accuracy: accuracy)
+        assertApproxEqual (qP.x, 0.258819)
+        assertApproxEqual (qP.y, 0.0)
+        assertApproxEqual (qP.z, 0.0)
+        assertApproxEqual (qP.w, 0.965926)
         
         let eulerR: Vector3 = Vector3 (x: 0.0, y: 0.0, z: roll)
         let qR: Quaternion = Quaternion.fromEuler (euler: eulerR)
-        XCTAssertEqual (qR.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qR.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (qR.z, 0.0871558, accuracy: accuracy)
-        XCTAssertEqual (qR.w, 0.996195, accuracy: accuracy)
+        assertApproxEqual (qR.x, 0.0)
+        assertApproxEqual (qR.y, 0.0)
+        assertApproxEqual (qR.z, 0.0871558)
+        assertApproxEqual (qR.w, 0.996195)
 
         // Test ZYX dynamic-axes since test data is available online.
         // Rotate first about X axis, then new Y axis, then new Z axis.
         // (Godot uses YXZ Yaw-Pitch-Roll order).
         let qYP: Quaternion = qY * qP
-        XCTAssertEqual (qYP.x, 0.239118, accuracy: accuracy)
-        XCTAssertEqual (qYP.y, 0.369644, accuracy: accuracy)
-        XCTAssertEqual (qYP.z, -0.099046, accuracy: accuracy)
-        XCTAssertEqual (qYP.w, 0.892399, accuracy: accuracy)
+        assertApproxEqual (qYP.x, 0.239118)
+        assertApproxEqual (qYP.y, 0.369644)
+        assertApproxEqual (qYP.z, -0.099046)
+        assertApproxEqual (qYP.w, 0.892399)
         
         let qRYP: Quaternion = qR * qYP
-        XCTAssertEqual (qRYP.x, 0.205991, accuracy: accuracy)
-        XCTAssertEqual (qRYP.y, 0.389078, accuracy: accuracy)
-        XCTAssertEqual (qRYP.z, -0.0208912, accuracy: accuracy)
-        XCTAssertEqual (qRYP.w, 0.897636, accuracy: accuracy)
+        assertApproxEqual (qRYP.x, 0.205991)
+        assertApproxEqual (qRYP.y, 0.389078)
+        assertApproxEqual (qRYP.z, -0.0208912)
+        assertApproxEqual (qRYP.w, 0.897636)
     }
     
     func testXformUnitVectors () {
@@ -291,15 +268,15 @@ final class QuaternionTests: GodotTestCase {
         var jT: Vector3 = q * Vector3 (x: 0.0, y: 1.0, z: 0.0)
         var kT: Vector3 = q * Vector3 (x: 0.0, y: 0.0, z: 1.0)
         
-        XCTAssertEqual (iT.x, 1.0, accuracy: accuracy)
-        XCTAssertEqual (iT.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (iT.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (jT.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (jT.y, -0.5, accuracy: accuracy)
-        XCTAssertEqual (jT.z, 0.866025, accuracy: accuracy)
-        XCTAssertEqual (kT.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (kT.y, -0.866025, accuracy: accuracy)
-        XCTAssertEqual (kT.z, -0.5, accuracy: accuracy)
+        assertApproxEqual (iT.x, 1.0)
+        assertApproxEqual (iT.y, 0.0)
+        assertApproxEqual (iT.z, 0.0)
+        assertApproxEqual (jT.x, 0.0)
+        assertApproxEqual (jT.y, -0.5)
+        assertApproxEqual (jT.z, 0.866025)
+        assertApproxEqual (kT.x, 0.0)
+        assertApproxEqual (kT.y, -0.866025)
+        assertApproxEqual (kT.z, -0.5)
         XCTAssertEqual (iT.length (), 1)
         XCTAssertEqual (jT.length (), 1)
         XCTAssertEqual (kT.length (), 1)
@@ -310,15 +287,15 @@ final class QuaternionTests: GodotTestCase {
         jT = q * Vector3 (x: 0.0, y: 1.0, z: 0.0)
         kT = q * Vector3 (x: 0.0, y: 0.0, z: 1.0)
         
-        XCTAssertEqual (iT.x, 0.866025, accuracy: accuracy)
-        XCTAssertEqual (iT.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (iT.z, -0.5, accuracy: accuracy)
-        XCTAssertEqual (jT.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (jT.y, 1.0, accuracy: accuracy)
-        XCTAssertEqual (jT.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (kT.x, 0.5, accuracy: accuracy)
-        XCTAssertEqual (kT.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (kT.z, 0.866025, accuracy: accuracy)
+        assertApproxEqual (iT.x, 0.866025)
+        assertApproxEqual (iT.y, 0.0)
+        assertApproxEqual (iT.z, -0.5)
+        assertApproxEqual (jT.x, 0.0)
+        assertApproxEqual (jT.y, 1.0)
+        assertApproxEqual (jT.z, 0.0)
+        assertApproxEqual (kT.x, 0.5)
+        assertApproxEqual (kT.y, 0.0)
+        assertApproxEqual (kT.z, 0.866025)
         XCTAssertEqual (iT.length (), 1)
         XCTAssertEqual (jT.length (), 1)
         XCTAssertEqual (kT.length (), 1)
@@ -329,15 +306,15 @@ final class QuaternionTests: GodotTestCase {
         jT = q * Vector3 (x: 0.0, y: 1.0, z: 0.0)
         kT = q * Vector3 (x: 0.0, y: 0.0, z: 1.0)
         
-        XCTAssertEqual (iT.x, 0.5, accuracy: accuracy)
-        XCTAssertEqual (iT.y, 0.866025, accuracy: accuracy)
-        XCTAssertEqual (iT.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (jT.x, -0.866025, accuracy: accuracy)
-        XCTAssertEqual (jT.y, 0.5, accuracy: accuracy)
-        XCTAssertEqual (jT.z, 0.0, accuracy: accuracy)
-        XCTAssertEqual (kT.x, 0.0, accuracy: accuracy)
-        XCTAssertEqual (kT.y, 0.0, accuracy: accuracy)
-        XCTAssertEqual (kT.z, 1.0, accuracy: accuracy)
+        assertApproxEqual (iT.x, 0.5)
+        assertApproxEqual (iT.y, 0.866025)
+        assertApproxEqual (iT.z, 0.0)
+        assertApproxEqual (jT.x, -0.866025)
+        assertApproxEqual (jT.y, 0.5)
+        assertApproxEqual (jT.z, 0.0)
+        assertApproxEqual (kT.x, 0.0)
+        assertApproxEqual (kT.y, 0.0)
+        assertApproxEqual (kT.z, 1.0)
         XCTAssertEqual (iT.length (), 1)
         XCTAssertEqual (jT.length (), 1)
         XCTAssertEqual (kT.length (), 1)
@@ -353,10 +330,8 @@ final class QuaternionTests: GodotTestCase {
         let vRot: Vector3 = q * vArb
         let vCompare: Vector3 = basisAxes * vArb
         
-        XCTAssertEqual (vRot.lengthSquared (), vArb.lengthSquared (), accuracy: Double (accuracy))
-        XCTAssertEqual (vRot.x, vCompare.x, accuracy: accuracy)
-        XCTAssertEqual (vRot.y, vCompare.y, accuracy: accuracy)
-        XCTAssertEqual (vRot.z, vCompare.z, accuracy: accuracy)
+        assertApproxEqual (vRot.lengthSquared (), vArb.lengthSquared ())
+        assertApproxEqual (vRot, vCompare)
     }
     
     func testManyVectorXforms () {
@@ -368,10 +343,8 @@ final class QuaternionTests: GodotTestCase {
             let vRot: Vector3 = q * vIn
             let vCompare: Vector3 = basisAxes * vIn
             
-            XCTAssertEqual (vRot.lengthSquared (), vIn.lengthSquared (), accuracy: Double (accuracy))
-            XCTAssertEqual (vRot.x, vCompare.x, accuracy: accuracy)
-            XCTAssertEqual (vRot.y, vCompare.y, accuracy: accuracy)
-            XCTAssertEqual (vRot.z, vCompare.z, accuracy: accuracy)
+            assertApproxEqual (vRot.lengthSquared (), vIn.lengthSquared ())
+            assertApproxEqual (vRot, vCompare)
         }
         
         // Many arbitrary quaternions rotate many arbitrary vectors.

--- a/Tests/SwiftGodotEngineTests/Math/QuaternionTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/QuaternionTests.swift
@@ -1,0 +1,428 @@
+// Based on godot/tests/core/math/test_quaternion.h
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class QuaternionTests: GodotTestCase {
+    
+    private let accuracy: Float = 0.0001
+    
+    func testDefaultConstruct () {
+        let q: Quaternion = Quaternion ()
+        XCTAssertEqual (q.x, 0)
+        XCTAssertEqual (q.y, 0)
+        XCTAssertEqual (q.z, 0)
+        XCTAssertEqual (q.w, 1)
+    }
+    
+    func testConstructXYZW () {
+        // Values are taken from actual use in another project & are valid (except roundoff error).
+        let q = Quaternion (x: 0.2391, y: 0.099, z: 0.3696, w: 0.8924)
+        XCTAssertEqual (q.x, 0.2391)
+        XCTAssertEqual (q.y, 0.099)
+        XCTAssertEqual (q.z, 0.3696)
+        XCTAssertEqual (q.w, 0.8924)
+    }
+    
+    func testConstructAxisAngle () {
+        var q: Quaternion
+        
+        // Easy to visualize: 120 deg about X-axis.
+        q = Quaternion (axis: Vector3 (x: 1.0, y: 0.0, z: 0.0), angle: Float (120).degreesToRadians)
+        XCTAssertEqual (q.x, 0.866025, accuracy: accuracy) // Sine of half the angle.
+        XCTAssertEqual (q.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (q.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (q.w, 0.5, accuracy: accuracy) // Cosine of half the angle.
+        
+        // Easy to visualize: 30 deg about Y-axis.
+        q = Quaternion (axis: Vector3 (x: 0.0, y: 1.0, z: 0.0), angle: Float (30).degreesToRadians)
+        XCTAssertEqual (q.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (q.y, 0.258819, accuracy: accuracy) // Sine of half the angle.
+        XCTAssertEqual (q.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (q.w, 0.965926, accuracy: accuracy) // Cosine of half the angle.
+        
+        // Easy to visualize: 60 deg about Z-axis.
+        q = Quaternion (axis: Vector3 (x: 0.0, y: 0.0, z: 1.0), angle: Float (60).degreesToRadians)
+        XCTAssertEqual (q.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (q.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (q.z, 0.5, accuracy: accuracy) // Sine of half the angle.
+        XCTAssertEqual (q.w, 0.866025, accuracy: accuracy) // Cosine of half the angle.
+        
+        
+        // More complex & hard to visualize, so test w/ data from online calculator.
+        let axis: Vector3 = Vector3 (x: 1.0, y: 2.0, z: 0.5)
+        q = Quaternion (axis: axis.normalized (), angle: Float (35).degreesToRadians)
+        XCTAssertEqual (q.x, 0.131239, accuracy: accuracy)
+        XCTAssertEqual (q.y, 0.262478, accuracy: accuracy)
+        XCTAssertEqual (q.z, 0.0656194, accuracy: accuracy)
+        XCTAssertEqual (q.w, 0.953717, accuracy: accuracy)
+    }
+    
+    func testConstructFromQuaternion () {
+        let axis: Vector3 = Vector3 (x: 1.0, y: 2.0, z: 0.5)
+        let qSrc: Quaternion = Quaternion (axis: axis.normalized (), angle: Float (35).degreesToRadians)
+        let q: Quaternion = Quaternion (from: qSrc)
+        XCTAssertEqual (q.x, 0.131239, accuracy: accuracy)
+        XCTAssertEqual (q.y, 0.262478, accuracy: accuracy)
+        XCTAssertEqual (q.z, 0.0656194, accuracy: accuracy)
+        XCTAssertEqual (q.w, 0.953717, accuracy: accuracy)
+    }
+    
+    func testConstructEulerSingleAxis () {
+        let yaw: Float = Float (45.0).degreesToRadians
+        let pitch: Float = Float (30.0).degreesToRadians
+        let roll: Float = Float (10.0).degreesToRadians
+
+        let eulerY: Vector3 = Vector3 (x: 0.0, y: yaw, z: 0.0)
+        let qY: Quaternion = Quaternion.fromEuler (euler: eulerY)
+        XCTAssertEqual (qY.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qY.y, 0.382684, accuracy: accuracy)
+        XCTAssertEqual (qY.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qY.w, 0.923879, accuracy: accuracy)
+        
+        let eulerP: Vector3 = Vector3 (x: pitch, y: 0.0, z: 0.0)
+        let qP: Quaternion = Quaternion.fromEuler (euler: eulerP)
+        XCTAssertEqual (qP.x, 0.258819, accuracy: accuracy)
+        XCTAssertEqual (qP.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qP.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qP.w, 0.965926, accuracy: accuracy)
+        
+        let eulerR: Vector3 = Vector3 (x: 0.0, y: 0.0, z: roll)
+        let qR: Quaternion = Quaternion.fromEuler (euler: eulerR)
+        XCTAssertEqual (qR.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qR.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qR.z, 0.0871558, accuracy: accuracy)
+        XCTAssertEqual (qR.w, 0.996195, accuracy: accuracy)
+    }
+    
+    func testConstructEulerYXZDynamicAxes () {
+        let yaw: Float = Float (45.0).degreesToRadians
+        let pitch: Float = Float (30.0).degreesToRadians
+        let roll: Float = Float (10.0).degreesToRadians
+
+        // Generate YXZ comparison data (Z-then-X-then-Y) using single-axis Euler
+        // constructor and quaternion product, both tested separately.
+        let eulerY: Vector3 = Vector3 (x: 0.0, y: yaw, z: 0.0)
+        let qY: Quaternion = Quaternion.fromEuler (euler: eulerY)
+        let eulerP: Vector3 = Vector3 (x: pitch, y: 0.0, z: 0.0)
+        let qP: Quaternion = Quaternion.fromEuler (euler: eulerP)
+        let eulerR: Vector3 = Vector3 (x: 0.0, y: 0.0, z: roll)
+        let qR: Quaternion = Quaternion.fromEuler (euler: eulerR)
+
+        // Instrinsically, Yaw-Y then Pitch-X then Roll-Z.
+        // Extrinsically, Roll-Z is followed by Pitch-X, then Yaw-Y.
+        let checkYxz: Quaternion = qY * qP * qR
+
+        // Test construction from YXZ Euler angles.
+        let eulerYxz: Vector3 = Vector3 (x: pitch, y: yaw, z: roll)
+        let q: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
+        XCTAssertEqual (q.x, checkYxz.x, accuracy: accuracy)
+        XCTAssertEqual (q.y, checkYxz.y, accuracy: accuracy)
+        XCTAssertEqual (q.z, checkYxz.z, accuracy: accuracy)
+        XCTAssertEqual (q.w, checkYxz.w, accuracy: accuracy)
+    }
+    
+    func testConstructBasisEuler () {
+        let yaw: Float = Float (45.0).degreesToRadians
+        let pitch: Float = Float (30.0).degreesToRadians
+        let roll: Float = Float (10.0).degreesToRadians
+        let eulerYxz: Vector3 = Vector3 (x: pitch, y: yaw, z: roll)
+        let qYxz: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
+        let basisAxes: Basis = Basis.fromEuler (euler: eulerYxz)
+        let q: Quaternion = basisAxes.getRotationQuaternion ()
+        XCTAssertEqual (q.x, qYxz.x, accuracy: accuracy)
+        XCTAssertEqual (q.y, qYxz.y, accuracy: accuracy)
+        XCTAssertEqual (q.z, qYxz.z, accuracy: accuracy)
+        XCTAssertEqual (q.w, qYxz.w, accuracy: accuracy)
+    }
+    
+    func testConstructBasisAxes () {
+        func quatEulerYxzDeg (angle: Vector3) -> Quaternion {
+            let yaw: Float = angle.y.degreesToRadians
+            let pitch: Float = angle.x.degreesToRadians
+            let roll: Float = angle.z.degreesToRadians
+
+            // Generate YXZ (Z-then-X-then-Y) Quaternion using single-axis Euler
+            // constructor and quaternion product, both tested separately.
+            let qY: Quaternion = Quaternion.fromEuler (euler: Vector3 (x: 0.0, y: yaw, z: 0.0))
+            let qP: Quaternion = Quaternion.fromEuler (euler: Vector3 (x: pitch, y: 0.0, z: 0.0))
+            let qR: Quaternion = Quaternion.fromEuler (euler: Vector3 (x: 0.0, y: 0.0, z: roll))
+            // Roll-Z is followed by Pitch-X, then Yaw-Y.
+            let qYxz: Quaternion = qY * qP * qR
+
+            return qYxz
+        }
+        // Arbitrary Euler angles.
+        let eulerYxz: Vector3 = Vector3 (x: Float (31.41).degreesToRadians, y: Float (-49.16).degreesToRadians, z: Float (12.34).degreesToRadians)
+        // Basis vectors from online calculation of rotation matrix.
+        let iUnit: Vector3 = Vector3 (x: 0.5545787, y: 0.1823950, z: 0.8118957)
+        let jUnit: Vector3 = Vector3 (x: -0.5249245, y: 0.8337420, z: 0.1712555)
+        let kUnit: Vector3 = Vector3 (x: -0.6456754, y: -0.5211586, z: 0.5581192)
+        
+        // Quaternion from online calculation.
+        let qCalc: Quaternion = Quaternion (x: 0.2016913, y: -0.4245716, z: 0.206033, w: 0.8582598)
+        // Quaternion from local calculation.
+        let qLocal: Quaternion = quatEulerYxzDeg (angle: Vector3 (x: 31.41, y: -49.16, z: 12.34))
+        // Quaternion from Euler angles constructor.
+        let qEuler: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
+        XCTAssertEqual (qCalc.x, qLocal.x, accuracy: accuracy)
+        XCTAssertEqual (qCalc.y, qLocal.y, accuracy: accuracy)
+        XCTAssertEqual (qCalc.z, qLocal.z, accuracy: accuracy)
+        XCTAssertEqual (qCalc.w, qLocal.w, accuracy: accuracy)
+        XCTAssertEqual (qLocal.x, qEuler.x, accuracy: accuracy)
+        XCTAssertEqual (qLocal.y, qEuler.y, accuracy: accuracy)
+        XCTAssertEqual (qLocal.z, qEuler.z, accuracy: accuracy)
+        XCTAssertEqual (qLocal.w, qEuler.w, accuracy: accuracy)
+
+        // Calculate Basis and construct Quaternion.
+        // When this is written, C++ Basis class does not construct from basis vectors.
+        // This is by design, but may be subject to change.
+        // Workaround by constructing Basis from Euler angles.
+        // basis_axes = Basis (i_unit, j_unit, k_unit);
+        let basisAxes: Basis = Basis.fromEuler (euler: eulerYxz)
+        let q: Quaternion = basisAxes.getRotationQuaternion ()
+        XCTAssertEqual (basisAxes.x.x, iUnit.x, accuracy: accuracy)
+        XCTAssertEqual (basisAxes.y.x, iUnit.y, accuracy: accuracy)
+        XCTAssertEqual (basisAxes.z.x, iUnit.z, accuracy: accuracy)
+        XCTAssertEqual (basisAxes.x.y, jUnit.x, accuracy: accuracy)
+        XCTAssertEqual (basisAxes.y.y, jUnit.y, accuracy: accuracy)
+        XCTAssertEqual (basisAxes.z.y, jUnit.z, accuracy: accuracy)
+        XCTAssertEqual (basisAxes.x.z, kUnit.x, accuracy: accuracy)
+        XCTAssertEqual (basisAxes.y.z, kUnit.y, accuracy: accuracy)
+        XCTAssertEqual (basisAxes.z.z, kUnit.z, accuracy: accuracy)
+        
+        XCTAssertEqual (q.x, qCalc.x, accuracy: accuracy)
+        XCTAssertEqual (q.y, qCalc.y, accuracy: accuracy)
+        XCTAssertEqual (q.z, qCalc.z, accuracy: accuracy)
+        XCTAssertEqual (q.w, qCalc.w, accuracy: accuracy)
+        XCTAssertEqual (q.x, qLocal.x, accuracy: accuracy)
+        XCTAssertEqual (q.y, qLocal.y, accuracy: accuracy)
+        XCTAssertEqual (q.z, qLocal.z, accuracy: accuracy)
+        XCTAssertEqual (q.w, qLocal.w, accuracy: accuracy)
+        XCTAssertEqual (q.x, qEuler.x, accuracy: accuracy)
+        XCTAssertEqual (q.y, qEuler.y, accuracy: accuracy)
+        XCTAssertEqual (q.z, qEuler.z, accuracy: accuracy)
+        XCTAssertEqual (q.w, qEuler.w, accuracy: accuracy)
+        XCTAssertEqual (q.x, 0.2016913, accuracy: accuracy)
+        XCTAssertEqual (q.y, -0.4245716, accuracy: accuracy)
+        XCTAssertEqual (q.z, 0.206033, accuracy: accuracy)
+        XCTAssertEqual (q.w, 0.8582598, accuracy: accuracy)
+    }
+    
+    func testGetEulerOrders () {
+        let x: Float = Float (45.0).degreesToRadians
+        let y: Float = Float (30.0).degreesToRadians
+        let z: Float = Float (10.0).degreesToRadians
+        let euler: Vector3 = Vector3 (x: x, y: y, z: z)
+        
+        for order: Int64 in 0..<6 {
+            let basis: Basis = Basis.fromEuler (euler: euler, order: order)
+            let q: Quaternion = basis.getRotationQuaternion ()
+            let check: Vector3 = q.getEuler (order: order)
+            XCTAssertEqual (check.x, euler.x, accuracy: accuracy, "Quaternion getEuler() method should return the original angles.")
+            XCTAssertEqual (check.y, euler.y, accuracy: accuracy, "Quaternion getEuler() method should return the original angles.")
+            XCTAssertEqual (check.z, euler.z, accuracy: accuracy, "Quaternion getEuler() method should return the original angles.")
+            let basisEuler: Vector3 = basis.getEuler (order: order)
+            XCTAssertEqual (check.x, basisEuler.x, accuracy: accuracy, "Quaternion getEuler() method should behave the same as Basis get_euler.")
+            XCTAssertEqual (check.y, basisEuler.y, accuracy: accuracy, "Quaternion getEuler() method should behave the same as Basis get_euler.")
+            XCTAssertEqual (check.z, basisEuler.z, accuracy: accuracy, "Quaternion getEuler() method should behave the same as Basis get_euler.")
+        }
+    }
+    
+    func testProductBook () {
+        // Example from "Quaternions and Rotation Sequences" by Jack Kuipers, p. 108.
+        let p: Quaternion = Quaternion (x: 1.0, y: -2.0, z: 1.0, w: 3.0)
+        let q: Quaternion = Quaternion (x: -1.0, y: 2.0, z: 3.0, w: 2.0)
+        let pq: Quaternion = p * q
+        XCTAssertEqual (pq.x, -9.0, accuracy: accuracy)
+        XCTAssertEqual (pq.y, -2.0, accuracy: accuracy)
+        XCTAssertEqual (pq.z, 11.0, accuracy: accuracy)
+        XCTAssertEqual (pq.w, 8.0, accuracy: accuracy)
+    }
+    
+    func testProduct () {
+        let yaw: Float = Float (45.0).degreesToRadians
+        let pitch: Float = Float (30.0).degreesToRadians
+        let roll: Float = Float (10.0).degreesToRadians
+        
+        let eulerY: Vector3 = Vector3 (x: 0.0, y: yaw, z: 0.0)
+        let qY: Quaternion = Quaternion.fromEuler (euler: eulerY)
+        XCTAssertEqual (qY.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qY.y, 0.382684, accuracy: accuracy)
+        XCTAssertEqual (qY.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qY.w, 0.923879, accuracy: accuracy)
+        
+        let eulerP: Vector3 = Vector3 (x: pitch, y: 0.0, z: 0.0)
+        let qP: Quaternion = Quaternion.fromEuler (euler: eulerP)
+        XCTAssertEqual (qP.x, 0.258819, accuracy: accuracy)
+        XCTAssertEqual (qP.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qP.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qP.w, 0.965926, accuracy: accuracy)
+        
+        let eulerR: Vector3 = Vector3 (x: 0.0, y: 0.0, z: roll)
+        let qR: Quaternion = Quaternion.fromEuler (euler: eulerR)
+        XCTAssertEqual (qR.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qR.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (qR.z, 0.0871558, accuracy: accuracy)
+        XCTAssertEqual (qR.w, 0.996195, accuracy: accuracy)
+
+        // Test ZYX dynamic-axes since test data is available online.
+        // Rotate first about X axis, then new Y axis, then new Z axis.
+        // (Godot uses YXZ Yaw-Pitch-Roll order).
+        let qYP: Quaternion = qY * qP
+        XCTAssertEqual (qYP.x, 0.239118, accuracy: accuracy)
+        XCTAssertEqual (qYP.y, 0.369644, accuracy: accuracy)
+        XCTAssertEqual (qYP.z, -0.099046, accuracy: accuracy)
+        XCTAssertEqual (qYP.w, 0.892399, accuracy: accuracy)
+        
+        let qRYP: Quaternion = qR * qYP
+        XCTAssertEqual (qRYP.x, 0.205991, accuracy: accuracy)
+        XCTAssertEqual (qRYP.y, 0.389078, accuracy: accuracy)
+        XCTAssertEqual (qRYP.z, -0.0208912, accuracy: accuracy)
+        XCTAssertEqual (qRYP.w, 0.897636, accuracy: accuracy)
+    }
+    
+    func testXformUnitVectors () {
+        // Easy to visualize: 120 deg about X-axis.
+        // Transform the i, j, & k unit vectors.
+        var q: Quaternion = Quaternion (axis: Vector3 (x: 1.0, y: 0.0, z: 0.0), angle: Float (120).degreesToRadians)
+        var iT: Vector3 = q * Vector3 (x: 1.0, y: 0.0, z: 0.0)
+        var jT: Vector3 = q * Vector3 (x: 0.0, y: 1.0, z: 0.0)
+        var kT: Vector3 = q * Vector3 (x: 0.0, y: 0.0, z: 1.0)
+        
+        XCTAssertEqual (iT.x, 1.0, accuracy: accuracy)
+        XCTAssertEqual (iT.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (iT.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (jT.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (jT.y, -0.5, accuracy: accuracy)
+        XCTAssertEqual (jT.z, 0.866025, accuracy: accuracy)
+        XCTAssertEqual (kT.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (kT.y, -0.866025, accuracy: accuracy)
+        XCTAssertEqual (kT.z, -0.5, accuracy: accuracy)
+        XCTAssertEqual (iT.length (), 1)
+        XCTAssertEqual (jT.length (), 1)
+        XCTAssertEqual (kT.length (), 1)
+        
+        // Easy to visualize: 30 deg about Y-axis.
+        q = Quaternion (axis: Vector3 (x: 0.0, y: 1.0, z: 0.0), angle: Float (30).degreesToRadians)
+        iT = q * Vector3 (x: 1.0, y: 0.0, z: 0.0)
+        jT = q * Vector3 (x: 0.0, y: 1.0, z: 0.0)
+        kT = q * Vector3 (x: 0.0, y: 0.0, z: 1.0)
+        
+        XCTAssertEqual (iT.x, 0.866025, accuracy: accuracy)
+        XCTAssertEqual (iT.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (iT.z, -0.5, accuracy: accuracy)
+        XCTAssertEqual (jT.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (jT.y, 1.0, accuracy: accuracy)
+        XCTAssertEqual (jT.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (kT.x, 0.5, accuracy: accuracy)
+        XCTAssertEqual (kT.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (kT.z, 0.866025, accuracy: accuracy)
+        XCTAssertEqual (iT.length (), 1)
+        XCTAssertEqual (jT.length (), 1)
+        XCTAssertEqual (kT.length (), 1)
+        
+        // Easy to visualize: 60 deg about Z-axis.
+        q = Quaternion (axis: Vector3 (x: 0.0, y: 0.0, z: 1.0), angle: Float (60).degreesToRadians)
+        iT = q * Vector3 (x: 1.0, y: 0.0, z: 0.0)
+        jT = q * Vector3 (x: 0.0, y: 1.0, z: 0.0)
+        kT = q * Vector3 (x: 0.0, y: 0.0, z: 1.0)
+        
+        XCTAssertEqual (iT.x, 0.5, accuracy: accuracy)
+        XCTAssertEqual (iT.y, 0.866025, accuracy: accuracy)
+        XCTAssertEqual (iT.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (jT.x, -0.866025, accuracy: accuracy)
+        XCTAssertEqual (jT.y, 0.5, accuracy: accuracy)
+        XCTAssertEqual (jT.z, 0.0, accuracy: accuracy)
+        XCTAssertEqual (kT.x, 0.0, accuracy: accuracy)
+        XCTAssertEqual (kT.y, 0.0, accuracy: accuracy)
+        XCTAssertEqual (kT.z, 1.0, accuracy: accuracy)
+        XCTAssertEqual (iT.length (), 1)
+        XCTAssertEqual (jT.length (), 1)
+        XCTAssertEqual (kT.length (), 1)
+    }
+    
+    func testXformVector () {
+        // Arbitrary quaternion rotates an arbitrary vector.
+        let eulerYzx: Vector3 = Vector3 (x: Float (31.41).degreesToRadians, y: Float (-49.16).degreesToRadians, z: Float (12.34).degreesToRadians)
+        let basisAxes: Basis = Basis.fromEuler (euler: eulerYzx)
+        let q: Quaternion = basisAxes.getRotationQuaternion ()
+        
+        let vArb: Vector3 = Vector3 (x: 3.0, y: 4.0, z: 5.0)
+        let vRot: Vector3 = q * vArb
+        let vCompare: Vector3 = basisAxes * vArb
+        
+        XCTAssertEqual (vRot.lengthSquared (), vArb.lengthSquared (), accuracy: Double (accuracy))
+        XCTAssertEqual (vRot.x, vCompare.x, accuracy: accuracy)
+        XCTAssertEqual (vRot.y, vCompare.y, accuracy: accuracy)
+        XCTAssertEqual (vRot.z, vCompare.z, accuracy: accuracy)
+    }
+    
+    func testManyVectorXforms () {
+        // Test vector xform for a single combination of Quaternion and Vector.
+        func assertQuatVecRotate (eulerYzx: Vector3, vIn: Vector3) {
+            let basisAxes: Basis = Basis.fromEuler (euler: eulerYzx)
+            let q: Quaternion = basisAxes.getRotationQuaternion ()
+            
+            let vRot: Vector3 = q * vIn
+            let vCompare: Vector3 = basisAxes * vIn
+            
+            XCTAssertEqual (vRot.lengthSquared (), vIn.lengthSquared (), accuracy: Double (accuracy))
+            XCTAssertEqual (vRot.x, vCompare.x, accuracy: accuracy)
+            XCTAssertEqual (vRot.y, vCompare.y, accuracy: accuracy)
+            XCTAssertEqual (vRot.z, vCompare.z, accuracy: accuracy)
+        }
+        
+        // Many arbitrary quaternions rotate many arbitrary vectors.
+        // For each trial, check that rotation by Quaternion yields same result as
+        // rotation by Basis.
+        let steps: Int = 10 // Number of test steps in each dimension
+        let delta: Float = 2.0 * Float.pi / Float (steps) // Angle increment per step
+        let deltaVec: Float = 20.0 / Float (steps) // Vector increment per step
+        var vecArb: Vector3 = Vector3 (x: 1.0, y: 1.0, z: 1.0)
+        
+        var xAngle: Float
+        var yAngle: Float
+        var zAngle: Float
+        
+        for i in 0..<steps {
+            vecArb.x = -10.0 + Float (i) * deltaVec
+            xAngle = Float (i) * delta - Float.pi
+            for j in 0..<steps {
+                vecArb.y = -10.0 + Float (j) * deltaVec
+                yAngle = Float (j) * delta - Float.pi
+                for k in 0..<steps {
+                    vecArb.y = -10.0 + Float (k) * deltaVec
+                    zAngle = Float (k) * delta - Float.pi
+                    let eulerYzx: Vector3 = Vector3 (x: xAngle, y: yAngle, z: zAngle)
+                    assertQuatVecRotate (eulerYzx: eulerYzx, vIn: vecArb)
+                }
+            }
+        }
+    }
+    
+    func testFiniteNumberChecks () {
+        XCTAssertTrue (Quaternion (x: 0, y: 1, z: 2, w: 3).isFinite (), "Quaternion with all components finite should be finite")
+        
+        XCTAssertFalse (Quaternion (x: .nan, y: 1, z: 2, w: 3).isFinite (), "Quaternion with one component infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: 0, y: .nan, z: 2, w: 3).isFinite (), "Quaternion with one component infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: 0, y: 1, z: .nan, w: 3).isFinite (), "Quaternion with one component infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: 0, y: 1, z: 2, w: .nan).isFinite (), "Quaternion with one component infinite should not be finite.")
+        
+        XCTAssertFalse (Quaternion (x: .nan, y: .nan, z: 2, w: 3).isFinite (), "Quaternion with two components infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: .nan, y: 1, z: .nan, w: 3).isFinite (), "Quaternion with two components infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: .nan, y: 1, z: 2, w: .nan).isFinite (), "Quaternion with two components infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: 0, y: .nan, z: .nan, w: 3).isFinite (), "Quaternion with two components infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: 0, y: .nan, z: 2, w: .nan).isFinite (), "Quaternion with two components infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: 0, y: 1, z: .nan, w: .nan).isFinite (), "Quaternion with two components infinite should not be finite.")
+        
+        XCTAssertFalse (Quaternion (x: 0, y: .nan, z: .nan, w: .nan).isFinite (), "Quaternion with one component infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: .nan, y: 1, z: .nan, w: .nan).isFinite (), "Quaternion with one component infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: .nan, y: .nan, z: .nan, w: 3).isFinite (), "Quaternion with one component infinite should not be finite.")
+        XCTAssertFalse (Quaternion (x: .nan, y: .nan, z: .nan, w: 3).isFinite (), "Quaternion with one component infinite should not be finite.")
+        
+        XCTAssertFalse (Quaternion (x: .nan, y: .nan, z: .nan, w: .nan).isFinite (), "Quaternion with four components infinite should not be finite.")
+    }
+    
+}


### PR DESCRIPTION
These are just C++ tests from Godot's repository converted into Swift. It's a relatively cheap way for us to get some test coverage, and to make sure things work as the engine devs intended.