### PR TITLE
Add `return` to `escapeSwift`

### DIFF
--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -57,7 +57,7 @@ public extension String {
 func escapeSwift(_ id: String) -> String {
     switch id {
     case "protocol", "func", "static", "inout", "in", "self", "case", "repeat", "default",
-         "import", "init", "continue", "class", "operator", "where", "var", "enum", "nil", "extension", "internal":
+         "import", "init", "continue", "class", "operator", "where", "var", "enum", "nil", "extension", "internal", "return":
         return "`\(id)`"
     default:
         return id


### PR DESCRIPTION
I'm using a godot module that has an enum with `return`. It failed to build since `return` wasn't being escaped. This fixes that.