### PR TITLE
Make SceneTree macro path optional

### DIFF
--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -180,7 +180,7 @@ public macro NativeHandleDiscarding() = #externalMacro(module: "SwiftGodotMacroL
 ///
 /// - Important: This property will become a computed property, and it cannot be reassigned later.
 @attached(accessor)
-public macro SceneTree(path: String) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SceneTreeMacro")
+public macro SceneTree(path: String? = nil) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SceneTreeMacro")
 
 /// Defines a Godot signal on a class.
 ///


### PR DESCRIPTION
Fixes #401. Not sure how it managed to work previously, `path` wasn't optional and didn't have a default value in the original PR. Maybe Xcode/Swift updates broke it, I don't know.