### PR TITLE
Fix Variant ret

### DIFF
--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -182,11 +182,11 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
         if value == UnsafeRawPointer(bitPattern: 0) {
             return nil
         }
+        let ret: T? = lookupObject(nativeHandle: value)
         if let rc = ret as? RefCounted {
             // When we pull out a refcounted out of a Variant, take a reference
             rc.reference ()
         }
-        let ret: T? = lookupObject(nativeHandle: value)
         return ret
     }
     


### PR DESCRIPTION
I was getting this compile error

```
/Users/nvanfleet/src/PlantQuest/build/checkouts/SwiftGodot/Sources/SwiftGodot/Variant.swift:185:21: error: use of local variable 'ret' before its declaration
        if let rc = ret as? RefCounted {
                    ^
/Users/nvanfleet/src/PlantQuest/build/checkouts/SwiftGodot/Sources/SwiftGodot/Variant.swift:189:13: note: 'ret' declared here
        let ret: T? = lookupObject(nativeHandle: value)
            ^
error: fatalError
```

Looks like the ret should be declared before it is used.

cc @migueldeicaza 