### PR TITLE
Fix destruction of externally managed variants

### DIFF
--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -67,12 +67,18 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
     var content: ContentType = (0, 0, 0)
     static var zero: ContentType = (0, 0, 0)
     
+    /// Underlying Godot Variant should be destroyed on Swift Variant deinit
+    var destroyOnDeinit: Bool = true
+    
     /// Initializes from the raw contents of another Variant
     init (fromContent: ContentType) {
         content = fromContent
+        // Content deallocation is managed externally
+        destroyOnDeinit = false
     }
     
     deinit {
+        guard destroyOnDeinit else { return }
         if experimentalDisableVariantUnref { return }
         gi.variant_destroy (&content)
     }


### PR DESCRIPTION
Fixes #390. Not sure if it's the correct solution, but the way I see it, Variant shouldn't destroy `content` which wasn't initialized for that variant and is managed somewhere else.