### PR TITLE
Exported `VariantCollection` and `ObjectCollection` types do not appear in the Editor

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -55,7 +55,6 @@ class GodotMacroProcessor {
         
         let className: String
         let hintStr: String
-        let usage = propType == ".array" ? ".array" : ".default"
         let hint = propType == ".array" ? ".arrayType" : ".none"
         
         if propType == ".array",
@@ -81,7 +80,7 @@ class GodotMacroProcessor {
         
         // TODO: perhaps for these prop infos that are parameters to functions, we should not bother making them unique
         // and instead share all the Ints, all the Floats and so on.
-        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\(parameterName)\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: \(usage))\n")
+        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\(parameterName)\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: .default)\n")
         propertyDeclarations [key] = name
         return name
     }
@@ -123,11 +122,10 @@ class GodotMacroProcessor {
         }
         
         let name = "prop_\(propertyDeclarations.count)"
-        let usage = propType == ".array" ? ".array" : ".default"
         let hint = propType == ".array" ? ".arrayType" : ".none"
         // TODO: perhaps for these prop infos that are parameters to functions, we should not bother making them unique
         // and instead share all the Ints, all the Floats and so on.
-        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: \(usage))\n")
+        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: .default)\n")
         propertyDeclarations [key] = name
         return name
     }
@@ -382,7 +380,7 @@ class GodotMacroProcessor {
         className: StringName("\(godotArrayTypeName)"),
         hint: .arrayType,
         hintStr: "\(godotArrayElementTypeName)",
-        usage: .array)\n
+        usage: .default)\n
     """)
             
             ctor.append("\tclassInfo.registerMethod (name: \"\(getterName)\", flags: .default, returnValue: \(pinfo), arguments: [], function: \(className).\(proxyGetterName))\n")

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -571,7 +571,7 @@ class Car: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
     	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
     	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
@@ -581,7 +581,7 @@ class Car: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
     	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
     	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
@@ -655,7 +655,7 @@ class Car: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -666,7 +666,7 @@ class Car: Node {
             className: StringName("Array[int]"),
             hint: .arrayType,
             hintStr: "int",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -739,7 +739,7 @@ class Car: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -749,7 +749,7 @@ class Car: Node {
             className: StringName("Array[int]"),
             hint: .arrayType,
             hintStr: "int",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -860,7 +860,7 @@ class Car: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -871,7 +871,7 @@ class Car: Node {
             className: StringName("Array[int]"),
             hint: .arrayType,
             hintStr: "int",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -881,7 +881,7 @@ class Car: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
     	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
     	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
@@ -891,7 +891,7 @@ class Car: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
     	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
     	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
@@ -968,7 +968,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
     	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
     	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
@@ -978,7 +978,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
     	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
     	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
@@ -1051,7 +1051,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -1062,7 +1062,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -1135,7 +1135,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -1145,7 +1145,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -1256,7 +1256,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
     	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
     	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -1267,7 +1267,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
     	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
     	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
@@ -1277,7 +1277,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
     	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
     	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
@@ -1287,7 +1287,7 @@ class Car: Node {
             className: StringName("Array[Node]"),
             hint: .arrayType,
             hintStr: "Node",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
     	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
     	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
@@ -1490,7 +1490,7 @@ class Garage: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_reviews", flags: .default, returnValue: _previews, arguments: [], function: Garage._mproxy_get_reviews)
     	classInfo.registerMethod (name: "set_reviews", flags: .default, returnValue: nil, arguments: [_previews], function: Garage._mproxy_set_reviews)
     	classInfo.registerProperty (_previews, getter: "get_reviews", setter: "set_reviews")
@@ -1500,7 +1500,7 @@ class Garage: Node {
             className: StringName("Array[CheckIn]"),
             hint: .arrayType,
             hintStr: "CheckIn",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_check_ins", flags: .default, returnValue: _pcheckIns, arguments: [], function: Garage._mproxy_get_checkIns)
     	classInfo.registerMethod (name: "set_check_ins", flags: .default, returnValue: nil, arguments: [_pcheckIns], function: Garage._mproxy_set_checkIns)
     	classInfo.registerProperty (_pcheckIns, getter: "get_check_ins", setter: "set_check_ins")
@@ -1521,7 +1521,7 @@ class Garage: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_days_of_operation", flags: .default, returnValue: _pdaysOfOperation, arguments: [], function: Garage._mproxy_get_daysOfOperation)
     	classInfo.registerMethod (name: "set_days_of_operation", flags: .default, returnValue: nil, arguments: [_pdaysOfOperation], function: Garage._mproxy_set_daysOfOperation)
     	classInfo.registerProperty (_pdaysOfOperation, getter: "get_days_of_operation", setter: "set_days_of_operation")
@@ -1531,7 +1531,7 @@ class Garage: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_hours", flags: .default, returnValue: _phours, arguments: [], function: Garage._mproxy_get_hours)
     	classInfo.registerMethod (name: "set_hours", flags: .default, returnValue: nil, arguments: [_phours], function: Garage._mproxy_set_hours)
     	classInfo.registerProperty (_phours, getter: "get_hours", setter: "set_hours")
@@ -1541,7 +1541,7 @@ class Garage: Node {
             className: StringName("Array[InsuranceProvider]"),
             hint: .arrayType,
             hintStr: "InsuranceProvider",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_insurance_providers_accepted", flags: .default, returnValue: _pinsuranceProvidersAccepted, arguments: [], function: Garage._mproxy_get_insuranceProvidersAccepted)
     	classInfo.registerMethod (name: "set_insurance_providers_accepted", flags: .default, returnValue: nil, arguments: [_pinsuranceProvidersAccepted], function: Garage._mproxy_set_insuranceProvidersAccepted)
     	classInfo.registerProperty (_pinsuranceProvidersAccepted, getter: "get_insurance_providers_accepted", setter: "set_insurance_providers_accepted")
@@ -1742,7 +1742,7 @@ class Garage: Node {
             className: StringName("Array[bool]"),
             hint: .arrayType,
             hintStr: "bool",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
     	classInfo.registerMethod (name: "set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
     	classInfo.registerProperty (_pbar, getter: "get_bar", setter: "set_bar")
@@ -1816,7 +1816,7 @@ public class Issue353: Node {
             className: StringName("Array[bool]"),
             hint: .arrayType,
             hintStr: "bool",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
     	classInfo.registerMethod (name: "set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
     	classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "get__prefixed_bool", setter: "set__prefixed_bool")
@@ -1826,7 +1826,7 @@ public class Issue353: Node {
             className: StringName("Array[bool]"),
             hint: .arrayType,
             hintStr: "bool",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
     	classInfo.registerMethod (name: "set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
     	classInfo.registerProperty (_pnon_prefixed_bool, getter: "get_non_prefixed_bool", setter: "set_non_prefixed_bool")

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -102,7 +102,7 @@ class SomeNode: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
     	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
     	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
@@ -255,7 +255,7 @@ class SomeNode: Node {
             className: StringName("Array[int]"),
             hint: .arrayType,
             hintStr: "int",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
     	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
     	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
@@ -327,7 +327,7 @@ class SomeNode: Node {
             className: StringName("Array[int]"),
             hint: .arrayType,
             hintStr: "int",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
     	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
     	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
@@ -337,7 +337,7 @@ class SomeNode: Node {
             className: StringName("Array[int]"),
             hint: .arrayType,
             hintStr: "int",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_some_other_numbers", flags: .default, returnValue: _psomeOtherNumbers, arguments: [], function: SomeNode._mproxy_get_someOtherNumbers)
     	classInfo.registerMethod (name: "set_some_other_numbers", flags: .default, returnValue: nil, arguments: [_psomeOtherNumbers], function: SomeNode._mproxy_set_someOtherNumbers)
     	classInfo.registerProperty (_psomeOtherNumbers, getter: "get_some_other_numbers", setter: "set_some_other_numbers")
@@ -411,7 +411,7 @@ class ArrayTest: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_first_names", flags: .default, returnValue: _pfirstNames, arguments: [], function: ArrayTest._mproxy_get_firstNames)
     	classInfo.registerMethod (name: "set_first_names", flags: .default, returnValue: nil, arguments: [_pfirstNames], function: ArrayTest._mproxy_set_firstNames)
     	classInfo.registerProperty (_pfirstNames, getter: "get_first_names", setter: "set_first_names")
@@ -421,7 +421,7 @@ class ArrayTest: Node {
             className: StringName("Array[String]"),
             hint: .arrayType,
             hintStr: "String",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_last_names", flags: .default, returnValue: _plastNames, arguments: [], function: ArrayTest._mproxy_get_lastNames)
     	classInfo.registerMethod (name: "set_last_names", flags: .default, returnValue: nil, arguments: [_plastNames], function: ArrayTest._mproxy_set_lastNames)
     	classInfo.registerProperty (_plastNames, getter: "get_last_names", setter: "set_last_names")
@@ -504,7 +504,7 @@ class SomeNode: Node {
             className: StringName("Array[Node3D]"),
             hint: .arrayType,
             hintStr: "Node3D",
-            usage: .array)
+            usage: .default)
     	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
     	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
     	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -375,7 +375,7 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .array)
+                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     	classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getIntegerCollection)
                     } ()
                 }
@@ -419,8 +419,8 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .array)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .array)
+                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     	let squareArgs = [
                     		prop_1,
                     	]
@@ -466,7 +466,7 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .array)
+                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .default)
                     	classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getNodeCollection)
                     } ()
                 }
@@ -510,7 +510,7 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "nodes", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .array)
+                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "nodes", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .default)
                     	let printNamesArgs = [
                     		prop_0,
                     	]
@@ -556,7 +556,7 @@ final class MacroGodotTests: XCTestCase {
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<MultiplierNode> (name: className)
                     	let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .array)
+                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     	let multiplyArgs = [
                     		prop_1,
                     	]
@@ -618,9 +618,9 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("CallableCollectionsNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .array)
+                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     	classInfo.registerMethod(name: StringName("get_ages"), flags: .default, returnValue: prop_0, arguments: [], function: CallableCollectionsNode._mproxy_get_ages)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .array)
+                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .default)
                     	classInfo.registerMethod(name: StringName("get_markers"), flags: .default, returnValue: prop_1, arguments: [], function: CallableCollectionsNode._mproxy_get_markers)
                     } ()
                 }
@@ -663,7 +663,7 @@ final class MacroGodotTests: XCTestCase {
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<MultiplierNode> (name: className)
                     	let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .array)
+                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     	let multiplyArgs = [
                     		prop_1,
                     	]
@@ -725,9 +725,9 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("CallableCollectionsNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .array)
+                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     	classInfo.registerMethod(name: StringName("get_ages"), flags: .default, returnValue: prop_0, arguments: [], function: CallableCollectionsNode._mproxy_get_ages)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .array)
+                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .default)
                     	classInfo.registerMethod(name: StringName("get_markers"), flags: .default, returnValue: prop_1, arguments: [], function: CallableCollectionsNode._mproxy_get_markers)
                     } ()
                 }


### PR DESCRIPTION
change `usage: .array` (back) to `usage: .default`