### PR TITLE
Fix resolution of dynamic types when only proper supertypes are exposed through GDExtension

### DIFF
--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -319,10 +319,17 @@ func lookupObject<T:GodotObject> (nativeHandle: UnsafeRawPointer) -> T? {
     if let a = objectFromHandle(nativeHandle: nativeHandle) {
         return a as? T
     }
-    let _result: GString = GString ()
-    let copy = nativeHandle
-    gi.object_method_bind_ptrcall (Object.method_get_class, UnsafeMutableRawPointer (mutating: copy), nil, &_result.content)
-    let className = _result.description
+    var className: String = ""
+    var sc: StringName.ContentType = StringName.zero
+    if gi.object_get_class_name (nativeHandle, library, &sc) != 0 {
+        let sn = StringName(content: sc)
+        className = String(sn)
+    } else {
+        let copy = nativeHandle
+        let _result: GString = GString ()
+        gi.object_method_bind_ptrcall (Object.method_get_class, UnsafeMutableRawPointer (mutating: copy), nil, &_result.content)
+        className = _result.description
+    }
     if let ctor = godotFrameworkCtors [className] {
         return ctor.init (nativeHandle: nativeHandle) as? T
     }


### PR DESCRIPTION
Originally, using ```Object.method_get_class``` meant that we tried using an object's dynamic type even if it was not registered with GDExtension, which resulted in falling back to the default case of using the static type from the method signature. This PR fixes this by introducing a call to ```gi.object_get_class_name```, which will return the name of the most specialized subtype that is still registered with GDExtension. If this fails for some reason, we fall back to the previous method.