### PR TITLE
Explicitly omit argument label for GArray.append

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -388,10 +388,8 @@ func generateBuiltinMethods (_ p: Printer,
         
         for arg in m.arguments ?? [] {
             var eliminate: String = ""
-            if args.isEmpty, m.name.hasSuffix ("_\(arg.name)") {
-                // if the first argument name matches the last part of the method name, we want
-                // to skip giving it a name.   For example:
-                // addPattern (pattern: xx) becomes addPattern (_ pattern: xx)
+            // Omit first argument label, if necessary
+            if args.isEmpty, shouldOmitFirstArgLabel(typeName: typeName, methodName: m.name, argName: arg.name) {
                 eliminate = "_ "
             }
             if args != "" { args += ", " }

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -237,6 +237,24 @@ let omittedMethodsList: [String: Set<String>] = [
     ],
 ]
 
+// Dictionary used to explicitly tell the generator to replace the first argument label with "_ "
+let omittedFirstArgLabelList: [String: Set<String>] = [
+    "GArray": ["append"]
+]
+
+/// Determines if the first argument name should be replaced with an underscore.
+///
+/// First argument name should be omitted if:
+/// 1. The name matches the suffix of the method name, for example: `addPattern(pattern: xx)` becomes `addPattern(_ pattern: xx)`
+/// 2. If it's found in `omittedFirstArgLabelList`.
+/// - Parameters:
+///   - typeName: Name of the parent type
+///   - methodName: Name of the method
+///   - argName: Name of the argument
+func shouldOmitFirstArgLabel(typeName: String, methodName: String, argName: String) -> Bool {
+    return methodName.hasSuffix ("_\(argName)") || omittedFirstArgLabelList[typeName]?.contains(methodName) == true
+}
+
 ///
 /// Returns a hashtable mapping a godot method name to a Swift Name + its definition
 /// this list is used to generate later the proxies outside the class

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -341,11 +341,9 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                 isRefOptional = isRefParameterOptional (className: className, method: method.name, arg: arg.name)
             }
             
-            // if the first argument name matches the last part of the method name, we want
-            // to skip giving it a name.   For example:
-            // addPattern (pattern: xx) becomes addPattern (_ pattern: xx)
+            // Omit first argument label, if necessary
             if firstArg == nil {
-                if method.name.hasSuffix("_\(arg.name)") {
+                if shouldOmitFirstArgLabel(typeName: className, methodName: method.name, argName: arg.name) {
                     eliminate = "_ "
                 } else {
                     eliminate = allEliminate

--- a/Sources/SwiftGodot/Core/GArray.swift
+++ b/Sources/SwiftGodot/Core/GArray.swift
@@ -38,4 +38,9 @@ extension GArray {
             ptr.pointee = newValue.content
         }
     }
+    
+    @available(*, deprecated, renamed: "append(_:)", message: "This method signature has been deprecated in favor of append(_:)")
+    public func append(value: Variant) {
+        append(value)
+    }
 }

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -32,14 +32,14 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     /// Initializes the collection using an array literal, for example: `let objectCollection: ObjectCollection<Node> = [Node()]`
 	public required init(arrayLiteral elements: ArrayLiteralElement...) {
 		array = elements.reduce(into: .init(Element.self)) {
-			$0.append(value: Variant($1))
+            $0.append(Variant($1))
 		}
 	}
     
     /// Initializes the collection using an array
     public init(_ elements: [Element]) {
         array = elements.reduce(into: .init(Element.self)) {
-            $0.append(value: Variant($1))
+            $0.append(Variant($1))
         }
     }
     
@@ -135,7 +135,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     
     /// Appends an element at the end of the array (alias of ``pushBack(value:)``).
     public final func append (value: Element) {
-        array.append (value: Variant (value))
+        array.append (Variant (value))
     }
     
     /// Resizes the array to contain a different number of elements. If the array size is smaller, elements are cleared, if bigger, new elements are `null`. Returns ``GodotError/ok`` on success, or one of the other ``GodotError`` values if the operation failed.

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -25,7 +25,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     /// Initializes the collection using an array literal, for example: `let variantCollection: VariantCollection<Int> = [0]`
     public required init(arrayLiteral elements: ArrayLiteralElement...) {
 		array = elements.reduce(into: .init(Element.self)) {
-			$0.append(value: Variant($1))
+            $0.append(Variant($1))
 		}
     }
     
@@ -126,7 +126,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     
     /// Appends an element at the end of the array (alias of ``pushBack(value:)``).
     public final func append (value: Element) {
-        array.append (value: Variant(value))
+        array.append (Variant(value))
     }
     
     /// Resizes the array to contain a different number of elements. If the array size is smaller, elements are cleared, if bigger, new elements are `null`. Returns ``GodotError/ok`` on success, or one of the other ``GodotError`` values if the operation failed.


### PR DESCRIPTION
Third time is the charm!

Fixes #483 by adding `omittedFirstArgLabelList` and checking for any explicitly omitted labels in `BuiltinGen` and `MethodGen`. 

Also deprecated `GArray.append(value: Variant)` and updated internal usages.