### PR TITLE
work around Godot crash when __CFBundleIdentifier isn't set

### DIFF
--- a/Sources/SwiftGodotTestability/GodotRuntime.swift
+++ b/Sources/SwiftGodotTestability/GodotRuntime.swift
@@ -77,6 +77,11 @@ private extension GodotRuntime {
             }
         )
 
+        // Godot crashes in -[GodotApplicationDelegate applicationDidFinishLaunching:] if __CFBundleIdentifier isn't set.
+        // Terminal sets this automatically. Xcode does not.
+        // If it's set to something that isn't the main bundle ID, Godot hacks macOS into treating the process as an interactive Mac app, which is desirable.
+        setenv("__CFBundleIdentifier", "SwiftGodotKit", 0)
+
         let args = ["SwiftGodotKit", "--headless", "--verbose"]
         withUnsafePtr (strings: args) { ptr in
             godot_main (Int32 (args.count), ptr)


### PR DESCRIPTION
The method `-[GodotApplicationDelegate applicationDidFinishLaunching:]` (which is part of Godot, not part of SwiftGodot) uses the environment variable `__CFBundleIdentifier` in a way that crashes if the variable is not set.

Terminal sets `__CFBundleIdentifier`, but Xcode does not.

This patch works around that crash.