### PR TITLE
Fix build command execution on Windows using Swift 5.10

### DIFF
--- a/Plugins/CodeGeneratorPlugin/plugin.swift
+++ b/Plugins/CodeGeneratorPlugin/plugin.swift
@@ -37,12 +37,15 @@ import PackagePlugin
         outputFiles.append (contentsOf: known.map { genSourcesDir.appending(["generated", $0])})
         #endif
 
+        // For Windows with Swift 5.10 both prebuildCommand and buildCommand are needed
+        #if !os(Windows) || swift(>=5.10)
         commands.append(Command.buildCommand(
             displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
             executable: generator,
             arguments: arguments,
             inputFiles: [api],
             outputFiles: outputFiles))
+        #endif
         
         return commands
     }

--- a/Plugins/CodeGeneratorPlugin/plugin.swift
+++ b/Plugins/CodeGeneratorPlugin/plugin.swift
@@ -11,6 +11,7 @@ import PackagePlugin
 /// Generates the API for the SwiftGodot from the Godot exported Json API
 @main struct SwiftCodeGeneratorPlugin: BuildToolPlugin {
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        var commands: [Command] = []
         // Configure the commands to write to a "GeneratedSources" directory.
         let genSourcesDir = context.pluginWorkDirectory.appending("GeneratedSources")
 
@@ -26,23 +27,24 @@ import PackagePlugin
         outputFiles.append(genSourcesDir.appending(subpath: "Generated.swift"))
         arguments.append(context.package.directory.appending(subpath: "doc"))
         arguments.append("--singlefile")
-        let cmd: Command = Command.prebuildCommand(
+        commands.append(Command.prebuildCommand(
             displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
             executable: generator,
             arguments: arguments,
-            outputFilesDirectory: genSourcesDir)
+            outputFilesDirectory: genSourcesDir))
         #else
         outputFiles.append (contentsOf: knownBuiltin.map { genSourcesDir.appending(["generated-builtin", $0])})
         outputFiles.append (contentsOf: known.map { genSourcesDir.appending(["generated", $0])})
-        let cmd: Command = Command.buildCommand(
+        #endif
+
+        commands.append(Command.buildCommand(
             displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
             executable: generator,
             arguments: arguments,
             inputFiles: [api],
-            outputFiles: outputFiles)
-        #endif
+            outputFiles: outputFiles))
         
-        return [cmd]
+        return commands
     }
 }
 


### PR DESCRIPTION
Fixes #418 

We have two build commands here:
1. `prebuildCommand` which works as a source generator on Windows, but shouldn't work by design (on macOS it throws `a prebuild command cannot use executables built from source, including executable target 'Generator'`). On Swift 5.9 this command also added sources from `outputFilesDirectory` to the build, which does not happen on Swift 5.10. Not sure if we should report this, as our use case is wrong to begin with.
2. `buildCommand` which does not generate sources on Windows (the `.exe` never gets called), but works as a source provider through `outputFiles`. I have already reported the issue at https://github.com/apple/swift-package-manager/issues/6962

So combining the two broken things makes the build work again on Swift 5.10 toolchain. ~This shouldn't affect 5.9 builds, as `buildCommand` does not add any actual workload to the build.~
I wish there was a less hacky solution.