### PR TITLE
update dependencies to point at swiftlang repos

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -185,8 +185,8 @@ let package = Package(
     ],
     products: products,
     dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-syntax", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "510.0.1"),
     ],
     targets: targets
 )


### PR DESCRIPTION
Apple has been migrating its Swift repos to the swiftlang organization on Github. This patch updates the URLs in Package.swift to point at the new organization.