### PR TITLE
Adds specifying a path to @BindNode

### DIFF
--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -32,7 +32,11 @@ public struct BindNode<Value: Node> {
           storage storageKeyPath: ReferenceWritableKeyPath<T, Self>
     ) -> Value {
         get {
-            if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *){
+            if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *) {
+				if let node = instance[keyPath: storageKeyPath].cachedNode {
+					return node as! Value
+				}
+
                 let name: String
                 let fullName = wrappedKeyPath.debugDescription
                 if let namePos = fullName.lastIndex(of: ".") {
@@ -42,7 +46,8 @@ public struct BindNode<Value: Node> {
                 }
                 let nodePath = NodePath(from: name)
                 
-                return instance.getNode(path: nodePath) as! Value
+				instance[keyPath: storageKeyPath].cachedNode = instance.getNode(path: nodePath)
+                return instance[keyPath: storageKeyPath].cachedNode as! Value
             } else {
                 fatalError ("BindNode is not supported with current swift, or older Mac")
             }
@@ -62,5 +67,6 @@ public struct BindNode<Value: Node> {
             fatalError()
         }
     }
+	private var cachedNode: Node?
 }
 

--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -37,6 +37,12 @@ public struct BindNode<Value: Node> {
 					return node as! Value
 				}
 
+				if !instance[keyPath: storageKeyPath].path.isEmpty {
+					let nodePath = NodePath(from: instance[keyPath: storageKeyPath].path)
+					instance[keyPath: storageKeyPath].cachedNode = instance.getNode(path: nodePath)
+					return instance[keyPath: storageKeyPath].cachedNode as! Value
+				}
+
                 let name: String
                 let fullName = wrappedKeyPath.debugDescription
                 if let namePos = fullName.lastIndex(of: ".") {
@@ -56,8 +62,9 @@ public struct BindNode<Value: Node> {
             fatalError()
         }
     }
-    
-    public init () {}
+	
+	/// - Parameter path: An optional path to the node within the tree, if not provided, the name of the property is used.
+    public init (withPath path: String = "") { self.path = path }
     @available(*, unavailable, message: "This property wrapper can only be applied to classes")
     public var wrappedValue: Value {
         get {
@@ -68,5 +75,6 @@ public struct BindNode<Value: Node> {
         }
     }
 	private var cachedNode: Node?
+	private var path: String
 }
 


### PR DESCRIPTION
Previously the `@BindNode` property wrapper would only fetch a node based on its property name. Leaving a mix of camel and pascal cased properties in the class. Basing the wrapper entirely on the property name also posed an issue if your node was nested within the tree. These changes allow one to use the property wrapper `@BindNode(withPath:)` to either specify a nested path, or to decouple the naming of the property and the node within Godot. As the initializer parameter is optional, this is a nonbreaking change.