### PR TITLE
Expose packed_byte_array_operator_index_const.

### DIFF
--- a/Sources/SwiftGodot/Core/Packed.swift
+++ b/Sources/SwiftGodot/Core/Packed.swift
@@ -81,6 +81,11 @@ extension PackedByteArray {
         return nil
     }
     
+    /// Read-only access the underlying data for this packed byte array
+    ///
+    /// - Parameter method: a callback that is invoked with a non-mutable pointer to the underlying data, and
+    /// the number of bytes in that block of data. The callback is allowed to return nil if it fails to
+    /// do anything with the data.
     public func withUnsafeConstAccessToData<T> (_ method: (_ pointer: UnsafeRawPointer, _ count: Int) -> T?) -> T? {
         if let ptr = gi.packed_byte_array_operator_index_const(&content, 0) {
             return method(ptr, Int(size()))

--- a/Sources/SwiftGodot/Core/Packed.swift
+++ b/Sources/SwiftGodot/Core/Packed.swift
@@ -80,6 +80,13 @@ extension PackedByteArray {
         }
         return nil
     }
+    
+    public func withUnsafeConstAccessToData<T> (_ method: (_ pointer: UnsafeRawPointer, _ count: Int) -> T?) -> T? {
+        if let ptr = gi.packed_byte_array_operator_index_const(&content, 0) {
+            return method(ptr, Int(size()))
+        }
+        return nil
+    }
 
     /// Initializes a PackedByteArray from an array of UInt8 values.
     public convenience init (_ data: [UInt8]) {

--- a/Sources/SwiftGodot/EntryPoint.swift
+++ b/Sources/SwiftGodot/EntryPoint.swift
@@ -188,6 +188,7 @@ struct GodotInterface {
     
     let packed_string_array_operator_index: GDExtensionInterfacePackedStringArrayOperatorIndex
     let packed_byte_array_operator_index: GDExtensionInterfacePackedByteArrayOperatorIndex
+    let packed_byte_array_operator_index_const: GDExtensionInterfacePackedByteArrayOperatorIndexConst
     let packed_color_array_operator_index: GDExtensionInterfacePackedColorArrayOperatorIndex
     let packed_float32_array_operator_index: GDExtensionInterfacePackedFloat32ArrayOperatorIndex
     let packed_float64_array_operator_index: GDExtensionInterfacePackedFloat64ArrayOperatorIndex
@@ -283,6 +284,7 @@ func loadGodotInterface (_ godotGetProcAddrPtr: GDExtensionInterfaceGetProcAddre
         
         packed_string_array_operator_index: load ("packed_string_array_operator_index"),
         packed_byte_array_operator_index: load ("packed_byte_array_operator_index"),
+        packed_byte_array_operator_index_const: load ("packed_byte_array_operator_index_const"),
         packed_color_array_operator_index: load ("packed_color_array_operator_index"),
         packed_float32_array_operator_index: load ("packed_float32_array_operator_index"),
         packed_float64_array_operator_index: load ("packed_float64_array_operator_index"),


### PR DESCRIPTION
Zero-copy access to byte arrays across the gdextension interface is possible with `packed_byte_array_operator_index_const`, which compliments the version we already use in `withUnsafeMutableAccessToData` -- `packed_byte_array_operator_index`

```
// the new GDExtensionInterface method in this PR
let packed_byte_array_operator_index_const: GDExtensionInterfacePackedByteArrayOperatorIndexConst
```

It's useful with a Foundation-using helper method like

```
extension PackedByteArray {
    /// Returns a Data pointing directly at the data in this PackedByteArray
    public func asDataNoCopy() -> Data? {
        withUnsafeConstAccessToData { ptr, count in 
            Data(bytesNoCopy: .init(mutating: ptr), count: count, deallocator: .none)
        }
    }
}
```