### PR TITLE
Packed: _const interface for subscript getters

### DIFF
--- a/Sources/SwiftGodot/Core/Packed.swift
+++ b/Sources/SwiftGodot/Core/Packed.swift
@@ -17,7 +17,7 @@ extension PackedStringArray {
     /// Accesses a specific element in the ``PackedStringArray``
     public subscript (index: Int) -> String {
         get {
-            return GString.stringFromGStringPtr(ptr: gi.packed_string_array_operator_index (&content, Int64 (index))) ?? ""
+            return GString.stringFromGStringPtr(ptr: gi.packed_string_array_operator_index_const (&content, Int64 (index))) ?? ""
         }
         set {
             set (index: Int64 (index), value: newValue)
@@ -29,7 +29,7 @@ extension PackedByteArray {
     /// Accesses a specific element in the ``PackedByteArray``
     public subscript (index: Int) -> UInt8 {
         get {
-            let ptr = gi.packed_byte_array_operator_index (&content, Int64 (index))
+            let ptr = gi.packed_byte_array_operator_index_const (&content, Int64 (index))
             return ptr!.pointee
         }
         set {
@@ -113,7 +113,7 @@ extension PackedColorArray {
     /// Accesses a specific element in the ``PackedColorArray``
     public subscript (index: Int) -> Color {
         get {
-            let ptr = gi.packed_color_array_operator_index (&content, Int64 (index))
+            let ptr = gi.packed_color_array_operator_index_const (&content, Int64 (index))
             return ptr!.assumingMemoryBound(to: Color.self).pointee
         }
         set {
@@ -126,7 +126,7 @@ extension PackedFloat32Array {
     /// Accesses a specific element in the ``PackedFloat32Array``
     public subscript (index: Int) -> Float {
         get {
-            let ptr = gi.packed_float32_array_operator_index (&content, Int64 (index))
+            let ptr = gi.packed_float32_array_operator_index_const (&content, Int64 (index))
             return ptr!.pointee
         }
         set {
@@ -154,7 +154,7 @@ extension PackedFloat64Array {
     /// Accesses a specific element in the ``PackedFloat64Array``
     public subscript (index: Int) -> Double {
         get {
-            let ptr = gi.packed_float64_array_operator_index (&content, Int64(index))
+            let ptr = gi.packed_float64_array_operator_index_const (&content, Int64(index))
             return ptr!.pointee
         }
         set {
@@ -183,7 +183,7 @@ extension PackedInt32Array {
     /// Accesses a specific element in the ``PackedInt32Array``
     public subscript (index: Int) -> Int32 {
         get {
-            let ptr = gi.packed_int32_array_operator_index (&content, Int64(index))
+            let ptr = gi.packed_int32_array_operator_index_const (&content, Int64(index))
             return ptr!.pointee
         }
         set {
@@ -211,7 +211,7 @@ extension PackedInt64Array {
     /// Accesses a specific element in the ``PackedInt64Array``
     public subscript (index: Int) -> Int64 {
         get {
-            let ptr = gi.packed_int64_array_operator_index(&content, Int64(index))
+            let ptr = gi.packed_int64_array_operator_index_const(&content, Int64(index))
             return ptr!.pointee
         }
         set {
@@ -239,7 +239,7 @@ extension PackedVector2Array {
     /// Accesses a specific element in the ``PackedVector2Array``
     public subscript (index: Int) -> Vector2 {
         get {
-            let ptr = gi.packed_vector2_array_operator_index (&content, Int64(index))
+            let ptr = gi.packed_vector2_array_operator_index_const (&content, Int64(index))
             return ptr!.assumingMemoryBound(to: Vector2.self).pointee
         }
         set {
@@ -252,7 +252,7 @@ extension PackedVector3Array {
     /// Accesses a specific element in the ``PackedVector3Array``
     public subscript (index: Int) -> Vector3 {
         get {
-            let ptr = gi.packed_vector3_array_operator_index (&content, Int64(index))
+            let ptr = gi.packed_vector3_array_operator_index_const (&content, Int64(index))
             return ptr!.assumingMemoryBound(to: Vector3.self).pointee
         }
         set {

--- a/Sources/SwiftGodot/EntryPoint.swift
+++ b/Sources/SwiftGodot/EntryPoint.swift
@@ -187,16 +187,24 @@ struct GodotInterface {
     let array_set_typed: GDExtensionInterfaceArraySetTyped
     
     let packed_string_array_operator_index: GDExtensionInterfacePackedStringArrayOperatorIndex
+    let packed_string_array_operator_index_const: GDExtensionInterfacePackedStringArrayOperatorIndexConst
     let packed_byte_array_operator_index: GDExtensionInterfacePackedByteArrayOperatorIndex
     let packed_byte_array_operator_index_const: GDExtensionInterfacePackedByteArrayOperatorIndexConst
     let packed_color_array_operator_index: GDExtensionInterfacePackedColorArrayOperatorIndex
+    let packed_color_array_operator_index_const: GDExtensionInterfacePackedColorArrayOperatorIndexConst
     let packed_float32_array_operator_index: GDExtensionInterfacePackedFloat32ArrayOperatorIndex
+    let packed_float32_array_operator_index_const: GDExtensionInterfacePackedFloat32ArrayOperatorIndexConst
     let packed_float64_array_operator_index: GDExtensionInterfacePackedFloat64ArrayOperatorIndex
+    let packed_float64_array_operator_index_const: GDExtensionInterfacePackedFloat64ArrayOperatorIndexConst
     let packed_int32_array_operator_index: GDExtensionInterfacePackedInt32ArrayOperatorIndex
+    let packed_int32_array_operator_index_const: GDExtensionInterfacePackedInt32ArrayOperatorIndexConst
     let packed_int64_array_operator_index: GDExtensionInterfacePackedInt64ArrayOperatorIndex
+    let packed_int64_array_operator_index_const: GDExtensionInterfacePackedInt64ArrayOperatorIndexConst
     let packed_vector2_array_operator_index: GDExtensionInterfacePackedVector2ArrayOperatorIndex
+    let packed_vector2_array_operator_index_const: GDExtensionInterfacePackedVector2ArrayOperatorIndexConst
     let packed_vector3_array_operator_index: GDExtensionInterfacePackedVector3ArrayOperatorIndex
-    
+    let packed_vector3_array_operator_index_const: GDExtensionInterfacePackedVector3ArrayOperatorIndexConst
+
     let callable_custom_create: GDExtensionInterfaceCallableCustomCreate
 }
 
@@ -283,16 +291,24 @@ func loadGodotInterface (_ godotGetProcAddrPtr: GDExtensionInterfaceGetProcAddre
         array_set_typed: load ("array_set_typed"),
         
         packed_string_array_operator_index: load ("packed_string_array_operator_index"),
+        packed_string_array_operator_index_const: load ("packed_string_array_operator_index_const"),
         packed_byte_array_operator_index: load ("packed_byte_array_operator_index"),
         packed_byte_array_operator_index_const: load ("packed_byte_array_operator_index_const"),
         packed_color_array_operator_index: load ("packed_color_array_operator_index"),
+        packed_color_array_operator_index_const: load ("packed_color_array_operator_index_const"),
         packed_float32_array_operator_index: load ("packed_float32_array_operator_index"),
+        packed_float32_array_operator_index_const: load ("packed_float32_array_operator_index_const"),
         packed_float64_array_operator_index: load ("packed_float64_array_operator_index"),
+        packed_float64_array_operator_index_const: load ("packed_float64_array_operator_index_const"),
         packed_int32_array_operator_index: load ("packed_int32_array_operator_index"),
+        packed_int32_array_operator_index_const: load ("packed_int32_array_operator_index_const"),
         packed_int64_array_operator_index: load ("packed_int64_array_operator_index"),
+        packed_int64_array_operator_index_const: load ("packed_int64_array_operator_index_const"),
         packed_vector2_array_operator_index: load ("packed_vector2_array_operator_index"),
+        packed_vector2_array_operator_index_const: load ("packed_vector2_array_operator_index_const"),
         packed_vector3_array_operator_index: load ("packed_vector3_array_operator_index"),
-        
+        packed_vector3_array_operator_index_const: load ("packed_vector3_array_operator_index_const"),
+
         callable_custom_create: load ("callable_custom_create")
     )
 }


### PR DESCRIPTION
 Building on #456 - the `subscript` `get` functions for `PackedXYZArray`s do not need writeable pointers from Godot.

This changeset, by using the `_const` versions of the packed array interface functions, can save memory allocations b/c the copy-on-write logic doesn't need to happen for read-only access.

(Some more performance work from my GodotVision profiling—hitting 90FPS is important there!)