### PR TITLE
Make StringName and GString Hashable

### DIFF
--- a/Sources/SwiftGodot/Core/StringExtensions.swift
+++ b/Sources/SwiftGodot/Core/StringExtensions.swift
@@ -7,7 +7,7 @@
 
 @_implementationOnly import GDExtension
 
-extension StringName: CustomStringConvertible {
+extension StringName: CustomStringConvertible, Hashable {
     /// Creates a StringName from a Swift String.Substring
     public convenience init (_ from: String.SubSequence) {
         self.init (from: String (from))
@@ -17,6 +17,10 @@ extension StringName: CustomStringConvertible {
     public var description: String {
         let buffer = toUtf8Buffer()
         return buffer.getStringFromUtf8().description
+    }
+    
+    public func hash (into hasher: inout Hasher) {
+        hasher.combine (hash ())
     }
     
     /// Compares two StringNames for equality.
@@ -42,7 +46,7 @@ func stringFromGodotString (_ ptr: UnsafeRawPointer) -> String? {
     }
 }
     
-extension GString: CustomStringConvertible {
+extension GString: CustomStringConvertible, Hashable {
     /// Returns a Swift string from a pointer to a native Godot string
     static func stringFromGStringPtr (ptr: UnsafeRawPointer?) -> String? {
         guard let ptr else {
@@ -69,6 +73,10 @@ extension GString: CustomStringConvertible {
                 } ?? ""
             }
         }
+    }
+    
+    public func hash (into hasher: inout Hasher) {
+        hasher.combine (hash ())
     }
 }
 


### PR DESCRIPTION
Closes #344, closes #379. 

It's probably possible to make it match Swift string hashing:
```swift
extension String: Hashable {
  /// Hashes the essential components of this value by feeding them into the
  /// given hasher.
  ///
  /// - Parameter hasher: The hasher to use when combining the components
  ///   of this instance.
  public func hash(into hasher: inout Hasher) {
    if _fastPath(self._guts.isNFCFastUTF8) {
      self._guts.withFastUTF8 {
        hasher.combine(bytes: UnsafeRawBufferPointer($0))
      }
      hasher.combine(0xFF as UInt8) // terminator
    } else {
      _gutsSlice._normalizedHash(into: &hasher)
    }
  }
}
```
by using `toUtf8Buffer`, but I don't think there's an effective way to get actual byte array from `PackedByteArray`.