### PR TITLE
Extend `initSwiftExtension` macro to expose all initialization levels (#464)

### DIFF
--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -119,6 +119,17 @@ public macro initSwiftExtension(cdecl: String,
                                 types: [Wrapped.Type] = []) = #externalMacro(module: "SwiftGodotMacroLibrary",
                                                                         type: "InitSwiftExtensionMacro")
 
+@freestanding(declaration, names: named(enterExtension))
+public macro initSwiftExtension(
+    cdecl: String,
+    coreTypes: [Wrapped.Type] = [],
+    editorTypes: [Wrapped.Type] = [],
+    sceneTypes: [Wrapped.Type] = [],
+    serverTypes: [Wrapped.Type] = []
+) = #externalMacro(
+    module: "SwiftGodotMacroLibrary",
+    type: "InitSwiftExtensionMacro")
+
 /// A macro that instantiates a `Texture2D` from a specified resource path. If the texture cannot be created, a
 /// `preconditionFailure` will be thrown.
 ///

--- a/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
@@ -27,21 +27,15 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                     print ("Error: Not all parameters were initialized.")
                     return 0
                 }
-                let types: [Wrapped.Type] = []
+                var types: [GDExtension.InitializationLevel: [Wrapped.Type]] = [:]
+                types[.core] = []
+                types[.editor] = []
+                types[.scene] = []
+                types[.servers] = []
                 initializeSwiftModule (interface, library, `extension`, initHook: { level in
-                    switch level {
-                    case .scene:
-                        types.forEach (register)
-                    default:
-                        break
-                    }
+                    types[level]?.forEach (register)
                 }, deInitHook: { level in
-                    switch level {
-                    case .scene:
-                        types.forEach (unregister)
-                    default:
-                        break
-                    }
+                    types[level]?.forEach (unregister)
                 })
                 return 1
             }
@@ -61,21 +55,15 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                     print ("Error: Not all parameters were initialized.")
                     return 0
                 }
-                let types: [Wrapped.Type] = []
+                var types: [GDExtension.InitializationLevel: [Wrapped.Type]] = [:]
+                types[.core] = []
+                types[.editor] = []
+                types[.scene] = []
+                types[.servers] = []
                 initializeSwiftModule (interface, library, `extension`, initHook: { level in
-                    switch level {
-                    case .scene:
-                        types.forEach (register)
-                    default:
-                        break
-                    }
+                    types[level]?.forEach (register)
                 }, deInitHook: { level in
-                    switch level {
-                    case .scene:
-                        types.forEach (unregister)
-                    default:
-                        break
-                    }
+                    types[level]?.forEach (unregister)
                 })
                 return 1
             }
@@ -84,7 +72,7 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
         )
     }
 
-    func testInitSwiftExtensionMacro() {
+    func testInitSwiftExtensionMacroWithSceneTypesOnly() {
         assertMacroExpansion(
             """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", types: [ChrysalisNode.self])
@@ -95,21 +83,127 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                     print ("Error: Not all parameters were initialized.")
                     return 0
                 }
-                let types: [Wrapped.Type] = [ChrysalisNode.self]
+                var types: [GDExtension.InitializationLevel: [Wrapped.Type]] = [:]
+                types[.core] = []
+                types[.editor] = []
+                types[.scene] = [ChrysalisNode.self]
+                types[.servers] = []
                 initializeSwiftModule (interface, library, `extension`, initHook: { level in
-                    switch level {
-                    case .scene:
-                        types.forEach (register)
-                    default:
-                        break
-                    }
+                    types[level]?.forEach (register)
                 }, deInitHook: { level in
-                    switch level {
-                    case .scene:
-                        types.forEach (unregister)
-                    default:
-                        break
-                    }
+                    types[level]?.forEach (unregister)
+                })
+                return 1
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testInitSwiftExtensionMacroWithEditorTypes() {
+        assertMacroExpansion(
+            """
+            #initSwiftExtension(cdecl: "libchrysalis_entry_point", editorTypes: [CaterpillarNode.self])
+            """,
+            expandedSource: """
+            @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+                guard let library, let interface, let `extension` else {
+                    print ("Error: Not all parameters were initialized.")
+                    return 0
+                }
+                var types: [GDExtension.InitializationLevel: [Wrapped.Type]] = [:]
+                types[.core] = []
+                types[.editor] = [CaterpillarNode.self]
+                types[.scene] = []
+                types[.servers] = []
+                initializeSwiftModule (interface, library, `extension`, initHook: { level in
+                    types[level]?.forEach (register)
+                }, deInitHook: { level in
+                    types[level]?.forEach (unregister)
+                })
+                return 1
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testInitSwiftExtensionMacroWithCoreTypes() {
+        assertMacroExpansion(
+            """
+            #initSwiftExtension(cdecl: "libchrysalis_entry_point", coreTypes: [EggNode.self])
+            """,
+            expandedSource: """
+            @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+                guard let library, let interface, let `extension` else {
+                    print ("Error: Not all parameters were initialized.")
+                    return 0
+                }
+                var types: [GDExtension.InitializationLevel: [Wrapped.Type]] = [:]
+                types[.core] = [EggNode.self]
+                types[.editor] = []
+                types[.scene] = []
+                types[.servers] = []
+                initializeSwiftModule (interface, library, `extension`, initHook: { level in
+                    types[level]?.forEach (register)
+                }, deInitHook: { level in
+                    types[level]?.forEach (unregister)
+                })
+                return 1
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testInitSwiftExtensionMacroWithServerTypes() {
+        assertMacroExpansion(
+            """
+            #initSwiftExtension(cdecl: "libchrysalis_entry_point", serverTypes: [ButterflyNode.self])
+            """,
+            expandedSource: """
+            @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+                guard let library, let interface, let `extension` else {
+                    print ("Error: Not all parameters were initialized.")
+                    return 0
+                }
+                var types: [GDExtension.InitializationLevel: [Wrapped.Type]] = [:]
+                types[.core] = []
+                types[.editor] = []
+                types[.scene] = []
+                types[.servers] = [ButterflyNode.self]
+                initializeSwiftModule (interface, library, `extension`, initHook: { level in
+                    types[level]?.forEach (register)
+                }, deInitHook: { level in
+                    types[level]?.forEach (unregister)
+                })
+                return 1
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testInitSwiftExtensionMacroWithAllTypes() {
+        assertMacroExpansion(
+            """
+            #initSwiftExtension(cdecl: "libchrysalis_entry_point", coreTypes: [EggNode.self], editorTypes: [CaterpillarNode.self], sceneTypes: [ChrysalisNode.self], serverTypes: [ButterflyNode.self])
+            """,
+            expandedSource: """
+            @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+                guard let library, let interface, let `extension` else {
+                    print ("Error: Not all parameters were initialized.")
+                    return 0
+                }
+                var types: [GDExtension.InitializationLevel: [Wrapped.Type]] = [:]
+                types[.core] = [EggNode.self]
+                types[.editor] = [CaterpillarNode.self]
+                types[.scene] = [ChrysalisNode.self]
+                types[.servers] = [ButterflyNode.self]
+                initializeSwiftModule (interface, library, `extension`, initHook: { level in
+                    types[level]?.forEach (register)
+                }, deInitHook: { level in
+                    types[level]?.forEach (unregister)
                 })
                 return 1
             }


### PR DESCRIPTION
closes #464 

Allows registration of types to Godot at all `GDExtension.InitializationLevel` cases.

Originally, this was supposed to support exposing types only at `.editor` initialization level, but the solution was generalized to include all cases. Maybe some esoteric use cases might require exposing types at `.core` and `.servers` levels.

I was able to work out a way of keeping the original declaration intact, so no breaking changes were introduced to the macro API.

Also, I still have to add api documentation and make some little adjustments to the existing one. If the code's good to go already, I'll do it.