### PR TITLE
Omit first argument name in built-in struct methods when possible

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -374,8 +374,15 @@ func generateBuiltinMethods (_ p: Printer,
         }
         
         for arg in m.arguments ?? [] {
+            var eliminate: String = ""
+            if args.isEmpty, m.name.hasSuffix ("_\(arg.name)") {
+                // if the first argument name matches the last part of the method name, we want
+                // to skip giving it a name.   For example:
+                // addPattern (pattern: xx) becomes addPattern (_ pattern: xx)
+                eliminate = "_ "
+            }
             if args != "" { args += ", " }
-            args += getArgumentDeclaration(arg, eliminate: "", isOptional: false)
+            args += getArgumentDeclaration(arg, eliminate: eliminate, isOptional: false)
         }
         
         doc (p, bc, m.description)

--- a/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
@@ -102,9 +102,9 @@ final class AABBTests: GodotTestCase {
         aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
         XCTAssertEqual (aabbBig.intersection (with: aabbSmall), AABB (), "intersection() with non-contained AABB should return the expected result.")
         
-        XCTAssertTrue (aabbBig.intersectsPlane (plane: Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 4)), "intersectsPlane() should return the expected result.")
-        XCTAssertTrue (aabbBig.intersectsPlane (plane: Plane (normal: Vector3 (x: 0, y: -1, z: 0), d: -4)), "intersectsPlane() should return the expected result.")
-        XCTAssertFalse (aabbBig.intersectsPlane (plane: Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 200)), "intersectsPlane() should return the expected result.")
+        XCTAssertTrue (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 4)), "intersectsPlane() should return the expected result.")
+        XCTAssertTrue (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: -1, z: 0), d: -4)), "intersectsPlane() should return the expected result.")
+        XCTAssertFalse (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 200)), "intersectsPlane() should return the expected result.")
         
         XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 1, y: 3, z: 0), to: Vector3 (x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
         XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 3, z: 0), to: Vector3 (x: 0, y: -300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
@@ -186,16 +186,16 @@ final class AABBTests: GodotTestCase {
     func testHasPoint () {
         let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
         
-        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: -1, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
-        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 2, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
-        XCTAssertFalse (aabb.hasPoint (point: Vector3 (x: -20, y: 0, z: 0)), "hasPoint() with non-contained point should return the expected value.")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: -1, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 2, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
+        XCTAssertFalse (aabb.hasPoint (Vector3 (x: -20, y: 0, z: 0)), "hasPoint() with non-contained point should return the expected value.")
         
-        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: -1.5, y: 3, z: 0)), "hasPoint() with positive size should include point on near face (X axis).")
-        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 2.5, y: 3, z: 0)), "hasPoint() with positive size should include point on far face (X axis).")
-        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 0, y: 2, z: 0)), "hasPoint() with positive size should include point on near face (Y axis).")
-        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 0, y: 7, z: 0)), "hasPoint() with positive size should include point on far face (Y axis).")
-        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 0, y: 3, z: -2.5)), "hasPoint() with positive size should include point on near face (Z axis).")
-        XCTAssertTrue (aabb.hasPoint (point: Vector3 (x: 0, y: 3, z: 3.5)), "hasPoint() with positive size should include point on far face (Z axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: -1.5, y: 3, z: 0)), "hasPoint() with positive size should include point on near face (X axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 2.5, y: 3, z: 0)), "hasPoint() with positive size should include point on far face (X axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 2, z: 0)), "hasPoint() with positive size should include point on near face (Y axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 7, z: 0)), "hasPoint() with positive size should include point on far face (Y axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 3, z: -2.5)), "hasPoint() with positive size should include point on near face (Z axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 3, z: 3.5)), "hasPoint() with positive size should include point on far face (Z axis).")
     }
     
     func testExpanding () {

--- a/Tests/SwiftGodotEngineTests/Math/BasisTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/BasisTests.swift
@@ -27,11 +27,11 @@ final class BasisTests: GodotTestCase {
         
         // Euler to rotation
         let originalEuler: Vector3 = Vector3 (x: eulerDegrees.x.degreesToRadians, y: eulerDegrees.y.degreesToRadians, z: eulerDegrees.z.degreesToRadians)
-        let toRotation: Basis = Basis.fromEuler (euler: originalEuler)
+        let toRotation: Basis = Basis.fromEuler (originalEuler)
 
         // Euler from rotation
         let eulerFromRotation: Vector3 = toRotation.getEuler (order: rawEulerOrder)
-        let rotationFromComputedEuler: Basis = Basis.fromEuler (euler: eulerFromRotation, order: rawEulerOrder)
+        let rotationFromComputedEuler: Basis = Basis.fromEuler (eulerFromRotation, order: rawEulerOrder)
         
         var res: Basis = toRotation.inverse () * rotationFromComputedEuler
         
@@ -43,7 +43,7 @@ final class BasisTests: GodotTestCase {
         
         let rawXyzEulerOrder: Int64 = Int64 (EulerOrder.xyz.rawValue)
         let eulerXyzFromRotation: Vector3 = toRotation.getEuler (order: rawXyzEulerOrder)
-        let rotationFromXyzComputedEuler: Basis = Basis.fromEuler (euler: eulerXyzFromRotation, order: rawXyzEulerOrder)
+        let rotationFromXyzComputedEuler: Basis = Basis.fromEuler (eulerXyzFromRotation, order: rawXyzEulerOrder)
         
         res = toRotation.inverse () * rotationFromXyzComputedEuler
         
@@ -233,19 +233,19 @@ final class BasisTests: GodotTestCase {
         basis = Basis ()
         XCTAssertTrue (basis.isConformal (), "Identity Basis should be conformal.")
         
-        basis = Basis.fromEuler (euler: Vector3 (x: 1.2, y: 3.4, z: 5.6))
+        basis = Basis.fromEuler (Vector3 (x: 1.2, y: 3.4, z: 5.6))
         XCTAssertTrue (basis.isConformal (), "Basis with only rotation should be conformal.")
         
-        basis = Basis.fromScale (scale: Vector3 (x: -1, y: -1, z: -1))
+        basis = Basis.fromScale (Vector3 (x: -1, y: -1, z: -1))
         XCTAssertTrue (basis.isConformal (), "Basis with only a flip should be conformal.")
         
-        basis = Basis.fromScale (scale: Vector3 (x: 1.2, y: 1.2, z: 1.2))
+        basis = Basis.fromScale (Vector3 (x: 1.2, y: 1.2, z: 1.2))
         XCTAssertTrue (basis.isConformal (), "Basis with only uniform scale should be conformal.")
         
         basis = Basis (xAxis: Vector3 (x: 3, y: 4, z: 0), yAxis: Vector3 (x: 4, y: -3, z: 0.0), zAxis: Vector3 (x: 0, y: 0, z: 5))
         XCTAssertTrue (basis.isConformal (), "Basis with a flip, rotation, and uniform scale should be conformal.")
         
-        basis = Basis.fromScale (scale: Vector3 (x: 1.2, y: 3.4, z: 5.6))
+        basis = Basis.fromScale (Vector3 (x: 1.2, y: 3.4, z: 5.6))
         XCTAssertFalse (basis.isConformal (), "Basis with non-uniform scale should not be conformal.")
         
         basis = Basis (xAxis: Vector3 (x: Float (0.5.squareRoot ()), y: Float (0.5.squareRoot ()), z: 0), yAxis: Vector3 (x: 0, y: 1, z: 0), zAxis: Vector3 (x: 0, y: 0, z: 1))

--- a/Tests/SwiftGodotEngineTests/Math/PlaneTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/PlaneTests.swift
@@ -49,16 +49,16 @@ final class PlaneTests: GodotTestCase {
         let xFacingPlaneWithDOffset: Plane = Plane (a: 1, b: 0, c: 0, d: 1)
         let yXxisPointWithDOffset: Vector3 = Vector3 (x: 1, y: 10, z: 0)
         
-        XCTAssertTrue (xFacingPlane.hasPoint (point: yAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
-        XCTAssertTrue (xFacingPlane.hasPoint (point: zAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (xFacingPlane.hasPoint (yAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (xFacingPlane.hasPoint (zAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
         
-        XCTAssertTrue (yFacingPlane.hasPoint (point: xAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
-        XCTAssertTrue (yFacingPlane.hasPoint (point: zAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (yFacingPlane.hasPoint (xAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (yFacingPlane.hasPoint (zAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
         
-        XCTAssertTrue (zFacingPlane.hasPoint (point: yAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
-        XCTAssertTrue (zFacingPlane.hasPoint (point: xAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (zFacingPlane.hasPoint (yAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
+        XCTAssertTrue (zFacingPlane.hasPoint (xAxisPoint), "hasPoint() with contained Vector3 should return the expected result.")
         
-        XCTAssertTrue (xFacingPlaneWithDOffset.hasPoint (point: yXxisPointWithDOffset), "hasPoint () with passed Vector3 should return the expected result.")
+        XCTAssertTrue (xFacingPlaneWithDOffset.hasPoint (yXxisPointWithDOffset), "hasPoint () with passed Vector3 should return the expected result.")
     }
     
     func testIntersection () {

--- a/Tests/SwiftGodotEngineTests/Math/QuaternionTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/QuaternionTests.swift
@@ -73,21 +73,21 @@ final class QuaternionTests: GodotTestCase {
         let roll: Float = Float (10.0).degreesToRadians
 
         let eulerY: Vector3 = Vector3 (x: 0.0, y: yaw, z: 0.0)
-        let qY: Quaternion = Quaternion.fromEuler (euler: eulerY)
+        let qY: Quaternion = Quaternion.fromEuler (eulerY)
         assertApproxEqual (qY.x, 0.0)
         assertApproxEqual (qY.y, 0.382684)
         assertApproxEqual (qY.z, 0.0)
         assertApproxEqual (qY.w, 0.923879)
         
         let eulerP: Vector3 = Vector3 (x: pitch, y: 0.0, z: 0.0)
-        let qP: Quaternion = Quaternion.fromEuler (euler: eulerP)
+        let qP: Quaternion = Quaternion.fromEuler (eulerP)
         assertApproxEqual (qP.x, 0.258819)
         assertApproxEqual (qP.y, 0.0)
         assertApproxEqual (qP.z, 0.0)
         assertApproxEqual (qP.w, 0.965926)
         
         let eulerR: Vector3 = Vector3 (x: 0.0, y: 0.0, z: roll)
-        let qR: Quaternion = Quaternion.fromEuler (euler: eulerR)
+        let qR: Quaternion = Quaternion.fromEuler (eulerR)
         assertApproxEqual (qR.x, 0.0)
         assertApproxEqual (qR.y, 0.0)
         assertApproxEqual (qR.z, 0.0871558)
@@ -102,11 +102,11 @@ final class QuaternionTests: GodotTestCase {
         // Generate YXZ comparison data (Z-then-X-then-Y) using single-axis Euler
         // constructor and quaternion product, both tested separately.
         let eulerY: Vector3 = Vector3 (x: 0.0, y: yaw, z: 0.0)
-        let qY: Quaternion = Quaternion.fromEuler (euler: eulerY)
+        let qY: Quaternion = Quaternion.fromEuler (eulerY)
         let eulerP: Vector3 = Vector3 (x: pitch, y: 0.0, z: 0.0)
-        let qP: Quaternion = Quaternion.fromEuler (euler: eulerP)
+        let qP: Quaternion = Quaternion.fromEuler (eulerP)
         let eulerR: Vector3 = Vector3 (x: 0.0, y: 0.0, z: roll)
-        let qR: Quaternion = Quaternion.fromEuler (euler: eulerR)
+        let qR: Quaternion = Quaternion.fromEuler (eulerR)
 
         // Instrinsically, Yaw-Y then Pitch-X then Roll-Z.
         // Extrinsically, Roll-Z is followed by Pitch-X, then Yaw-Y.
@@ -114,7 +114,7 @@ final class QuaternionTests: GodotTestCase {
 
         // Test construction from YXZ Euler angles.
         let eulerYxz: Vector3 = Vector3 (x: pitch, y: yaw, z: roll)
-        let q: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
+        let q: Quaternion = Quaternion.fromEuler (eulerYxz)
         assertApproxEqual (q, checkYxz)
     }
     
@@ -123,8 +123,8 @@ final class QuaternionTests: GodotTestCase {
         let pitch: Float = Float (30.0).degreesToRadians
         let roll: Float = Float (10.0).degreesToRadians
         let eulerYxz: Vector3 = Vector3 (x: pitch, y: yaw, z: roll)
-        let qYxz: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
-        let basisAxes: Basis = Basis.fromEuler (euler: eulerYxz)
+        let qYxz: Quaternion = Quaternion.fromEuler (eulerYxz)
+        let basisAxes: Basis = Basis.fromEuler (eulerYxz)
         let q: Quaternion = basisAxes.getRotationQuaternion ()
         assertApproxEqual (q, qYxz)
     }
@@ -137,9 +137,9 @@ final class QuaternionTests: GodotTestCase {
 
             // Generate YXZ (Z-then-X-then-Y) Quaternion using single-axis Euler
             // constructor and quaternion product, both tested separately.
-            let qY: Quaternion = Quaternion.fromEuler (euler: Vector3 (x: 0.0, y: yaw, z: 0.0))
-            let qP: Quaternion = Quaternion.fromEuler (euler: Vector3 (x: pitch, y: 0.0, z: 0.0))
-            let qR: Quaternion = Quaternion.fromEuler (euler: Vector3 (x: 0.0, y: 0.0, z: roll))
+            let qY: Quaternion = Quaternion.fromEuler (Vector3 (x: 0.0, y: yaw, z: 0.0))
+            let qP: Quaternion = Quaternion.fromEuler (Vector3 (x: pitch, y: 0.0, z: 0.0))
+            let qR: Quaternion = Quaternion.fromEuler (Vector3 (x: 0.0, y: 0.0, z: roll))
             // Roll-Z is followed by Pitch-X, then Yaw-Y.
             let qYxz: Quaternion = qY * qP * qR
 
@@ -157,7 +157,7 @@ final class QuaternionTests: GodotTestCase {
         // Quaternion from local calculation.
         let qLocal: Quaternion = quatEulerYxzDeg (angle: Vector3 (x: 31.41, y: -49.16, z: 12.34))
         // Quaternion from Euler angles constructor.
-        let qEuler: Quaternion = Quaternion.fromEuler (euler: eulerYxz)
+        let qEuler: Quaternion = Quaternion.fromEuler (eulerYxz)
         assertApproxEqual (qCalc, qLocal)
         assertApproxEqual (qLocal, qEuler)
 
@@ -166,7 +166,7 @@ final class QuaternionTests: GodotTestCase {
         // This is by design, but may be subject to change.
         // Workaround by constructing Basis from Euler angles.
         // basis_axes = Basis (i_unit, j_unit, k_unit);
-        let basisAxes: Basis = Basis.fromEuler (euler: eulerYxz)
+        let basisAxes: Basis = Basis.fromEuler (eulerYxz)
         let q: Quaternion = basisAxes.getRotationQuaternion ()
         assertApproxEqual (basisAxes.x.x, iUnit.x)
         assertApproxEqual (basisAxes.y.x, iUnit.y)
@@ -194,7 +194,7 @@ final class QuaternionTests: GodotTestCase {
         let euler: Vector3 = Vector3 (x: x, y: y, z: z)
         
         for order: Int64 in 0..<6 {
-            let basis: Basis = Basis.fromEuler (euler: euler, order: order)
+            let basis: Basis = Basis.fromEuler (euler, order: order)
             let q: Quaternion = basis.getRotationQuaternion ()
             let check: Vector3 = q.getEuler (order: order)
             assertApproxEqual (check.x, euler.x, "Quaternion getEuler() method should return the original angles.")
@@ -224,21 +224,21 @@ final class QuaternionTests: GodotTestCase {
         let roll: Float = Float (10.0).degreesToRadians
         
         let eulerY: Vector3 = Vector3 (x: 0.0, y: yaw, z: 0.0)
-        let qY: Quaternion = Quaternion.fromEuler (euler: eulerY)
+        let qY: Quaternion = Quaternion.fromEuler (eulerY)
         assertApproxEqual (qY.x, 0.0)
         assertApproxEqual (qY.y, 0.382684)
         assertApproxEqual (qY.z, 0.0)
         assertApproxEqual (qY.w, 0.923879)
         
         let eulerP: Vector3 = Vector3 (x: pitch, y: 0.0, z: 0.0)
-        let qP: Quaternion = Quaternion.fromEuler (euler: eulerP)
+        let qP: Quaternion = Quaternion.fromEuler (eulerP)
         assertApproxEqual (qP.x, 0.258819)
         assertApproxEqual (qP.y, 0.0)
         assertApproxEqual (qP.z, 0.0)
         assertApproxEqual (qP.w, 0.965926)
         
         let eulerR: Vector3 = Vector3 (x: 0.0, y: 0.0, z: roll)
-        let qR: Quaternion = Quaternion.fromEuler (euler: eulerR)
+        let qR: Quaternion = Quaternion.fromEuler (eulerR)
         assertApproxEqual (qR.x, 0.0)
         assertApproxEqual (qR.y, 0.0)
         assertApproxEqual (qR.z, 0.0871558)
@@ -323,7 +323,7 @@ final class QuaternionTests: GodotTestCase {
     func testXformVector () {
         // Arbitrary quaternion rotates an arbitrary vector.
         let eulerYzx: Vector3 = Vector3 (x: Float (31.41).degreesToRadians, y: Float (-49.16).degreesToRadians, z: Float (12.34).degreesToRadians)
-        let basisAxes: Basis = Basis.fromEuler (euler: eulerYzx)
+        let basisAxes: Basis = Basis.fromEuler (eulerYzx)
         let q: Quaternion = basisAxes.getRotationQuaternion ()
         
         let vArb: Vector3 = Vector3 (x: 3.0, y: 4.0, z: 5.0)
@@ -337,7 +337,7 @@ final class QuaternionTests: GodotTestCase {
     func testManyVectorXforms () {
         // Test vector xform for a single combination of Quaternion and Vector.
         func assertQuatVecRotate (eulerYzx: Vector3, vIn: Vector3) {
-            let basisAxes: Basis = Basis.fromEuler (euler: eulerYzx)
+            let basisAxes: Basis = Basis.fromEuler (eulerYzx)
             let q: Quaternion = basisAxes.getRotationQuaternion ()
             
             let vRot: Vector3 = q * vIn


### PR DESCRIPTION
There's already similar logic for general classes, but not for built-ins.