### PR TITLE
Fix arithmetic overflow crash in unary minus operators

### DIFF
--- a/Sources/SwiftGodot/Extensions/Arithmetic.swift
+++ b/Sources/SwiftGodot/Extensions/Arithmetic.swift
@@ -59,11 +59,16 @@ extension Vector4: IntScalable & DoubleScalable {}
 extension Quaternion: IntScalable & DoubleScalable {}
 extension Color: IntScalable & DoubleScalable {}
 
+prefix operator &-
+@inline(__always) prefix func &- <T: SignedInteger & FixedWidthInteger> (_ i: T) -> T {
+    return 0 &- i
+}
+
 public extension Vector2i {
     
     /// Returns the negative value of the Vector2i. This is the same as writing Vector2i(-v.x, -v.y). This operation flips the direction of the vector while keeping the same magnitude.
     static prefix func - (_ v: Self) -> Self {
-        return Self (x: -v.x, y: -v.y)
+        return Self (x: &-v.x, y: &-v.y)
     }
     
     static func += (left: inout Self, right: Self) {
@@ -115,7 +120,7 @@ public extension Vector3i {
     
     /// Returns the negative value of the Vector3i. This is the same as writing Vector3i(-v.x, -v.y, -v.z). This operation flips the direction of the vector while keeping the same magnitude.
     static prefix func - (_ v: Self) -> Self {
-        return Self (x: -v.x, y: -v.y, z: -v.z)
+        return Self (x: &-v.x, y: &-v.y, z: &-v.z)
     }
     
     static func += (left: inout Self, right: Self) {
@@ -167,7 +172,7 @@ public extension Vector4i {
     
     /// Returns the negative value of the Vector4i. This is the same as writing Vector4i(-v.x, -v.y, -v.z, -v.w). This operation flips the direction of the vector while keeping the same magnitude.
     static prefix func - (_ v: Self) -> Self {
-        return Self (x: -v.x, y: -v.y, z: -v.z, w: -v.w)
+        return Self (x: &-v.x, y: &-v.y, z: &-v.z, w: &-v.w)
     }
     
     static func += (left: inout Self, right: Self) {

--- a/Tests/SwiftGodotTests/BuiltIn/ColorTests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/ColorTests.swift
@@ -1,0 +1,36 @@
+//
+//  ColorTests.swift
+//
+//
+//  Created by Mikhail Tishin on 23.01.2024.
+//
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class ColorTests: GodotTestCase {
+    
+    func testOperatorUnaryMinus () {
+        var value: Color
+        
+        value = -Color.white
+        XCTAssertEqual (value.red, 0)
+        XCTAssertEqual (value.green, 0)
+        XCTAssertEqual (value.blue, 0)
+        XCTAssertEqual (value.alpha, 0)
+        
+        value = -Color.black
+        XCTAssertEqual (value.red, 1)
+        XCTAssertEqual (value.green, 1)
+        XCTAssertEqual (value.blue, 1)
+        XCTAssertEqual (value.alpha, 0)
+        
+        value = -Color (r: 0.1, g: 0.2, b: 0.3, a: 0.4)
+        XCTAssertEqual (value.red, 0.9)
+        XCTAssertEqual (value.green, 0.8)
+        XCTAssertEqual (value.blue, 0.7)
+        XCTAssertEqual (value.alpha, 0.6)
+    }
+    
+}

--- a/Tests/SwiftGodotTests/BuiltIn/PlaneTests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/PlaneTests.swift
@@ -1,0 +1,48 @@
+//
+//  PlaneTests.swift
+//
+//
+//  Created by Mikhail Tishin on 23.01.2024.
+//
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class PlaneTests: GodotTestCase {
+    
+    func testOperatorUnaryMinus () {
+        var value: Plane
+        
+        value = -Plane (normal: Vector3 (x: -1.1, y: 2.2, z: -3.3), d: 4.4)
+        XCTAssertEqual (value.normal.x, 1.1)
+        XCTAssertEqual (value.normal.y, -2.2)
+        XCTAssertEqual (value.normal.z, 3.3)
+        XCTAssertEqual (value.d, -4.4)
+        
+        value = -Plane (normal: Vector3 (x: 5.5, y: -6.6, z: 7.7), d: -8.8)
+        XCTAssertEqual (value.normal.x, -5.5)
+        XCTAssertEqual (value.normal.y, 6.6)
+        XCTAssertEqual (value.normal.z, -7.7)
+        XCTAssertEqual (value.d, 8.8)
+        
+        value = -Plane (normal: Vector3 (x: -.greatestFiniteMagnitude, y: .greatestFiniteMagnitude, z: -.greatestFiniteMagnitude), d: .greatestFiniteMagnitude)
+        XCTAssertEqual (value.normal.x, .greatestFiniteMagnitude)
+        XCTAssertEqual (value.normal.y, -.greatestFiniteMagnitude)
+        XCTAssertEqual (value.normal.z, .greatestFiniteMagnitude)
+        XCTAssertEqual (value.d, -.greatestFiniteMagnitude)
+        
+        value = -Plane (normal: Vector3 (x: .infinity, y: -.infinity, z: .infinity), d: -.infinity)
+        XCTAssertEqual (value.normal.x, -.infinity)
+        XCTAssertEqual (value.normal.y, .infinity)
+        XCTAssertEqual (value.normal.z, -.infinity)
+        XCTAssertEqual (value.d, .infinity)
+        
+        value = -Plane (normal: Vector3 (x: .nan, y: .nan, z: .nan), d: .nan)
+        XCTAssertTrue (value.normal.x.isNaN)
+        XCTAssertTrue (value.normal.y.isNaN)
+        XCTAssertTrue (value.normal.z.isNaN)
+        XCTAssertTrue (value.d.isNaN)
+    }
+    
+}

--- a/Tests/SwiftGodotTests/BuiltIn/QuaternionTests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/QuaternionTests.swift
@@ -1,0 +1,48 @@
+//
+//  QuaternionTests.swift
+//
+//
+//  Created by Mikhail Tishin on 23.01.2024.
+//
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class QuaternionTests: GodotTestCase {
+    
+    func testOperatorUnaryMinus () {
+        var value: Quaternion
+        
+        value = -Quaternion (x: -1.1, y: 2.2, z: -3.3, w: 4.4)
+        XCTAssertEqual (value.x, 1.1)
+        XCTAssertEqual (value.y, -2.2)
+        XCTAssertEqual (value.z, 3.3)
+        XCTAssertEqual (value.w, -4.4)
+        
+        value = -Quaternion (x: 5.5, y: -6.6, z: 7.7, w: -8.8)
+        XCTAssertEqual (value.x, -5.5)
+        XCTAssertEqual (value.y, 6.6)
+        XCTAssertEqual (value.z, -7.7)
+        XCTAssertEqual (value.w, 8.8)
+        
+        value = -Quaternion (x: -.greatestFiniteMagnitude, y: .greatestFiniteMagnitude, z: -.greatestFiniteMagnitude, w: .greatestFiniteMagnitude)
+        XCTAssertEqual (value.x, .greatestFiniteMagnitude)
+        XCTAssertEqual (value.y, -.greatestFiniteMagnitude)
+        XCTAssertEqual (value.z, .greatestFiniteMagnitude)
+        XCTAssertEqual (value.w, -.greatestFiniteMagnitude)
+        
+        value = -Quaternion (x: .infinity, y: -.infinity, z: .infinity, w: -.infinity)
+        XCTAssertEqual (value.x, -.infinity)
+        XCTAssertEqual (value.y, .infinity)
+        XCTAssertEqual (value.z, -.infinity)
+        XCTAssertEqual (value.w, .infinity)
+        
+        value = -Quaternion (x: .nan, y: .nan, z: .nan, w: .nan)
+        XCTAssertTrue (value.x.isNaN)
+        XCTAssertTrue (value.y.isNaN)
+        XCTAssertTrue (value.z.isNaN)
+        XCTAssertTrue (value.w.isNaN)
+    }
+    
+}

--- a/Tests/SwiftGodotTests/BuiltIn/Vector2Tests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/Vector2Tests.swift
@@ -1,0 +1,38 @@
+//
+//  Vector2Tests.swift
+//
+//
+//  Created by Mikhail Tishin on 21.10.2023.
+//
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class Vector2Tests: GodotTestCase {
+    
+    func testOperatorUnaryMinus () {
+        var value: Vector2
+        
+        value = -Vector2 (x: -1.1, y: 2.2)
+        XCTAssertEqual (value.x, 1.1)
+        XCTAssertEqual (value.y, -2.2)
+        
+        value = -Vector2 (x: 3.3, y: -4.4)
+        XCTAssertEqual (value.x, -3.3)
+        XCTAssertEqual (value.y, 4.4)
+        
+        value = -Vector2 (x: -.greatestFiniteMagnitude, y: .greatestFiniteMagnitude)
+        XCTAssertEqual (value.x, .greatestFiniteMagnitude)
+        XCTAssertEqual (value.y, -.greatestFiniteMagnitude)
+        
+        value = -Vector2 (x: .infinity, y: -.infinity)
+        XCTAssertEqual (value.x, -.infinity)
+        XCTAssertEqual (value.y, .infinity)
+        
+        value = -Vector2 (x: .nan, y: .nan)
+        XCTAssertTrue (value.x.isNaN)
+        XCTAssertTrue (value.y.isNaN)
+    }
+    
+}

--- a/Tests/SwiftGodotTests/BuiltIn/Vector2iTests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/Vector2iTests.swift
@@ -11,6 +11,30 @@ import SwiftGodotTestability
 
 final class Vector2iTests: GodotTestCase {
     
+    func testOperatorUnaryMinus () {
+        var value: Vector2i
+        
+        value = -Vector2i (x: -1, y: 2)
+        XCTAssertEqual (value.x, 1)
+        XCTAssertEqual (value.y, -2)
+        
+        value = -Vector2i (x: 3, y: -4)
+        XCTAssertEqual (value.x, -3)
+        XCTAssertEqual (value.y, 4)
+        
+        value = -Vector2i (x: Int32.max, y: Int32.max)
+        XCTAssertEqual (value.x, Int32.min + 1)
+        XCTAssertEqual (value.y, Int32.min + 1)
+        
+        value = -Vector2i (x: Int32.min + 1, y: Int32.min + 1)
+        XCTAssertEqual (value.x, Int32.max)
+        XCTAssertEqual (value.y, Int32.max)
+        
+        value = -Vector2i (x: Int32.min, y: Int32.min)
+        XCTAssertEqual (value.x, Int32.min)
+        XCTAssertEqual (value.y, Int32.min)
+    }
+    
     func testOperatorPlus () {
         var value: Vector2i
         

--- a/Tests/SwiftGodotTests/BuiltIn/Vector3Tests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/Vector3Tests.swift
@@ -1,0 +1,43 @@
+//
+//  Vector3Tests.swift
+//
+//
+//  Created by Mikhail Tishin on 21.10.2023.
+//
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class Vector3Tests: GodotTestCase {
+    
+    func testOperatorUnaryMinus () {
+        var value: Vector3
+        
+        value = -Vector3 (x: -1.1, y: 2.2, z: -3.3)
+        XCTAssertEqual (value.x, 1.1)
+        XCTAssertEqual (value.y, -2.2)
+        XCTAssertEqual (value.z, 3.3)
+        
+        value = -Vector3 (x: 4.4, y: -5.5, z: 6.6)
+        XCTAssertEqual (value.x, -4.4)
+        XCTAssertEqual (value.y, 5.5)
+        XCTAssertEqual (value.z, -6.6)
+        
+        value = -Vector3 (x: -.greatestFiniteMagnitude, y: .greatestFiniteMagnitude, z: -.greatestFiniteMagnitude)
+        XCTAssertEqual (value.x, .greatestFiniteMagnitude)
+        XCTAssertEqual (value.y, -.greatestFiniteMagnitude)
+        XCTAssertEqual (value.z, .greatestFiniteMagnitude)
+        
+        value = -Vector3 (x: .infinity, y: -.infinity, z: .infinity)
+        XCTAssertEqual (value.x, -.infinity)
+        XCTAssertEqual (value.y, .infinity)
+        XCTAssertEqual (value.z, -.infinity)
+        
+        value = -Vector3 (x: .nan, y: .nan, z: .nan)
+        XCTAssertTrue (value.x.isNaN)
+        XCTAssertTrue (value.y.isNaN)
+        XCTAssertTrue (value.z.isNaN)
+    }
+    
+}

--- a/Tests/SwiftGodotTests/BuiltIn/Vector3iTests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/Vector3iTests.swift
@@ -11,6 +11,35 @@ import SwiftGodotTestability
 
 final class Vector3iTests: GodotTestCase {
     
+    func testOperatorUnaryMinus () {
+        var value: Vector3i
+        
+        value = -Vector3i (x: -1, y: 2, z: -3)
+        XCTAssertEqual (value.x, 1)
+        XCTAssertEqual (value.y, -2)
+        XCTAssertEqual (value.z, 3)
+        
+        value = -Vector3i (x: 4, y: -5, z: 6)
+        XCTAssertEqual (value.x, -4)
+        XCTAssertEqual (value.y, 5)
+        XCTAssertEqual (value.z, -6)
+        
+        value = -Vector3i (x: Int32.max, y: Int32.max, z: Int32.max)
+        XCTAssertEqual (value.x, Int32.min + 1)
+        XCTAssertEqual (value.y, Int32.min + 1)
+        XCTAssertEqual (value.z, Int32.min + 1)
+        
+        value = -Vector3i (x: Int32.min + 1, y: Int32.min + 1, z: Int32.min + 1)
+        XCTAssertEqual (value.x, Int32.max)
+        XCTAssertEqual (value.y, Int32.max)
+        XCTAssertEqual (value.z, Int32.max)
+        
+        value = -Vector3i (x: Int32.min, y: Int32.min, z: Int32.min)
+        XCTAssertEqual (value.x, Int32.min)
+        XCTAssertEqual (value.y, Int32.min)
+        XCTAssertEqual (value.z, Int32.min)
+    }
+    
     func testOperatorPlus () {
         var value: Vector3i
         

--- a/Tests/SwiftGodotTests/BuiltIn/Vector4Tests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/Vector4Tests.swift
@@ -1,0 +1,48 @@
+//
+//  Vector4Tests.swift
+//
+//
+//  Created by Mikhail Tishin on 21.10.2023.
+//
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class Vector4Tests: GodotTestCase {
+    
+    func testOperatorUnaryMinus () {
+        var value: Vector4
+        
+        value = -Vector4 (x: -1.1, y: 2.2, z: -3.3, w: 4.4)
+        XCTAssertEqual (value.x, 1.1)
+        XCTAssertEqual (value.y, -2.2)
+        XCTAssertEqual (value.z, 3.3)
+        XCTAssertEqual (value.w, -4.4)
+        
+        value = -Vector4 (x: 5.5, y: -6.6, z: 7.7, w: -8.8)
+        XCTAssertEqual (value.x, -5.5)
+        XCTAssertEqual (value.y, 6.6)
+        XCTAssertEqual (value.z, -7.7)
+        XCTAssertEqual (value.w, 8.8)
+        
+        value = -Vector4 (x: -.greatestFiniteMagnitude, y: .greatestFiniteMagnitude, z: -.greatestFiniteMagnitude, w: .greatestFiniteMagnitude)
+        XCTAssertEqual (value.x, .greatestFiniteMagnitude)
+        XCTAssertEqual (value.y, -.greatestFiniteMagnitude)
+        XCTAssertEqual (value.z, .greatestFiniteMagnitude)
+        XCTAssertEqual (value.w, -.greatestFiniteMagnitude)
+        
+        value = -Vector4 (x: .infinity, y: -.infinity, z: .infinity, w: -.infinity)
+        XCTAssertEqual (value.x, -.infinity)
+        XCTAssertEqual (value.y, .infinity)
+        XCTAssertEqual (value.z, -.infinity)
+        XCTAssertEqual (value.w, .infinity)
+        
+        value = -Vector4 (x: .nan, y: .nan, z: .nan, w: .nan)
+        XCTAssertTrue (value.x.isNaN)
+        XCTAssertTrue (value.y.isNaN)
+        XCTAssertTrue (value.z.isNaN)
+        XCTAssertTrue (value.w.isNaN)
+    }
+    
+}

--- a/Tests/SwiftGodotTests/BuiltIn/Vector4iTests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/Vector4iTests.swift
@@ -11,6 +11,40 @@ import SwiftGodotTestability
 
 final class Vector4iTests: GodotTestCase {
     
+    func testOperatorUnaryMinus () {
+        var value: Vector4i
+        
+        value = -Vector4i (x: -1, y: 2, z: -3, w: 4)
+        XCTAssertEqual (value.x, 1)
+        XCTAssertEqual (value.y, -2)
+        XCTAssertEqual (value.z, 3)
+        XCTAssertEqual (value.w, -4)
+        
+        value = -Vector4i (x: 5, y: -6, z: 7, w: -8)
+        XCTAssertEqual (value.x, -5)
+        XCTAssertEqual (value.y, 6)
+        XCTAssertEqual (value.z, -7)
+        XCTAssertEqual (value.w, 8)
+        
+        value = -Vector4i (x: Int32.max, y: Int32.max, z: Int32.max, w: Int32.max)
+        XCTAssertEqual (value.x, Int32.min + 1)
+        XCTAssertEqual (value.y, Int32.min + 1)
+        XCTAssertEqual (value.z, Int32.min + 1)
+        XCTAssertEqual (value.w, Int32.min + 1)
+        
+        value = -Vector4i (x: Int32.min + 1, y: Int32.min + 1, z: Int32.min + 1, w: Int32.min + 1)
+        XCTAssertEqual (value.x, Int32.max)
+        XCTAssertEqual (value.y, Int32.max)
+        XCTAssertEqual (value.z, Int32.max)
+        XCTAssertEqual (value.w, Int32.max)
+        
+        value = -Vector4i (x: Int32.min, y: Int32.min, z: Int32.min, w: Int32.min)
+        XCTAssertEqual (value.x, Int32.min)
+        XCTAssertEqual (value.y, Int32.min)
+        XCTAssertEqual (value.z, Int32.min)
+        XCTAssertEqual (value.w, Int32.min)
+    }
+    
     func testOperatorPlus () {
         var value: Vector4i
         


### PR DESCRIPTION
Follow-up to #359. Godot does not crash on arithmetic overflows, so neither should we.