### PR TITLE
Fix extension api reading in Swift 5.10 on Windows

### DIFF
--- a/Generator/Generator/Data.swift
+++ b/Generator/Generator/Data.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension Data {
+
+    init(url: URL) throws {
+        // init(contentsOf:) is broken in Swift 5.10 on Windows
+        #if os(Windows) && swift(>=5.10)
+        let input = InputStream(url: url)!
+        try self.init(reading: input)
+        #else
+        try self.init(contentsOf: url)
+        #endif
+    }
+
+    init(reading input: InputStream) throws {
+        self.init()
+        input.open()
+        defer {
+            input.close()
+        }
+
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer {
+            buffer.deallocate()
+        }
+        while input.hasBytesAvailable {
+            let read = input.read(buffer, maxLength: bufferSize)
+            if read < 0 {
+                //Stream error occured
+                throw input.streamError!
+            } else if read == 0 {
+                //EOF
+                break
+            }
+            self.append(buffer, count: read)
+        }
+    }
+
+}

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -27,7 +27,7 @@ if args.count < 2 {
     print ("Running with Miguel's testing defaults")
 }
 
-let jsonData = try! Data(contentsOf: URL(fileURLWithPath: jsonFile))
+let jsonData = try! Data(url: URL(fileURLWithPath: jsonFile))
 let jsonApi = try! JSONDecoder().decode(JGodotExtensionAPI.self, from: jsonData)
 
 // Determines whether a built-in type is defined as a structure, this means:


### PR DESCRIPTION
Partly addresses #418. This makes source generation work, but there are still some issues with Windows build on Swift 5.10 remaining.