### PR TITLE
Add static version of SwiftGodot library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,9 @@ var products: [Product] = [
         type: .dynamic,
         targets: ["SwiftGodot"]),
     .library(
+        name: "SwiftGodotStatic",
+        targets: ["SwiftGodot"]),
+    .library(
         name: "ExtensionApi",
         targets: [
             "ExtensionApi",


### PR DESCRIPTION
Partly addresses #424, making it possible to use `SwiftGodotTestability` to test user extensions when extension itself depends on `SwiftGodotStatic`.