### PR TITLE
Fix hot reloading

### DIFF
--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -245,6 +245,15 @@ public func register<T:Wrapped> (type: T.Type) {
     register (type: StringName (typeStr), parent: StringName (superStr), type: type)
 }
 
+public func unregister<T:Wrapped> (type: T.Type) {
+    let typeStr = String (describing: type)
+    let name = StringName (typeStr)
+    pd ("Unregistering \(typeStr)")
+    withUnsafePointer (to: &name.content) { namePtr in
+        gi.classdb_unregister_extension_class (library, namePtr)
+    }
+}
+
 /// Currently contains all instantiated objects, but might want to separate those
 /// (or find a way of easily telling appart) framework objects from user subtypes
 fileprivate var liveFrameworkObjects: [UnsafeRawPointer:Wrapped] = [:]

--- a/Sources/SwiftGodot/EntryPoint.swift
+++ b/Sources/SwiftGodot/EntryPoint.swift
@@ -84,7 +84,8 @@ struct GodotInterface {
     let classdb_register_extension_class_property_group: GDExtensionInterfaceClassdbRegisterExtensionClassPropertyGroup
     let classdb_register_extension_class_property_subgroup:
     GDExtensionInterfaceClassdbRegisterExtensionClassPropertySubgroup
-    
+    let classdb_unregister_extension_class: GDExtensionInterfaceClassdbUnregisterExtensionClass
+
     let object_set_instance: GDExtensionInterfaceObjectSetInstance
     let object_set_instance_binding: GDExtensionInterfaceObjectSetInstanceBinding
     let object_get_class_name: GDExtensionInterfaceObjectGetClassName
@@ -198,6 +199,7 @@ func loadGodotInterface (_ godotGetProcAddrPtr: GDExtensionInterfaceGetProcAddre
         classdb_register_extension_class_property: load ("classdb_register_extension_class_property"),
         classdb_register_extension_class_property_group: load ("classdb_register_extension_class_property_group"),
         classdb_register_extension_class_property_subgroup: load ("classdb_register_extension_class_property_subgroup"),
+        classdb_unregister_extension_class: load ("classdb_unregister_extension_class"),
         
         object_set_instance: load ("object_set_instance"),
         object_set_instance_binding: load ("object_set_instance_binding"),
@@ -300,12 +302,12 @@ public func initializeSwiftModule (
     if library == nil {
         library = GDExtensionClassLibraryPtr(libraryPtr)
     }
+    extensionInitCallbacks = [initHook]
+    extensionDeInitCallbacks = [deInitHook]
     let initialization = UnsafeMutablePointer<GDExtensionInitialization> (extensionPtr)
     initialization.pointee.deinitialize = extension_deinitialize
     initialization.pointee.initialize = extension_initialize
-    initialization.pointee.minimum_initialization_level = GDEXTENSION_INITIALIZATION_CORE
-    extensionInitCallbacks.append(initHook)
-    extensionDeInitCallbacks.append (deInitHook)
+    initialization.pointee.minimum_initialization_level = GDEXTENSION_INITIALIZATION_SCENE
 }
 
 /*

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -89,7 +89,7 @@ public macro exportGroup(_ name: String, prefix: String = "") = #externalMacro(m
 ///
 /// - Parameter cdecl: The name of the entrypoint exposed to C.
 /// - Parameter types: The node types that should be registered with Godot.
-@freestanding(declaration, names: named(enterExtension), named(setupExtension))
+@freestanding(declaration, names: named(enterExtension))
 public macro initSwiftExtension(cdecl: String,
                                 types: [Wrapped.Type] = []) = #externalMacro(module: "SwiftGodotMacroLibrary",
                                                                         type: "InitSwiftExtensionMacro")

--- a/Sources/SwiftGodotMacroLibrary/InitSwiftExtensionMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/InitSwiftExtensionMacro.swift
@@ -28,28 +28,30 @@ public struct InitSwiftExtensionMacro: DeclarationMacro {
 		}
 
         let initModule: DeclSyntax = """
-        @_cdecl(\(raw: cDecl.description)) public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+        @_cdecl(\(raw: cDecl.description)) public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
             guard let library, let interface, let `extension` else {
-                print("Error: Not all parameters were initialized.")
+                print ("Error: Not all parameters were initialized.")
                 return 0
             }
-            let deinitHook: (GDExtension.InitializationLevel) -> Void = { _ in }
-            initializeSwiftModule(interface, library, `extension`, initHook: setupExtension, deInitHook: deinitHook)
+            let types: [Wrapped.Type] = \(types)
+            initializeSwiftModule (interface, library, `extension`, initHook: { level in
+                switch level {
+                case .scene:
+                    types.forEach (register)
+                default:
+                    break
+                }
+            }, deInitHook: { level in
+                switch level {
+                case .scene:
+                    types.forEach (unregister)
+                default:
+                    break
+                }
+            })
             return 1
         }
         """
-
-        let setupModule: DeclSyntax = """
-        func setupExtension(level: GDExtension.InitializationLevel) {
-            let types: [Wrapped.Type] = \(types)
-            switch level {
-            case .scene:
-                types.forEach(register)
-            default:
-                break
-            }
-        }
-        """
-        return [initModule, setupModule]
+        return [initModule]
     }
 }

--- a/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
@@ -22,24 +22,28 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
             #initSwiftExtension(cdecl: "libchrysalis_entry_point")
             """,
             expandedSource: """
-            @_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+            @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
-                    print("Error: Not all parameters were initialized.")
+                    print ("Error: Not all parameters were initialized.")
                     return 0
                 }
-                let deinitHook: (GDExtension.InitializationLevel) -> Void = { _ in
-                }
-                initializeSwiftModule(interface, library, `extension`, initHook: setupExtension, deInitHook: deinitHook)
-                return 1
-            }
-            func setupExtension(level: GDExtension.InitializationLevel) {
                 let types: [Wrapped.Type] = []
-                switch level {
-                case .scene:
-                    types.forEach(register)
-                default:
-                    break
-                }
+                initializeSwiftModule (interface, library, `extension`, initHook: { level in
+                    switch level {
+                    case .scene:
+                        types.forEach (register)
+                    default:
+                        break
+                    }
+                }, deInitHook: { level in
+                    switch level {
+                    case .scene:
+                        types.forEach (unregister)
+                    default:
+                        break
+                    }
+                })
+                return 1
             }
             """,
             macros: testMacros
@@ -52,24 +56,28 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", types: [])
             """,
             expandedSource: """
-            @_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+            @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
-                    print("Error: Not all parameters were initialized.")
+                    print ("Error: Not all parameters were initialized.")
                     return 0
                 }
-                let deinitHook: (GDExtension.InitializationLevel) -> Void = { _ in
-                }
-                initializeSwiftModule(interface, library, `extension`, initHook: setupExtension, deInitHook: deinitHook)
-                return 1
-            }
-            func setupExtension(level: GDExtension.InitializationLevel) {
                 let types: [Wrapped.Type] = []
-                switch level {
-                case .scene:
-                    types.forEach(register)
-                default:
-                    break
-                }
+                initializeSwiftModule (interface, library, `extension`, initHook: { level in
+                    switch level {
+                    case .scene:
+                        types.forEach (register)
+                    default:
+                        break
+                    }
+                }, deInitHook: { level in
+                    switch level {
+                    case .scene:
+                        types.forEach (unregister)
+                    default:
+                        break
+                    }
+                })
+                return 1
             }
             """,
             macros: testMacros
@@ -82,24 +90,28 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", types: [ChrysalisNode.self])
             """,
             expandedSource: """
-            @_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+            @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
-                    print("Error: Not all parameters were initialized.")
+                    print ("Error: Not all parameters were initialized.")
                     return 0
                 }
-                let deinitHook: (GDExtension.InitializationLevel) -> Void = { _ in
-                }
-                initializeSwiftModule(interface, library, `extension`, initHook: setupExtension, deInitHook: deinitHook)
-                return 1
-            }
-            func setupExtension(level: GDExtension.InitializationLevel) {
                 let types: [Wrapped.Type] = [ChrysalisNode.self]
-                switch level {
-                case .scene:
-                    types.forEach(register)
-                default:
-                    break
-                }
+                initializeSwiftModule (interface, library, `extension`, initHook: { level in
+                    switch level {
+                    case .scene:
+                        types.forEach (register)
+                    default:
+                        break
+                    }
+                }, deInitHook: { level in
+                    switch level {
+                    case .scene:
+                        types.forEach (unregister)
+                    default:
+                        break
+                    }
+                })
+                return 1
             }
             """,
             macros: testMacros


### PR DESCRIPTION
Fixes #273. I don't see any problems with unregistering and reregistering classes using this solution. Class duplication discussed in the issue was probably due to `extensionInitCallbacks` accumulating hooks with each initialization, that should be fixed. If not, I'll look into it again when we have a more definitive fail case.