### PR TITLE
#278 add support for export subgroup

### DIFF
--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -45,7 +45,7 @@ public macro Export(_ hint: PropertyHint = .none, _ hintStr: String? = nil) = #e
 
 // MARK: - Freestanding Macros
 
-/// A macro used to add a category to exported properties
+/// A macro used to add a group to exported properties
 ///
 /// For example:
 /// ```swift
@@ -68,6 +68,31 @@ public macro Export(_ hint: PropertyHint = .none, _ hintStr: String? = nil) = #e
 /// - Parameter prefix: The optional prefix of the group which can be used to only group properties with the specified prefix.
 @freestanding(expression)
 public macro exportGroup(_ name: String, prefix: String = "") = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacroExportGroup")
+
+/// A macro used to add a subgroup to exported properties
+///
+/// For example:
+/// ```swift
+/// @Godot
+/// class Vehicle: Sprite2D {
+///     #exportGroup("Vehicle")
+///     #exportSubgroup("VIN")
+///     @Export
+///     var vin: String = "0123456789ABCDEF0"
+///     #exportSubgroup("YMM", prefix: "ymms_")
+///     @Export
+///     var ymms_year: Int = 0
+///     @Export
+///     var ymms_make: String = "Make"
+///     @Export
+///     var ymms_model: String = "Model"
+/// }
+/// ```
+///
+/// - Parameter name: The name of the subgroup.
+/// - Parameter prefix: The optional prefix of the subgroup which can be used to only group properties with the specified prefix.
+@freestanding(expression)
+public macro exportSubgroup(_ name: String, prefix: String = "") = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacroExportSubgroup")
 
 /// A macro used to write an entrypoint for a Godot extension.
 ///

--- a/Sources/SwiftGodotMacroLibrary/MacroExportSubgroup.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExportSubgroup.swift
@@ -1,0 +1,21 @@
+//
+//  MacroExportSubgroup.swift
+//
+//  Created by Estevan Hernandez on 1/20/24.
+//
+
+import Foundation
+import SwiftCompilerPlugin
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct GodotMacroExportSubgroup: DeclarationMacro {
+    public static func expansion(
+      of node: some FreestandingMacroExpansionSyntax,
+      in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        return []
+    }
+}

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -160,6 +160,14 @@ class GodotMacroProcessor {
         )
     }
     
+    func processExportSubgroup(name: String, prefix: String) {
+        ctor.append(
+            """
+            classInfo.addPropertySubgroup(name: "\(name)", prefix: "\(prefix)")\n
+            """
+        )
+    }
+    
     // Processes a function
     func processFunction (_ funcDecl: FunctionDeclSyntax) throws {
         guard hasCallableAttribute(funcDecl.attributes) else {
@@ -394,22 +402,27 @@ class GodotMacroProcessor {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<\(className)> (name: className)\n
     """
-        var previousPrefix: String? = nil
+        var previousGroupPrefix: String? = nil
+        var previousSubgroupPrefix: String? = nil
         
         for member in classDecl.memberBlock.members.enumerated() {
             let decl = member.element.decl
             
             if let macroExpansion = MacroExpansionDeclSyntax(decl),
                let name = macroExpansion.exportGroupName {
-                previousPrefix = macroExpansion.exportGroupPrefix ?? ""
-                processExportGroup(name: name, prefix: previousPrefix ?? "")
+                previousGroupPrefix = macroExpansion.exportGroupPrefix ?? ""
+                processExportGroup(name: name, prefix: previousGroupPrefix ?? "")
+            } else if let macroExpansion = MacroExpansionDeclSyntax(decl),
+                 let name = macroExpansion.exportSubgroupName {
+                previousSubgroupPrefix = macroExpansion.exportSubgroupPrefix ?? ""
+                processExportSubgroup(name: name, prefix: previousSubgroupPrefix ?? "")
             } else if let funcDecl = FunctionDeclSyntax(decl) {
 				try processFunction (funcDecl)
 			} else if let varDecl = VariableDeclSyntax(decl) {
 				if varDecl.isGArrayCollection {
-                    try processGArrayCollectionVariable(varDecl, prefix: previousPrefix)
+                    try processGArrayCollectionVariable(varDecl, prefix: previousSubgroupPrefix ?? previousGroupPrefix)
 				} else {
-					try processVariable(varDecl, prefix: previousPrefix)
+					try processVariable(varDecl, prefix: previousSubgroupPrefix ?? previousGroupPrefix)
 				}
             } else if let macroDecl = MacroExpansionDeclSyntax(decl) {
                 try classInitSignals(macroDecl)
@@ -577,6 +590,10 @@ private extension MacroExpansionDeclSyntax {
         macroName.text == "exportGroup"
     }
     
+    private var isExportSubgroup: Bool {
+        macroName.text == "exportSubgroup"
+    }
+    
     var exportGroupPrefix: String? {
         guard isExportGroup, arguments.count == 2 else { return nil }
         return arguments
@@ -593,6 +610,34 @@ private extension MacroExpansionDeclSyntax {
     
     var exportGroupName: String? {
         guard isExportGroup, arguments.count >= 1 else { return nil }
+        return arguments
+            .first?
+            .as(LabeledExprSyntax.self)?
+            .expression
+            .as(StringLiteralExprSyntax.self)?
+            .segments
+            .first?
+            .as(StringSegmentSyntax.self)?
+            .content
+            .text
+    }
+    
+    var exportSubgroupPrefix: String? {
+        guard isExportSubgroup, arguments.count == 2 else { return nil }
+        return arguments
+            .last?
+            .as(LabeledExprSyntax.self)?
+            .expression
+            .as(StringLiteralExprSyntax.self)?
+            .segments
+            .first?
+            .as(StringSegmentSyntax.self)?
+            .content
+            .text
+    }
+    
+    var exportSubgroupName: String? {
+        guard isExportSubgroup, arguments.count >= 1 else { return nil }
         return arguments
             .first?
             .as(LabeledExprSyntax.self)?

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
@@ -1,0 +1,191 @@
+//
+//  MacroGodotExportSubgroupTests.swift
+//  SwiftGodotMacrosTests
+//
+//  Created by Estevan Hernandez on 1/20/24.
+//
+
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+import SwiftGodotMacroLibrary
+
+final class MacroGodotExportSubroupTests: XCTestCase {
+    let testMacros: [String: Macro.Type] = [
+        "Godot": GodotMacro.self,
+        "Export": GodotExport.self,
+        "exportGroup": GodotMacroExportGroup.self,
+        "exportSubgroup": GodotMacroExportSubgroup.self
+    ]
+    
+    func testGodotExportSubgroupWithAndWithoutPrefixWithGroup() {
+        assertMacroExpansion(
+"""
+@Godot class Car: Node {
+    #exportGroup("Vehicle")
+    #exportSubgroup("VIN")
+    @Export var vin: String = ""
+    #exportSubgroup("YMMS", prefix: "ymms_")
+    @Export var ymms_year: Int = 1998
+    @Export var ymms_make: String = "Honda"
+    @Export var ymms_model: String = "Odyssey"
+    @Export var ymms_series: String = "LX"
+}
+""",
+        expandedSource: """
+
+class Car: Node {
+    var vin: String = ""
+
+    func _mproxy_set_vin (args: [Variant]) -> Variant? {
+    	guard let arg = args.first else {
+    		return nil
+    	}
+    	if let value = String (arg) {
+    		vin = value
+    	} else {
+    		GD.printErr ("Unable to set `vin` value: ", arg)
+    	}
+    	return nil
+    }
+
+    func _mproxy_get_vin (args: [Variant]) -> Variant? {
+        return Variant (vin)
+    }
+    var ymms_year: Int = 1998
+
+    func _mproxy_set_ymms_year (args: [Variant]) -> Variant? {
+    	guard let arg = args.first else {
+    		return nil
+    	}
+    	if let value = Int (arg) {
+    		ymms_year = value
+    	} else {
+    		GD.printErr ("Unable to set `ymms_year` value: ", arg)
+    	}
+    	return nil
+    }
+
+    func _mproxy_get_ymms_year (args: [Variant]) -> Variant? {
+        return Variant (ymms_year)
+    }
+    var ymms_make: String = "Honda"
+
+    func _mproxy_set_ymms_make (args: [Variant]) -> Variant? {
+    	guard let arg = args.first else {
+    		return nil
+    	}
+    	if let value = String (arg) {
+    		ymms_make = value
+    	} else {
+    		GD.printErr ("Unable to set `ymms_make` value: ", arg)
+    	}
+    	return nil
+    }
+
+    func _mproxy_get_ymms_make (args: [Variant]) -> Variant? {
+        return Variant (ymms_make)
+    }
+    var ymms_model: String = "Odyssey"
+
+    func _mproxy_set_ymms_model (args: [Variant]) -> Variant? {
+    	guard let arg = args.first else {
+    		return nil
+    	}
+    	if let value = String (arg) {
+    		ymms_model = value
+    	} else {
+    		GD.printErr ("Unable to set `ymms_model` value: ", arg)
+    	}
+    	return nil
+    }
+
+    func _mproxy_get_ymms_model (args: [Variant]) -> Variant? {
+        return Variant (ymms_model)
+    }
+    var ymms_series: String = "LX"
+
+    func _mproxy_set_ymms_series (args: [Variant]) -> Variant? {
+    	guard let arg = args.first else {
+    		return nil
+    	}
+    	if let value = String (arg) {
+    		ymms_series = value
+    	} else {
+    		GD.printErr ("Unable to set `ymms_series` value: ", arg)
+    	}
+    	return nil
+    }
+
+    func _mproxy_get_ymms_series (args: [Variant]) -> Variant? {
+        return Variant (ymms_series)
+    }
+
+    override open class var classInitializer: Void {
+        let _ = super.classInitializer
+        return _initializeClass
+    }
+
+    private static var _initializeClass: Void = {
+        let className = StringName("Car")
+        assert(ClassDB.classExists(class: className))
+        let classInfo = ClassInfo<Car> (name: className)
+        classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
+        classInfo.addPropertySubgroup(name: "VIN", prefix: "")
+        let _pvin = PropInfo (
+            propertyType: .string,
+            propertyName: "vin",
+            className: className,
+            hint: .none,
+            hintStr: "",
+            usage: .default)
+    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+        classInfo.addPropertySubgroup(name: "YMMS", prefix: "ymms_")
+        let _pymms_year = PropInfo (
+            propertyType: .int,
+            propertyName: "ymms_year",
+            className: className,
+            hint: .none,
+            hintStr: "",
+            usage: .default)
+    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pymms_year, arguments: [], function: Car._mproxy_get_ymms_year)
+    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pymms_year], function: Car._mproxy_set_ymms_year)
+    	classInfo.registerProperty (_pymms_year, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+        let _pymms_make = PropInfo (
+            propertyType: .string,
+            propertyName: "ymms_make",
+            className: className,
+            hint: .none,
+            hintStr: "",
+            usage: .default)
+    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pymms_make, arguments: [], function: Car._mproxy_get_ymms_make)
+    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pymms_make], function: Car._mproxy_set_ymms_make)
+    	classInfo.registerProperty (_pymms_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+        let _pymms_model = PropInfo (
+            propertyType: .string,
+            propertyName: "ymms_model",
+            className: className,
+            hint: .none,
+            hintStr: "",
+            usage: .default)
+    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pymms_model, arguments: [], function: Car._mproxy_get_ymms_model)
+    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pymms_model], function: Car._mproxy_set_ymms_model)
+    	classInfo.registerProperty (_pymms_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+        let _pymms_series = PropInfo (
+            propertyType: .string,
+            propertyName: "ymms_series",
+            className: className,
+            hint: .none,
+            hintStr: "",
+            usage: .default)
+    	classInfo.registerMethod (name: "_mproxy_get_series", flags: .default, returnValue: _pymms_series, arguments: [], function: Car._mproxy_get_ymms_series)
+    	classInfo.registerMethod (name: "_mproxy_set_series", flags: .default, returnValue: nil, arguments: [_pymms_series], function: Car._mproxy_set_ymms_series)
+    	classInfo.registerProperty (_pymms_series, getter: "_mproxy_get_series", setter: "_mproxy_set_series")
+    } ()
+}
+""",
+        macros: testMacros)
+    }
+}


### PR DESCRIPTION
resolves: #278 
```swift
@Godot class Car: Node {
    #exportGroup("Vehicle")
    #exportSubgroup("VIN")
    @Export var vin: String = ""
    #exportSubgroup("YMMS", prefix: "ymms_")
    @Export var ymms_year: Int = 1998
    @Export var ymms_make: String = "Honda"
    @Export var ymms_model: String = "Odyssey"
    @Export var ymms_series: String = "LX"
}
```

<img width="414" alt="image" src="https://github.com/migueldeicaza/SwiftGodot/assets/5488655/7b029e64-e9e2-47c3-a03e-2e416eac54a7">
