### PR TITLE
Use Int instead of Int64 across the board, undoes a previous change t…

### DIFF
--- a/Generator/Generator/Enums.swift
+++ b/Generator/Generator/Enums.swift
@@ -85,7 +85,7 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
         }
         let extraConformances = enumDefName == "Error" ? ", Error" : ""
             
-        p ("public enum \(getGodotType (SimpleType (type: enumDefName))): Int64, CustomDebugStringConvertible\(extraConformances)") {
+        p ("public enum \(getGodotType (SimpleType (type: enumDefName))): Int, CaseIterable, CustomDebugStringConvertible\(extraConformances)") {
             var used = Set<Int> ()
             
             func getName (_ enumVal: JGodotValueElement) -> String? {

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -201,7 +201,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                     return "var _result = UnsafeRawPointer (bitPattern: 0)"
                 } else {
                     if godotReturnType.starts(with: "enum::") {
-                        return "var _result: Int64 = 0 // to avoid packed enums on the stack"
+                        return "var _result: Int = 0 // to avoid packed enums on the stack"
                     } else {
                         
                         var declType: String = "let"
@@ -309,7 +309,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
             if returnType == "Variant" {
                 return "return Variant (fromContentPtr: &_result)"
             } else if returnType == "GodotError" {
-                return "return GodotError (rawValue: Int64 (Variant (fromContentPtr: &_result))!)!"
+                return "return GodotError (rawValue: Int (Variant (fromContentPtr: &_result))!)!"
             } else if returnType == "String" {
                 return "return GString (Variant (fromContentPtr: &_result))?.description ?? \"\""
             } else {

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -264,7 +264,7 @@ func getGodotType (_ t: TypeWithMeta?, kind: ArgumentKind = .classes) -> String 
             if kind == .builtInField {
                 return "Int32"
             } else {
-                return "Int64"
+                return "Int"
             }
         }
     case "float", "real":

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -98,7 +98,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     }
     
     /// Returns the number of elements in the array.
-    public final func size ()-> Int64 {
+    public final func size ()-> Int {
         return array.size ()
     }
 
@@ -116,7 +116,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     ///
     /// > Note: ``GArray``s with equal content will always produce identical hash values. However, the reverse is not true. Returning identical hash values does _not_ imply the arrays are equal, because different arrays can have identical hash values due to hash collisions.
     ///
-    public final func hash ()-> Int64 {
+    public final func hash ()-> Int {
         array.hash ()
     }
     
@@ -142,7 +142,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     ///
     /// > Note: This method acts in-place and doesn't return a modified array.
     ///
-    public final func resize (size: Int64)-> Int64 {
+    public final func resize (size: Int)-> Int {
         array.resize (size: size)
     }
     
@@ -152,7 +152,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     ///
     /// > Note: On large arrays, this method will be slower if the inserted element is close to the beginning of the array (index 0). This is because all elements placed after the newly inserted element have to be reindexed.
     ///
-    public final func insert (position: Int64, value: Element)-> Int64 {
+    public final func insert (position: Int, value: Element)-> Int {
         array.insert (position: position, value: Variant (value))
     }
     
@@ -164,7 +164,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     ///
     /// > Note: `position` cannot be negative. To remove an element relative to the end of the array, use `arr.remove_at(arr.size() - (i + 1))`. To remove the last element from the array without returning the value, use `arr.resize(arr.size() - 1)`.
     ///
-    public final func removeAt (position: Int64) {
+    public final func removeAt (position: Int) {
         array.removeAt (position: position)
     }
 
@@ -204,17 +204,17 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
 
     
     /// Searches the array for a value and returns its index or `-1` if not found. Optionally, the initial search index can be passed.
-    public final func find (what: Element, from: Int64 = 0)-> Int64 {
+    public final func find (what: Element, from: Int = 0)-> Int {
         array.find (what: Variant (what), from: from)
     }
     
     /// Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
-    public final func rfind (what: Element, from: Int64 = -1)-> Int64 {
+    public final func rfind (what: Element, from: Int = -1)-> Int {
         array.rfind (what: Variant (what), from: from)
     }
     
     /// Returns the number of times an element is in the array.
-    public final func count (value: Element)-> Int64 {
+    public final func count (value: Element)-> Int {
         array.count (value: Variant (value))
     }
     
@@ -243,7 +243,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     ///
     /// > Note: On large arrays, this method can be slower than ``popBack()`` as it will reindex the array's elements that are located after the removed element. The larger the array and the lower the index of the removed element, the slower ``popAt(position:)`` will be.
     ///
-    public final func popAt (position: Int64)-> Element {
+    public final func popAt (position: Int)-> Element {
         toStrong (array.popAt (position: position))
     }
     
@@ -278,7 +278,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     ///
     /// > Note: Calling ``bsearch(value:before:)`` on an unsorted array results in unexpected behavior.
     ///
-    public final func bsearch (value: Element, before: Bool = true)-> Int64 {
+    public final func bsearch (value: Element, before: Bool = true)-> Int {
         array.bsearch(value: Variant (value), before: before)
     }
     
@@ -286,7 +286,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     ///
     /// > Note: Calling ``bsearchCustom(value:`func`:before:)`` on an unsorted array results in unexpected behavior.
     ///
-    public final func bsearchCustom (value: Element, `func`: Callable, before: Bool = true)-> Int64 {
+    public final func bsearchCustom (value: Element, `func`: Callable, before: Bool = true)-> Int {
         array.bsearchCustom(value: Variant(value), func: `func`, before: before)
     }
     
@@ -306,7 +306,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     }
     
     /// Returns the ``Variant.GType`` constant for a typed array. If the ``GArray`` is not typed, returns ``Variant.GType/`nil```.
-    public final func getTypedBuiltin ()-> Int64 {
+    public final func getTypedBuiltin ()-> Int {
         array.getTypedBuiltin()
     }
     

--- a/Sources/SwiftGodot/Core/Packed.swift
+++ b/Sources/SwiftGodot/Core/Packed.swift
@@ -20,7 +20,7 @@ extension PackedStringArray {
             return GString.stringFromGStringPtr(ptr: gi.packed_string_array_operator_index_const (&content, Int64 (index))) ?? ""
         }
         set {
-            set (index: Int64 (index), value: newValue)
+            set (index: index, value: newValue)
         }
     }
 }
@@ -29,11 +29,11 @@ extension PackedByteArray {
     /// Accesses a specific element in the ``PackedByteArray``
     public subscript (index: Int) -> UInt8 {
         get {
-            let ptr = gi.packed_byte_array_operator_index_const (&content, Int64 (index))
+            let ptr = gi.packed_byte_array_operator_index_const (&content, Int64(index))
             return ptr!.pointee
         }
         set {
-            set (index: Int64 (index), value: Int64 (newValue))
+            set (index: index, value: Int(newValue))
         }
     }
     
@@ -96,7 +96,7 @@ extension PackedByteArray {
     /// Initializes a PackedByteArray from an array of UInt8 values.
     public convenience init (_ data: [UInt8]) {
         self.init ()
-        _ = resize(newSize: Int64(data.count))
+        _ = resize(newSize: data.count)
         if let ptr = gi.packed_byte_array_operator_index(&content, 0) {
             ptr.withMemoryRebound(to: UInt8.self, capacity: data.count) { typed in
                 var idx = 0
@@ -117,7 +117,7 @@ extension PackedColorArray {
             return ptr!.assumingMemoryBound(to: Color.self).pointee
         }
         set {
-            set (index: Int64 (index), value: newValue)
+            set (index: index, value: newValue)
         }
     }
 }
@@ -130,14 +130,14 @@ extension PackedFloat32Array {
             return ptr!.pointee
         }
         set {
-            set (index: Int64 (index), value: Double (newValue))
+            set (index: index, value: Double (newValue))
         }
     }
     
     /// Initializes a PackedByteArray from an array of Float values.
     public convenience init (_ data: [Float]) {
         self.init ()
-        _ = resize(newSize: Int64(data.count))
+        _ = resize(newSize: data.count)
         if let ptr = gi.packed_float32_array_operator_index(&content, 0) {
             ptr.withMemoryRebound(to: Float.self, capacity: data.count) { typed in
                 var idx = 0
@@ -158,14 +158,14 @@ extension PackedFloat64Array {
             return ptr!.pointee
         }
         set {
-            set (index: Int64 (index), value: newValue)
+            set (index: index, value: newValue)
         }
     }
     
     /// Initializes a PackedByteArray from an array of Double values.
     public convenience init (_ data: [Double]) {
         self.init ()
-        _ = resize(newSize: Int64(data.count))
+        _ = resize(newSize: data.count)
         if let ptr = gi.packed_float64_array_operator_index(&content, 0) {
             ptr.withMemoryRebound(to: Double.self, capacity: data.count) { typed in
                 var idx = 0
@@ -187,14 +187,14 @@ extension PackedInt32Array {
             return ptr!.pointee
         }
         set {
-            set (index: Int64 (index), value: Int64(newValue))
+            set (index: Int (index), value: Int(newValue))
         }
     }
     
     /// Initializes a PackedByteArray from an array of Int32 values values.
     public convenience init (_ data: [Int32]) {
         self.init ()
-        _ = resize(newSize: Int64(data.count))
+        _ = resize(newSize: Int(data.count))
         if let ptr = gi.packed_int32_array_operator_index(&content, 0) {
             ptr.withMemoryRebound(to: Int32.self, capacity: data.count) { typed in
                 var idx = 0
@@ -215,7 +215,7 @@ extension PackedInt64Array {
             return ptr!.pointee
         }
         set {
-            set (index: Int64 (index), value: newValue)
+            set (index: Int (index), value: Int(newValue))
         }
     }
     
@@ -243,7 +243,7 @@ extension PackedVector2Array {
             return ptr!.assumingMemoryBound(to: Vector2.self).pointee
         }
         set {
-            set (index: Int64 (index), value: newValue)
+            set (index: Int (index), value: newValue)
         }
     }
 }
@@ -256,7 +256,7 @@ extension PackedVector3Array {
             return ptr!.assumingMemoryBound(to: Vector3.self).pointee
         }
         set {
-            set (index: Int64 (index), value: newValue)
+            set (index: Int (index), value: newValue)
         }
     }
 }

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -89,7 +89,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     
     
     /// Returns the number of elements in the array.
-    public final func size ()-> Int64 {
+    public final func size ()-> Int {
         return array.size ()
     }
 
@@ -107,7 +107,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     ///
     /// > Note: ``GArray``s with equal content will always produce identical hash values. However, the reverse is not true. Returning identical hash values does _not_ imply the arrays are equal, because different arrays can have identical hash values due to hash collisions.
     ///
-    public final func hash ()-> Int64 {
+    public final func hash ()-> Int {
         array.hash ()
     }
     
@@ -133,7 +133,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     ///
     /// > Note: This method acts in-place and doesn't return a modified array.
     ///
-    public final func resize (size: Int64)-> Int64 {
+    public final func resize (size: Int)-> Int {
         array.resize (size: size)
     }
     
@@ -143,7 +143,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     ///
     /// > Note: On large arrays, this method will be slower if the inserted element is close to the beginning of the array (index 0). This is because all elements placed after the newly inserted element have to be reindexed.
     ///
-    public final func insert (position: Int64, value: Element)-> Int64 {
+    public final func insert (position: Int, value: Element)-> Int {
         array.insert (position: position, value: Variant(value))
     }
     
@@ -155,7 +155,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     ///
     /// > Note: `position` cannot be negative. To remove an element relative to the end of the array, use `arr.remove_at(arr.size() - (i + 1))`. To remove the last element from the array without returning the value, use `arr.resize(arr.size() - 1)`.
     ///
-    public final func removeAt (position: Int64) {
+    public final func removeAt (position: Int) {
         array.removeAt (position: position)
     }
 
@@ -195,17 +195,17 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
 
     
     /// Searches the array for a value and returns its index or `-1` if not found. Optionally, the initial search index can be passed.
-    public final func find (what: Element, from: Int64 = 0)-> Int64 {
+    public final func find (what: Element, from: Int = 0)-> Int {
         array.find (what: Variant(what), from: from)
     }
     
     /// Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
-    public final func rfind (what: Element, from: Int64 = -1)-> Int64 {
+    public final func rfind (what: Element, from: Int = -1)-> Int {
         array.rfind (what: Variant(what), from: from)
     }
     
     /// Returns the number of times an element is in the array.
-    public final func count (value: Element)-> Int64 {
+    public final func count (value: Element)-> Int {
         array.count (value: Variant(value))
     }
     
@@ -234,7 +234,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     ///
     /// > Note: On large arrays, this method can be slower than ``popBack()`` as it will reindex the array's elements that are located after the removed element. The larger the array and the lower the index of the removed element, the slower ``popAt(position:)`` will be.
     ///
-    public final func popAt (position: Int64)-> Element {
+    public final func popAt (position: Int)-> Element {
         toStrong (array.popAt (position: position))
     }
     
@@ -269,7 +269,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     ///
     /// > Note: Calling ``bsearch(value:before:)`` on an unsorted array results in unexpected behavior.
     ///
-    public final func bsearch (value: Element, before: Bool = true)-> Int64 {
+    public final func bsearch (value: Element, before: Bool = true)-> Int {
         array.bsearch(value: Variant(value), before: before)
     }
     
@@ -277,7 +277,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     ///
     /// > Note: Calling ``bsearchCustom(value:`func`:before:)`` on an unsorted array results in unexpected behavior.
     ///
-    public final func bsearchCustom (value: Element, `func`: Callable, before: Bool = true)-> Int64 {
+    public final func bsearchCustom (value: Element, `func`: Callable, before: Bool = true)-> Int {
         array.bsearchCustom(value: Variant(value), func: `func`, before: before)
     }
     
@@ -297,7 +297,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     }
     
     /// Returns the ``Variant.GType`` constant for a typed array. If the ``GArray`` is not typed, returns ``Variant.GType/`nil```.
-    public final func getTypedBuiltin ()-> Int64 {
+    public final func getTypedBuiltin ()-> Int {
         array.getTypedBuiltin()
     }
     

--- a/Sources/SwiftGodot/EntryPoint.swift
+++ b/Sources/SwiftGodot/EntryPoint.swift
@@ -42,7 +42,7 @@ public func setExtensionInterface (to: OpaquePointer?, library lib: OpaquePointe
 // Extension initialization callback
 func extension_initialize (userData: UnsafeMutableRawPointer?, l: GDExtensionInitializationLevel) {
     //print ("SWIFT: extension_initialize")
-    let level = GDExtension.InitializationLevel(rawValue: Int64 (exactly: l.rawValue)!)!
+    let level = GDExtension.InitializationLevel(rawValue: Int (exactly: l.rawValue)!)!
     
     for cb in extensionInitCallbacks {
         cb (level)
@@ -53,7 +53,7 @@ func extension_initialize (userData: UnsafeMutableRawPointer?, l: GDExtensionIni
 func extension_deinitialize (userData: UnsafeMutableRawPointer?, l: GDExtensionInitializationLevel) {
     //print ("SWIFT: extension_deinitialize")
     
-    let level = GDExtension.InitializationLevel(rawValue: Int64 (exactly: l.rawValue)!)!
+    let level = GDExtension.InitializationLevel(rawValue: Int (exactly: l.rawValue)!)!
     for cb in extensionDeInitCallbacks {
         cb (level)
     }

--- a/Sources/SwiftGodot/Extensions/Arithmetic.swift
+++ b/Sources/SwiftGodot/Extensions/Arithmetic.swift
@@ -7,19 +7,19 @@
 
 public protocol IntScalable {
     
-    static func / (lhs: Self, rhs: Int64) -> Self
-    static func * (lhs: Self, rhs: Int64) -> Self
+    static func / (lhs: Self, rhs: Int) -> Self
+    static func * (lhs: Self, rhs: Int) -> Self
     
 }
 
 public extension IntScalable {
     
     static func / (lhs: Self, rhs: Int) -> Self {
-        return lhs / Int64(rhs)
+        return lhs / Int(rhs)
     }
     
     static func * (lhs: Self, rhs: Int) -> Self {
-        return lhs * Int64(rhs)
+        return lhs * Int(rhs)
     }
     
     static func /= (_ lhs: inout Self, _ rhs: Int) {

--- a/Sources/SwiftGodot/Extensions/RefCountedExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/RefCountedExtensions.swift
@@ -6,7 +6,7 @@ public extension RefCounted {
     /// This is flagged `_exp` because it will eventually be folded into deinit for RefCounted
     /// objects
     func _exp_unref() {
-        let instanceID = Int64(bitPattern: UInt64(getInstanceId()))
+        let instanceID = Int(bitPattern: UInt(getInstanceId()))
         if GD.isInstanceIdValid(id: instanceID) {
             if unreference() {
                 gi.object_destroy(UnsafeMutableRawPointer(mutating: handle))

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -123,7 +123,7 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
         withUnsafeMutablePointer(to: &content) { selfPtr in
             var mutableValue = value.content
             withUnsafeMutablePointer(to: &mutableValue) { ptr in
-                Variant.fromTypeMap [Int (godotType.rawValue)] (selfPtr, ptr)
+                Variant.fromTypeMap [Int(godotType.rawValue)] (selfPtr, ptr)
             }
         }
     }
@@ -131,12 +131,12 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
     /// This describes the type of the data wrapped by this variant
     public var gtype: GType {
         var copy = content
-        return GType (rawValue: Int64 (gi.variant_get_type (&copy).rawValue)) ?? .nil
+        return GType (rawValue: Int (gi.variant_get_type (&copy).rawValue)) ?? .nil
     }
     
     func toType (_ type: GType, dest: UnsafeMutableRawPointer) {
         withUnsafeMutablePointer(to: &content) { selfPtr in
-            Variant.toTypeMap [Int (type.rawValue)] (dest, selfPtr)
+            Variant.toTypeMap [type.rawValue] (dest, selfPtr)
         }
     }
     


### PR DESCRIPTION
…o the way we store enumerations, and instead makes it so that our public API that took Int64 values takes Int values