### PR TITLE
Replace NSRegularExpressions with native Swift Regexes

### DIFF
--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -19,16 +19,13 @@ func snakeToCamel(_ s: String) -> String {
 
 extension String {
     func camelCaseToSnakeCase() -> String {
-        let acronymPattern = "([A-Z]+)([A-Z][a-z]|[0-9])"
-        let normalPattern = "([a-z0-9])([A-Z])"
-        return processCamalCaseRegex(pattern: acronymPattern)?
-            .processCamalCaseRegex(pattern: normalPattern)?.lowercased() ?? lowercased()
+        let acronymRegex = #/([A-Z]+)([A-Z][a-z]|[0-9])/#
+        let normalRegex = #/([a-z0-9])([A-Z])/#
+        return processCamelCaseRegex(acronymRegex).processCamelCaseRegex(normalRegex).lowercased()
     }
 
-    fileprivate func processCamalCaseRegex(pattern: String) -> String? {
-        let regex = try? NSRegularExpression(pattern: pattern, options: [])
-        let range = NSRange(location: 0, length: count)
-        return regex?.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "$1_$2")
+    fileprivate func processCamelCaseRegex(_ regex: Regex<(Substring, Substring, Substring)>) -> String {
+        replacing(regex) { "\($0.1)_\($0.2)" }
     }
 }
 
@@ -111,19 +108,6 @@ extension String {
     }
 
     func isValidSwiftName() -> Bool {
-        let pattern = #"\b[a-zA-Z_][a-zA-Z0-9_]*\b"#
-
-        do {
-            let regex = try NSRegularExpression(pattern: pattern)
-            let range = NSRange(self.startIndex..<self.endIndex, in: self)
-            
-            if let match = regex.firstMatch(in: self, range: range) {
-                return match.range == range
-            } else {
-                return false
-            }
-        } catch {
-            fatalError("Invalid regex pattern: \(error)")
-        }
+        wholeMatch(of: #/\b[a-zA-Z_][a-zA-Z0-9_]*\b/#) != nil
     }
 }

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -479,16 +479,13 @@ private func godotArrayElementType(gType: String) -> String? {
 
 extension String {
     func camelCaseToSnakeCase() -> String {
-        let acronymPattern = "([A-Z]+)([A-Z][a-z]|[0-9])"
-        let normalPattern = "([a-z0-9])([A-Z])"
-        return processCamalCaseRegex(pattern: acronymPattern)?
-            .processCamalCaseRegex(pattern: normalPattern)?.lowercased() ?? lowercased()
+        let acronymRegex = #/([A-Z]+)([A-Z][a-z]|[0-9])/#
+        let normalRegex = #/([a-z0-9])([A-Z])/#
+        return processCamelCaseRegex(acronymRegex).processCamelCaseRegex(normalRegex).lowercased()
     }
 
-    fileprivate func processCamalCaseRegex(pattern: String) -> String? {
-        let regex = try? NSRegularExpression(pattern: pattern, options: [])
-        let range = NSRange(location: 0, length: count)
-        return regex?.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "$1_$2")
+    fileprivate func processCamelCaseRegex(_ regex: Regex<(Substring, Substring, Substring)>) -> String {
+        replacing(regex) { "\($0.1)_\($0.2)" }
     }
 }
 


### PR DESCRIPTION
I don't think anyone should use `NSRegularExpression` in Swift anymore, so I replaced the few places where it is used with the native Swift Regexes that are available since Swift 5.7.