### PR TITLE
Clean up unnecessary Foundation imports

### DIFF
--- a/Sources/SwiftGodot/Core/InspectableProperty.swift
+++ b/Sources/SwiftGodot/Core/InspectableProperty.swift
@@ -5,8 +5,6 @@
 //  Created by Marquis Kurt on 10/15/23.
 //
 
-import Foundation
-
 /// A structure that houses a property that can be added to a Godot inspector.
 public struct InspectableProperty<T> {
     /// A typealias for the the method type used to register a property to Godot for inspectors.

--- a/Sources/SwiftGodot/Extensions/InputEvents.swift
+++ b/Sources/SwiftGodot/Extensions/InputEvents.swift
@@ -1,9 +1,0 @@
-//
-//  InputEvents.swift
-//
-//
-//  Created by Miguel de Icaza on 10/15/23.
-//
-
-import Foundation
-

--- a/Sources/SwiftGodot/Extensions/RefCountedExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/RefCountedExtensions.swift
@@ -1,4 +1,3 @@
-import Foundation
 @_implementationOnly import GDExtension
 
 public extension RefCounted {

--- a/Sources/SwiftGodot/Native/LinearInterpolation.swift
+++ b/Sources/SwiftGodot/Native/LinearInterpolation.swift
@@ -1,4 +1,3 @@
-import Foundation
 
 public protocol LinearInterpolation {
     /// Linearly interpolate from self to the given value considering the weight.

--- a/Sources/SwiftGodot/Native/RotationConversion.swift
+++ b/Sources/SwiftGodot/Native/RotationConversion.swift
@@ -1,4 +1,3 @@
-import Foundation
 
 extension BinaryFloatingPoint {
     /// Converts this floating point value assumed to be in degrees to radians.

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-2.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-2.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/22/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-3.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-3.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/22/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-4.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-4.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/22/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-5.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-5.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/22/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-6.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-6.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/22/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-init.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-init.swift
@@ -5,5 +5,4 @@
 //  Created by Marquis Kurt on 7/22/23.
 //
 
-import Foundation
 import SwiftGodot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-multiscript-2.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-multiscript-2.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-2.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-2.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-3.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-3.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-4.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-4.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-5.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-5.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-6.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-6.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-7.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-7.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-8.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-8.swift
@@ -5,7 +5,6 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot
 
 @Godot

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-init.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/PlayerController-starter-init.swift
@@ -5,5 +5,4 @@
 //  Created by Marquis Kurt on 7/19/23.
 //
 
-import Foundation
 import SwiftGodot


### PR DESCRIPTION
This leaves only 2 imports in `SwiftGodot` where `Foundation` is actually used:
- `PackedByteArray.asData()` returning `Data`
- `Numeric.snapped` native implementation using `floor()`

Both can be refactored without using `Foundation` dependency, which is too heavy for non-Darwin platforms compared to the convenience it brings. I think it should be up to users to decide whether they want to include `Foundation` into their game or not.