### PR TITLE
use let instead of var for _initializeClass

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -416,7 +416,7 @@ class GodotMacroProcessor {
     func processType () throws -> String {
         ctor =
     """
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("\(className)")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<\(className)> (name: className)\n

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -71,7 +71,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -157,7 +157,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -244,7 +244,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -330,7 +330,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -454,7 +454,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -560,7 +560,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -645,7 +645,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -729,7 +729,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -849,7 +849,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -957,7 +957,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -1041,7 +1041,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -1125,7 +1125,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -1245,7 +1245,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
@@ -1458,7 +1458,7 @@ class Garage: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Garage")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Garage> (name: className)
@@ -1588,7 +1588,7 @@ class Garage: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Garage")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Garage> (name: className)
@@ -1664,7 +1664,7 @@ public class Issue353: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Issue353")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Issue353> (name: className)
@@ -1731,7 +1731,7 @@ class Garage: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Garage")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Garage> (name: className)
@@ -1805,7 +1805,7 @@ public class Issue353: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Issue353")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Issue353> (name: className)

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -92,7 +92,7 @@ class SomeNode: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<SomeNode> (name: className)
@@ -246,7 +246,7 @@ class SomeNode: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<SomeNode> (name: className)
@@ -301,7 +301,7 @@ class SomeNode: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<SomeNode> (name: className)
@@ -373,7 +373,7 @@ class SomeNode: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<SomeNode> (name: className)
@@ -457,7 +457,7 @@ class ArrayTest: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("ArrayTest")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<ArrayTest> (name: className)
@@ -550,7 +550,7 @@ class SomeNode: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<SomeNode> (name: className)

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
@@ -70,7 +70,7 @@ final class MacroGodotExportEnumTests: XCTestCase {
                 return _initializeClass
             }
 
-            private static var _initializeClass: Void = {
+            private static let _initializeClass: Void = {
                 let className = StringName("SomeNode")
                 assert(ClassDB.classExists(class: className))
                 let classInfo = ClassInfo<SomeNode> (name: className)

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
@@ -126,7 +126,7 @@ class Car: Node {
         return _initializeClass
     }
 
-    private static var _initializeClass: Void = {
+    private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -36,7 +36,7 @@ final class MacroGodotTests: XCTestCase {
                     return _initializeClass
                 }
             
-                private static var _initializeClass: Void = {
+                private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<Hi> (name: className)
@@ -63,7 +63,7 @@ final class MacroGodotTests: XCTestCase {
                     return _initializeClass
                 }
 
-                private static var _initializeClass: Void = {
+                private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<Hi> (name: className)
@@ -99,7 +99,7 @@ final class MacroGodotTests: XCTestCase {
                     return _initializeClass
                 }
             
-                private static var _initializeClass: Void = {
+                private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<Hi> (name: className)
@@ -136,7 +136,7 @@ final class MacroGodotTests: XCTestCase {
                     return _initializeClass
                 }
             
-                private static var _initializeClass: Void = {
+                private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<Hi> (name: className)
@@ -170,7 +170,7 @@ final class MacroGodotTests: XCTestCase {
                     return _initializeClass
                 }
             
-                private static var _initializeClass: Void = {
+                private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<Hi> (name: className)
@@ -237,7 +237,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("Castro")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<Castro> (name: className)
@@ -290,7 +290,7 @@ final class MacroGodotTests: XCTestCase {
                     return _initializeClass
                 }
 
-                private static var _initializeClass: Void = {
+                private static let _initializeClass: Void = {
                     let className = StringName("MyData")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<MyData> (name: className)
@@ -320,7 +320,7 @@ final class MacroGodotTests: XCTestCase {
                     return _initializeClass
                 }
 
-                private static var _initializeClass: Void = {
+                private static let _initializeClass: Void = {
                     let className = StringName("MyClass")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<MyClass> (name: className)
@@ -371,7 +371,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
@@ -415,7 +415,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
                 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
@@ -462,7 +462,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
@@ -506,7 +506,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
                 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
@@ -551,7 +551,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
                 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("MultiplierNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<MultiplierNode> (name: className)
@@ -614,7 +614,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
                 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("CallableCollectionsNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
@@ -658,7 +658,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
                 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("MultiplierNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<MultiplierNode> (name: className)
@@ -721,7 +721,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
                 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("CallableCollectionsNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
@@ -772,7 +772,7 @@ final class MacroGodotTests: XCTestCase {
                         return _initializeClass
                     }
 
-                    private static var _initializeClass: Void = {
+                    private static let _initializeClass: Void = {
                         let className = StringName("MathHelper")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<MathHelper> (name: className)
@@ -840,7 +840,7 @@ final class MacroGodotTests: XCTestCase {
                     return _initializeClass
                 }
             
-                private static var _initializeClass: Void = {
+                private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<Hi> (name: className)


### PR DESCRIPTION
In Swift 6, `_initializeClass` as a `static var` produces an error:

> Static property '_initializeClass' is not concurrency-safe because it is non-isolated global shared mutable state

There's no reason to for it to be a `var`, so make it a `let` instead.