### PR TITLE
Prevent SwiftGodot subclasses from executing in editor by default

### DIFF
--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -14,9 +14,16 @@
 /// any `@Export` and `@Callable` methods for the class effectively surfacing properties and
 /// methods to godot
 ///
+/// - Parameter behavior: using `.tool` value makes the overridden methods like `_ready` or
+/// `_process` run in editor, making the class work like `@tool` annotated script in GDScript
+///
 @attached(member,
           names: named (_initializeClass), named(classInitializer), named (implementedOverrides))
-public macro Godot() = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacro")
+public macro Godot(_ behavior: ClassBehavior = .gameplay) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacro")
+
+public enum ClassBehavior: Int {
+    case gameplay, tool
+}
 
 /// Exposes the function to the Godot runtime
 ///

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -535,7 +535,16 @@ public struct GodotMacro: MemberMacro {
                     return stringName
                 }
                 
-                var implementedOverridesDecl = "override \(accessControlLevel) class func implementedOverrides() -> [StringName] {\nsuper.implementedOverrides() + [\n"
+                var isTool: Bool = false
+                if case let .argumentList (arguments) = node.arguments, let expression = arguments.first?.expression {
+                    isTool = expression.description.trimmingCharacters (in: .whitespacesAndNewlines) .hasSuffix(".tool")
+                }
+                
+                var implementedOverridesDecl = "override \(accessControlLevel) class func implementedOverrides () -> [StringName] {\n"
+                if !isTool {
+                    implementedOverridesDecl += "guard !Engine.isEditorHint () else { return [] }\n"
+                }
+                implementedOverridesDecl += "return super.implementedOverrides () + [\n"
                 for name in stringNames {
                     implementedOverridesDecl.append("\t\(name),\n")
                 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -69,8 +69,11 @@ final class MacroGodotTests: XCTestCase {
                     let classInfo = ClassInfo<Hi> (name: className)
                 } ()
 
-                override public class func implementedOverrides() -> [StringName] {
-                    super.implementedOverrides() + [
+                override public class func implementedOverrides () -> [StringName] {
+                    guard !Engine.isEditorHint () else {
+                        return []
+                    }
+                    return super.implementedOverrides () + [
                     	StringName("_has_point"),
                     ]
                 }
@@ -83,7 +86,7 @@ final class MacroGodotTests: XCTestCase {
     func testGodotVirtualMethodsMacro() {
         assertMacroExpansion(
             """
-            @Godot class Hi: Control {
+            @Godot(.tool) class Hi: Control {
                 override func _hasPoint(_ point: Vector2) -> Bool { false }
             }
             """,
@@ -102,8 +105,8 @@ final class MacroGodotTests: XCTestCase {
                     let classInfo = ClassInfo<Hi> (name: className)
                 } ()
             
-                override open class func implementedOverrides() -> [StringName] {
-                    super.implementedOverrides() + [
+                override open class func implementedOverrides () -> [StringName] {
+                    return super.implementedOverrides () + [
                     	StringName("_has_point"),
                     ]
                 }


### PR DESCRIPTION
Fixes #347. Classes can be annotated as `@Godot(.tool)` to make them run in editor akin to `@tool` scripts.