### PR TITLE
Throw an error when async or throwing function have @Callable macro

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -19,11 +19,11 @@ public struct GodotCallable: PeerMacro {
         var retProp: String? = nil
         var retOptional: Bool = false
 		
-		if let effects = funcDecl.signature.effectSpecifiers,
-		   effects.asyncSpecifier?.presence == .present ||
-			effects.throwsSpecifier?.presence == .present {
-			throw GodotMacroError.unsupportedCallableEffect
-		}
+        if let effects = funcDecl.signature.effectSpecifiers,
+           effects.asyncSpecifier?.presence == .present ||
+            effects.throwsSpecifier?.presence == .present {
+            throw GodotMacroError.unsupportedCallableEffect
+        }
         
         if let (retType, _, ro) = getIdentifier (funcDecl.signature.returnClause?.type) {
             retProp = godotTypeToProp (typeName: retType)

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -18,6 +18,12 @@ public struct GodotCallable: PeerMacro {
         var genMethod = "func _mproxy_\(funcName) (args: [Variant]) -> Variant? {\n"
         var retProp: String? = nil
         var retOptional: Bool = false
+		
+		if let effects = funcDecl.signature.effectSpecifiers,
+		   effects.asyncSpecifier?.presence == .present ||
+			effects.throwsSpecifier?.presence == .present {
+			throw GodotMacroError.unsupportedCallableEffect
+		}
         
         if let (retType, _, ro) = getIdentifier (funcDecl.signature.returnClause?.type) {
             retProp = godotTypeToProp (typeName: retType)

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -47,6 +47,7 @@ enum GodotMacroError: Error, DiagnosticMessage {
     case unsupportedType(VariableDeclSyntax)
     case expectedIdentifier(PatternBindingListSyntax.Element)
     case unknownError(Error)
+	case unsupportedCallableEffect
     
     var severity: DiagnosticSeverity {
         return .error
@@ -74,6 +75,8 @@ enum GodotMacroError: Error, DiagnosticMessage {
             "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead"
         case .requiresNonOptionalGArrayCollection:
             "@Export optional Collections are not supported"
+		case .unsupportedCallableEffect:
+			"@Callable does not support asynchronous or throwing functions"
 		}
     }
     

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -47,7 +47,7 @@ enum GodotMacroError: Error, DiagnosticMessage {
     case unsupportedType(VariableDeclSyntax)
     case expectedIdentifier(PatternBindingListSyntax.Element)
     case unknownError(Error)
-	case unsupportedCallableEffect
+    case unsupportedCallableEffect
     
     var severity: DiagnosticSeverity {
         return .error
@@ -75,8 +75,8 @@ enum GodotMacroError: Error, DiagnosticMessage {
             "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead"
         case .requiresNonOptionalGArrayCollection:
             "@Export optional Collections are not supported"
-		case .unsupportedCallableEffect:
-			"@Callable does not support asynchronous or throwing functions"
+        case .unsupportedCallableEffect:
+            "@Callable does not support asynchronous or throwing functions"
 		}
     }
     


### PR DESCRIPTION
Following the discussion on #327, I have implemented a check for async/throwing functions since currently it just does not compile and does not give an explanation on why.

This PR makes the code below throw an error before compile-time.

```swift
@Callable func test() async throws { // ERROR: @Callable does not support asynchronous or throwing functions
    print("test")
}
```