### PR TITLE
Proposal: Updated BindNode with safety and convenience lookup

### DIFF
--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -19,25 +19,53 @@
 ///
 ///     getNode(path: NodeName("GameOverLabel")) as! Label
 
+/// Use the BindNode property wrapper in any subclass of Node to retrieve the node from the
+/// current container that matches the name of the property.
+///
+/// For example:
+///
+///     class MyElements: CanvasLayer {
+///         @BindNode var GameOverLabel: Label
+///         @BindNode var gameOverLabel: Label
+///
+///         @BindNode(nodeName: "GameOverLabel") var customLabel: Label
+///     }
+///
+/// The above is equivalent to calling
+///
+///     getNode(path: NodeName("GameOverLabel")) as! Label
+
 @propertyWrapper
 public struct BindNode<Value: Node> {
     public static subscript<T: Node>(
           _enclosingInstance instance: T,
-          wrapped wrappedKeyPath: ReferenceWritableKeyPath<T, Value>,
+          wrapped wrappedKeyPath: ReferenceWritableKeyPath<T, Value?>,
           storage storageKeyPath: ReferenceWritableKeyPath<T, Self>
-    ) -> Value {
+    ) -> Value? {
         get {
             if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *){
-                let name: String
-                let fullName = wrappedKeyPath.debugDescription
-                if let namePos = fullName.lastIndex(of: ".") {
-                    name = String (fullName [fullName.index(namePos, offsetBy: 1)...])
-                } else {
-                    name = fullName
-                }
-                let nodePath = NodePath(from: name)
-                
-                return instance.getNode(path: nodePath) as! Value
+                let discoveredName: String = {
+                    if let nodeName = instance[keyPath: storageKeyPath].nodeName {
+                        return nodeName
+                    }
+
+                    // Check original variable name
+                    let cleanedDebugName = makeCleanName(from: wrappedKeyPath.debugDescription)
+                    guard !instance.hasNode(path: NodePath(from: cleanedDebugName)) else {
+                        return cleanedDebugName
+                    }
+
+                    // Check lower/upper cased first character variants to bridge the casing gap with
+                    // swift variables and GD scene names.
+                    let firstCharacterCaseVariantNames = makeVariantNames(from: cleanedDebugName)
+                    if instance.hasNode(path: NodePath(from: firstCharacterCaseVariantNames.camel)) {
+                        return firstCharacterCaseVariantNames.camel
+                    } else {
+                        return firstCharacterCaseVariantNames.pascal
+                    }
+                }()
+
+                return instance.getNode(path: NodePath(from: discoveredName)) as? Value
             } else {
                 fatalError ("BindNode is not supported with current swift, or older Mac")
             }
@@ -46,16 +74,29 @@ public struct BindNode<Value: Node> {
             fatalError()
         }
     }
-    
-    public init () {}
-    @available(*, unavailable, message: "This property wrapper can only be applied to classes")
-    public var wrappedValue: Value {
-        get {
-            fatalError()
-        }
-        set {
-            fatalError()
+
+    private static func makeCleanName(from debugDescriptionName: String) -> String {
+        if let namePos = debugDescriptionName.lastIndex(of: ".") {
+            return String (debugDescriptionName [debugDescriptionName.index(namePos, offsetBy: 1)...])
+        } else {
+            return debugDescriptionName
         }
     }
-}
 
+    private static func makeVariantNames(from name: String) -> (camel: String, pascal: String) {
+        let camel = name.prefix(1).lowercased() + name.dropFirst()
+        let pascal = name.prefix(1).uppercased() + name.dropFirst()
+        return (camel, pascal)
+    }
+
+    var nodeName: String?
+    public init(nodeName: String? = nil) {
+        self.nodeName = nodeName
+    }
+
+    @available(*, unavailable, message: "This property wrapper can only be applied to classes")
+    public var wrappedValue: Value? {
+        get { fatalError() }
+        set { fatalError() }
+    }
+}

--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -11,23 +11,9 @@
 /// For example:
 ///
 ///     class MyElements: CanvasLayer {
-///         @BindNode var GameOverLabel: Label
-///     }
-///
-///
-/// The above is equivalent to calling
-///
-///     getNode(path: NodeName("GameOverLabel")) as! Label
-
-/// Use the BindNode property wrapper in any subclass of Node to retrieve the node from the
-/// current container that matches the name of the property.
-///
-/// For example:
-///
-///     class MyElements: CanvasLayer {
 ///         @BindNode var MovementComponent: Node?
 ///         @BindNode var movementComponent: Node?
-///         @BindNode(nodeName: "MovementComponent") var customLabel: Node?
+///         @BindNode("MovementComponent") var customLabel: Node?
 ///     }
 ///
 /// The above is equivalent to calling
@@ -89,7 +75,7 @@ public struct BindNode<Value: Node> {
     }
 
     var nodeName: String?
-    public init(nodeName: String? = nil) {
+    public init(_ nodeName: String? = nil) {
         self.nodeName = nodeName
     }
 

--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -25,15 +25,14 @@
 /// For example:
 ///
 ///     class MyElements: CanvasLayer {
-///         @BindNode var GameOverLabel: Label
-///         @BindNode var gameOverLabel: Label
-///
-///         @BindNode(nodeName: "GameOverLabel") var customLabel: Label
+///         @BindNode var MovementComponent: Node?
+///         @BindNode var movementComponent: Node?
+///         @BindNode(nodeName: "MovementComponent") var customLabel: Node?
 ///     }
 ///
 /// The above is equivalent to calling
 ///
-///     getNode(path: NodeName("GameOverLabel")) as! Label
+///     getNode(path: NodeName("MovementComponent")) as? Node
 
 @propertyWrapper
 public struct BindNode<Value: Node> {

--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -40,14 +40,16 @@ public struct BindNode<Value: Node> {
                         return cleanedDebugName
                     }
 
-                    // Check lower/upper cased first character variants to bridge the casing gap with
-                    // swift variables and GD scene names.
-                    let firstCharacterCaseVariantNames = makeVariantNames(from: cleanedDebugName)
-                    if instance.hasNode(path: NodePath(from: firstCharacterCaseVariantNames.camel)) {
-                        return firstCharacterCaseVariantNames.camel
-                    } else {
-                        return firstCharacterCaseVariantNames.pascal
+                    // Check upper cased first character variant to bridge the casing gap with swift
+                    // variables and GD scene names.
+                    let pascalVariantName = makePascalCaseName(from: cleanedDebugName)
+                    if instance.hasNode(path: NodePath(from: pascalVariantName)) {
+                        return pascalVariantName
                     }
+
+                    // This won't be found, but it triggers a warning in godot pointing to the original
+                    // inferred name used in the binding.
+                    return cleanedDebugName
                 }()
 
                 return instance.getNode(path: NodePath(from: discoveredName)) as? Value
@@ -68,10 +70,8 @@ public struct BindNode<Value: Node> {
         }
     }
 
-    private static func makeVariantNames(from name: String) -> (camel: String, pascal: String) {
-        let camel = name.prefix(1).lowercased() + name.dropFirst()
-        let pascal = name.prefix(1).uppercased() + name.dropFirst()
-        return (camel, pascal)
+    private static func makePascalCaseName(from name: String) -> String {
+        return name.prefix(1).uppercased() + name.dropFirst()
     }
 
     var nodeName: String?


### PR DESCRIPTION
Just a few improvements to make `@BindNode` a little bit better to work with. 

### Improved Lookup

Given a Scene Node named "MovementComponent": 
```swift
    @BindNode var MovementComponent: Node? // existing
    @BindNode var movementComponent: Node? // inferred
    @BindNode("MovementComponent") var customLabel: Node? // custom
```
All become valid ways to look up via BindNode. 

### Safe Lookup

Previously, `@BindNode` didn't include the ability to look-up via optional, but this now forces them to be defined as optionals. This prevents the chance that a misnamed or missing Node is going to cause a crash instead puts it on the programmer to handle the missing node.

This has a backwards incompatible change to more-or-less force safety on BindNode which is primarily the reason why I marked it a proposal in the title here. Feel feel to object but thought I'd take the chance given the early-ish state of the project and how annoying that was to stumble on 🙂
