### PR TITLE
Omit parameter labels and deprecate autogenerated methods

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -391,7 +391,7 @@ func generateBuiltinMethods (_ p: Printer,
         for arg in m.arguments ?? [] {
             var eliminate: String = ""
             
-            if arg.omitArgumentLabel ?? false {
+            if arg.omitLabel ?? false {
                 eliminate = "_ "
             }
             

--- a/Sources/ExtensionApi/ApiJsonModel.swift
+++ b/Sources/ExtensionApi/ApiJsonModel.swift
@@ -244,7 +244,14 @@ public struct JGodotBuiltinClassMethod: Codable {
     public let hash: Int
     public let description: String
     public let arguments: [JGodotArgument]?
+    public let isDuplicateCallSignature: Bool?
+    public let deprecation: Deprecation?
 
+    public struct Deprecation: Codable {
+        public let message: String
+        public let renamed: String?
+    }
+    
     enum CodingKeys: String, CodingKey {
         case name
         case returnType = "return_type"
@@ -253,6 +260,8 @@ public struct JGodotBuiltinClassMethod: Codable {
         case isStatic = "is_static"
         case hash, arguments
         case description
+        case isDuplicateCallSignature = "is_duplicate_call_signature"
+        case deprecation
     }
 
     public init(name: String, description: String, returnType: String?, isVararg: Bool, isConst: Bool, isStatic: Bool, hash: Int, arguments: [JGodotArgument]?) {
@@ -264,6 +273,8 @@ public struct JGodotBuiltinClassMethod: Codable {
         self.hash = hash
         self.arguments = arguments
         self.description = description
+        self.isDuplicateCallSignature = false
+        self.deprecation = nil
     }
 }
 
@@ -273,12 +284,14 @@ public struct JGodotArgument: Codable {
     public let description: String?
     public let defaultValue: String?
     public let meta: JGodotArgumentMeta?
+    public let omitArgumentLabel: Bool?
 
     enum CodingKeys: String, CodingKey {
         case name, type
         case defaultValue = "default_value"
         case meta
         case description
+        case omitArgumentLabel = "omit_argument_label"
     }
 
     public init(name: String, type: String, description: String? = nil, defaultValue: String?, meta: JGodotArgumentMeta?) {
@@ -287,6 +300,7 @@ public struct JGodotArgument: Codable {
         self.defaultValue = defaultValue
         self.meta = meta
         self.description = description
+        self.omitArgumentLabel = false
     }
 }
 

--- a/Sources/ExtensionApi/ApiJsonModel.swift
+++ b/Sources/ExtensionApi/ApiJsonModel.swift
@@ -284,14 +284,14 @@ public struct JGodotArgument: Codable {
     public let description: String?
     public let defaultValue: String?
     public let meta: JGodotArgumentMeta?
-    public let omitArgumentLabel: Bool?
+    public let omitLabel: Bool?
 
     enum CodingKeys: String, CodingKey {
         case name, type
         case defaultValue = "default_value"
         case meta
         case description
-        case omitArgumentLabel = "omit_argument_label"
+        case omitLabel = "omit_argument_label"
     }
 
     public init(name: String, type: String, description: String? = nil, defaultValue: String?, meta: JGodotArgumentMeta?) {
@@ -300,7 +300,7 @@ public struct JGodotArgument: Codable {
         self.defaultValue = defaultValue
         self.meta = meta
         self.description = description
-        self.omitArgumentLabel = false
+        self.omitLabel = false
     }
 }
 


### PR DESCRIPTION
Relates to #483 

@migueldeicaza this is more of a POC, not a fully fleshed out solution, am curious to hear your thoughts before I go any further.

A request was made to remove the `value` parameter label from `GArray.append(value: Variant)` to imitate Swift's `Array.append(_:)` signature.

My goal was to add the new, label-omitted signature and add a deprecation warning to the old signature.

The `GArray.append` method is autogenerated from the `extensions_api.json`. So in order to achieve the goal I needed to:
1. Add `omitLabel` flag to `JGodotArgument` and if found prepend `_ ` to the argument's label
2. Add `isDuplicateSignature` flag to `JGodotBuiltinClassMethod` to avoid generating any duplicate `GDExtensionPtrBuiltInMethod`
3. Add `Deprecation` object to `JGodotBuiltinClassMethod` which contains information for the Xcode deprecation warning.

There is still plenty of work to be done, cleaning/tightening things up. The duplicate flag could be handled dynamically (but I kinda like the declaration?). `Deprecation` object could be generalized. etc etc.

#### Deprecation warning
<img width="1175" alt="Screenshot 2024-05-24 at 12 37 53 PM" src="https://github.com/migueldeicaza/SwiftGodot/assets/10519018/8293dc63-6352-456e-9402-06cec5ba1b2c">

#### Deprecation warning expanded
<img width="1164" alt="Screenshot 2024-05-24 at 12 38 21 PM" src="https://github.com/migueldeicaza/SwiftGodot/assets/10519018/3b42c0a3-fafd-4c17-a0f6-66f00c01b6e5">

#### Deprecation warning in autocomplete
<img width="434" alt="Screenshot 2024-05-24 at 12 38 35 PM" src="https://github.com/migueldeicaza/SwiftGodot/assets/10519018/c9fd299e-3c63-46b8-b5cf-b2d6e0a43c85">
