### PR TITLE
Reuse collection conformance generation for GArray

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -484,7 +484,7 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
             conformances.append ("ExpressibleByStringInterpolation")
             conformances.append ("LosslessStringConvertible")
         }
-        if bc.name.starts(with: "Packed") {
+        if bc.name.hasSuffix ("Array") {
             conformances.append ("Collection")
         }
         var proto = ""
@@ -677,7 +677,7 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                     }
                 }
             }
-            if bc.name.starts(with: "Packed") {
+            if bc.name.hasSuffix ("Array") {
                 p ("public var startIndex: Int") {
                     p ("0")
                 }

--- a/Sources/SwiftGodot/Core/GArray.swift
+++ b/Sources/SwiftGodot/Core/GArray.swift
@@ -10,7 +10,7 @@
 public enum ArrayError {
     case outOfRange
 }
-extension GArray: Collection {
+extension GArray {
     /// Initializes an empty, but typed `GArray`. For example: `GArray(Node.self)`
     /// - Parameter type: `T` the type of the elements in the GArray, must conform to `VariantStorable`.
 	public convenience init<T: VariantStorable>(_ type: T.Type = T.self) {
@@ -21,19 +21,6 @@ extension GArray: Collection {
 			script: Variant()
 		)
 	}
-	
-    public func index(after i: Int) -> Int {
-        return i+1
-    }
-    
-    public var startIndex: Int {
-        return 0
-    }
-    
-    /// The collection’s “past the end” position—that is, the position one greater than the last valid subscript argument.
-    public var endIndex: Int {
-        return Int (size())
-    }
     
     public subscript (index: Int) -> Variant {
         get {


### PR DESCRIPTION
This will hook `GArray` to the generated indexing implementation already used in packed arrays.