### PR TITLE
Add protocol GodotMacroClass to label @Godot classes

### DIFF
--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -7,6 +7,8 @@
 
 #if !(os(Windows) && swift(<5.9.1))
 
+public protocol GodotMacroClass: GodotObject {}
+
 /// Creates the definition for a Swift class to be surfaced to Godot.
 ///
 /// This macro creates the required constructors that the SwiftGodot framework requires (the `init`, and the
@@ -19,6 +21,7 @@
 ///
 @attached(member,
           names: named (_initializeClass), named(classInitializer), named (implementedOverrides))
+@attached(extension, conformances: GodotMacroClass)
 public macro Godot(_ behavior: ClassBehavior = .gameplay) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacro")
 
 public enum ClassBehavior: Int {

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -501,7 +501,7 @@ func camelToSnake(_ s: String) -> String {
 /// `init(nativeHandle:)` and `init()` constructors along with the
 /// static class initializer for any exported properties and methods.
 ///
-public struct GodotMacro: MemberMacro {
+public struct GodotMacro: MemberMacro, ExtensionMacro {
     
     public static func expansion(of node: AttributeSyntax,
                                  providingMembersOf declaration: some DeclGroupSyntax,
@@ -573,6 +573,27 @@ public struct GodotMacro: MemberMacro {
             context.diagnose(diagnostic)
             return []
         }
+    }
+    
+    public static func expansion(
+      of node: AttributeSyntax,
+      attachedTo declaration: some DeclGroupSyntax,
+      providingExtensionsOf type: some TypeSyntaxProtocol,
+      conformingTo protocols: [TypeSyntax],
+      in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        guard let classDecl = declaration.as(ClassDeclSyntax.self) else {
+            let classError = Diagnostic(node: declaration.root, message: GodotMacroError.requiresClass)
+            context.diagnose(classError)
+            return []
+        }
+        return [
+            try ExtensionDeclSyntax(
+            """
+            extension \(raw: classDecl.name.text): GodotMacroClass {}
+            """
+            )
+        ]
     }
 }
 

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -42,6 +42,9 @@ final class MacroGodotTests: XCTestCase {
                     let classInfo = ClassInfo<Hi> (name: className)
                 } ()
             }
+            
+            extension Hi: GodotMacroClass {
+            }
             """,
             macros: testMacros
         )
@@ -78,6 +81,9 @@ final class MacroGodotTests: XCTestCase {
                     ]
                 }
             }
+            
+            extension Hi: GodotMacroClass {
+            }
             """,
             macros: testMacros
         )
@@ -111,6 +117,9 @@ final class MacroGodotTests: XCTestCase {
                     ]
                 }
             }
+            
+            extension Hi: GodotMacroClass {
+            }
             """,
             macros: testMacros
         )
@@ -141,6 +150,9 @@ final class MacroGodotTests: XCTestCase {
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<Hi> (name: className)
                 } ()
+            }
+            
+            extension Hi: GodotMacroClass {
             }
             """,
 			macros: testMacros
@@ -179,6 +191,9 @@ final class MacroGodotTests: XCTestCase {
                     classInfo.registerSignal(name: Hi.differentInit.name, arguments: Hi.differentInit.arguments)
                     classInfo.registerSignal(name: Hi.differentInit2.name, arguments: Hi.differentInit2.arguments)
                 } ()
+            }
+            
+            extension Hi: GodotMacroClass {
             }
             """,
             macros: testMacros
@@ -265,6 +280,9 @@ final class MacroGodotTests: XCTestCase {
                     	classInfo.registerMethod(name: StringName("queue"), flags: .default, returnValue: nil, arguments: queueArgs, function: Castro._mproxy_queue)
                     } ()
                 }
+                
+                extension Castro: GodotMacroClass {
+                }
                 """,
 			macros: testMacros
 		)
@@ -335,6 +353,12 @@ final class MacroGodotTests: XCTestCase {
                 	classInfo.registerMethod (name: "_mproxy_set_data", flags: .default, returnValue: nil, arguments: [_pdata], function: MyClass._mproxy_set_data)
                 	classInfo.registerProperty (_pdata, getter: "_mproxy_get_data", setter: "_mproxy_set_data")
                 } ()
+            }
+
+            extension MyData: GodotMacroClass {
+            }
+
+            extension MyClass: GodotMacroClass {
             }
             """,
             macros: testMacros
@@ -802,6 +826,9 @@ final class MacroGodotTests: XCTestCase {
                     	classInfo.registerMethod(name: StringName("areBothTrue"), flags: .default, returnValue: prop_6, arguments: areBothTrueArgs, function: MathHelper._mproxy_areBothTrue)
                     } ()
                 }
+
+                extension MathHelper: GodotMacroClass {
+                }
                 """,
 			macros: testMacros
 		)
@@ -855,6 +882,9 @@ final class MacroGodotTests: XCTestCase {
                 	classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
                 	classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
                 } ()
+            }
+
+            extension Hi: GodotMacroClass {
             }
             """,
 			macros: testMacros


### PR DESCRIPTION
This adds conformance to GodotMacroClass for all classes generated with the `@Godot` macro.