### PR TITLE
Swift macro testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -114,7 +114,7 @@ targets.append(
             dependencies: [
                 "SwiftGodotMacroLibrary",
                 "SwiftGodot",
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+                .product(name: "MacroTesting", package: "swift-macro-testing"),
             ]))
 #endif
 
@@ -187,6 +187,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "510.0.1"),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.5.2"),
     ],
     targets: targets
 )

--- a/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
@@ -1,27 +1,21 @@
-//
-//  SwiftGodotInitSwiftExtensionMacroTests.swift
-//  SwiftGodot
-//
-//  Created by Marquis Kurt on 6/9/23.
-//
-
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
-import SwiftGodot
-import SwiftGodotMacroLibrary
 
 final class InitSwiftExtensionMacroTests: XCTestCase {
-    let testMacros: [String: Macro.Type] = [
-        "initSwiftExtension": InitSwiftExtensionMacro.self
-    ]
+
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
+    }
 
     func testInitSwiftExtensionMacroWithUnspecifiedTypes() {
-        assertMacroExpansion(
+        assertMacro {
             """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point")
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
                     print ("Error: Not all parameters were initialized.")
@@ -39,17 +33,17 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                 })
                 return 1
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testInitSwiftExtensionMacroWithEmptyTypes() {
-        assertMacroExpansion(
+        assertMacro {
             """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", types: [])
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
                     print ("Error: Not all parameters were initialized.")
@@ -67,17 +61,17 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                 })
                 return 1
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testInitSwiftExtensionMacroWithSceneTypesOnly() {
-        assertMacroExpansion(
+        assertMacro {
             """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", types: [ChrysalisNode.self])
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
                     print ("Error: Not all parameters were initialized.")
@@ -95,17 +89,17 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                 })
                 return 1
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testInitSwiftExtensionMacroWithEditorTypes() {
-        assertMacroExpansion(
+        assertMacro {
             """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", editorTypes: [CaterpillarNode.self])
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
                     print ("Error: Not all parameters were initialized.")
@@ -123,17 +117,17 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                 })
                 return 1
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testInitSwiftExtensionMacroWithCoreTypes() {
-        assertMacroExpansion(
+        assertMacro {
             """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", coreTypes: [EggNode.self])
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
                     print ("Error: Not all parameters were initialized.")
@@ -151,17 +145,17 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                 })
                 return 1
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testInitSwiftExtensionMacroWithServerTypes() {
-        assertMacroExpansion(
+        assertMacro {
             """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", serverTypes: [ButterflyNode.self])
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
                     print ("Error: Not all parameters were initialized.")
@@ -179,17 +173,17 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                 })
                 return 1
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testInitSwiftExtensionMacroWithAllTypes() {
-        assertMacroExpansion(
+        assertMacro {
             """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point", coreTypes: [EggNode.self], editorTypes: [CaterpillarNode.self], sceneTypes: [ChrysalisNode.self], serverTypes: [ButterflyNode.self])
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             @_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
                 guard let library, let interface, let `extension` else {
                     print ("Error: Not all parameters were initialized.")
@@ -207,8 +201,8 @@ final class InitSwiftExtensionMacroTests: XCTestCase {
                 })
                 return 1
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
+
 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -1,12 +1,6 @@
-//
 // This file is solely here to ensure that we can compile the resulting macros,
 // which is not covered by the macro output generation.
-//
-//
-//  Created by Miguel de Icaza on 2/27/24.
-//
 
-import Foundation
 import SwiftGodot
 
 @Godot
@@ -18,4 +12,3 @@ class Demo: Object {
 class Demo2: Object {
 	@Export var demo: Variant = Variant()
 }
-

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -1,1839 +1,1793 @@
-//
-//  MacroGodotExportGroupTests.swift
-//  SwiftGodotMacrosTests
-//
-//  Created by Estevan Hernandez on 12/4/23.
-//
-
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
-import SwiftGodotMacroLibrary
 
 final class MacroGodotExportGroupTests: XCTestCase {
-    let testMacros: [String: Macro.Type] = [
-        "Godot": GodotMacro.self,
-        "Export": GodotExport.self,
-        "exportGroup": GodotMacroExportGroup.self
-    ]
-    
+
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
+    }
+
     func testGodotExportGroupWithPrefix() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    #exportGroup("Vehicle", prefix: "vehicle_")
-    @Export var vehicle_make: String = "Mazda"
-    @Export var vehicle_model: String = "RX7"
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                #exportGroup("Vehicle", prefix: "vehicle_")
+                @Export var vehicle_make: String = "Mazda"
+                @Export var vehicle_model: String = "RX7"
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vehicle_make: String = "Mazda"
 
-class Car: Node {
-    var vehicle_make: String = "Mazda"
+                func _mproxy_set_vehicle_make (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.vehicle_make = value
+                	} else {
+                		GD.printErr ("Unable to set `vehicle_make` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_vehicle_make (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vehicle_make = value
-    	} else {
-    		GD.printErr ("Unable to set `vehicle_make` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_vehicle_make (args: [Variant]) -> Variant? {
+                    return Variant (vehicle_make)
+                }
+                var vehicle_model: String = "RX7"
 
-    func _mproxy_get_vehicle_make (args: [Variant]) -> Variant? {
-        return Variant (vehicle_make)
-    }
-    var vehicle_model: String = "RX7"
+                func _mproxy_set_vehicle_model (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.vehicle_model = value
+                	} else {
+                		GD.printErr ("Unable to set `vehicle_model` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_vehicle_model (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vehicle_model = value
-    	} else {
-    		GD.printErr ("Unable to set `vehicle_model` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_vehicle_model (args: [Variant]) -> Variant? {
+                    return Variant (vehicle_model)
+                }
 
-    func _mproxy_get_vehicle_model (args: [Variant]) -> Variant? {
-        return Variant (vehicle_model)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        classInfo.addPropertyGroup(name: "Vehicle", prefix: "vehicle_")
-        let _pvehicle_make = PropInfo (
-            propertyType: .string,
-            propertyName: "vehicle_make",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pvehicle_make, arguments: [], function: Car._mproxy_get_vehicle_make)
-    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pvehicle_make], function: Car._mproxy_set_vehicle_make)
-    	classInfo.registerProperty (_pvehicle_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
-        let _pvehicle_model = PropInfo (
-            propertyType: .string,
-            propertyName: "vehicle_model",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pvehicle_model, arguments: [], function: Car._mproxy_get_vehicle_model)
-    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pvehicle_model], function: Car._mproxy_set_vehicle_model)
-    	classInfo.registerProperty (_pvehicle_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
-    } ()
-}
-""",
-        macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    classInfo.addPropertyGroup(name: "Vehicle", prefix: "vehicle_")
+                    let _pvehicle_make = PropInfo (
+                        propertyType: .string,
+                        propertyName: "vehicle_make",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pvehicle_make, arguments: [], function: Car._mproxy_get_vehicle_make)
+                	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pvehicle_make], function: Car._mproxy_set_vehicle_make)
+                	classInfo.registerProperty (_pvehicle_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+                    let _pvehicle_model = PropInfo (
+                        propertyType: .string,
+                        propertyName: "vehicle_model",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pvehicle_model, arguments: [], function: Car._mproxy_get_vehicle_model)
+                	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pvehicle_model], function: Car._mproxy_set_vehicle_model)
+                	classInfo.registerProperty (_pvehicle_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    #exportGroup("Vehicle")
-    @Export var make: String = "Mazda"
-    @Export var model: String = "RX7"
-}
-""",
-   expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                #exportGroup("Vehicle")
+                @Export var make: String = "Mazda"
+                @Export var model: String = "RX7"
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var make: String = "Mazda"
 
-class Car: Node {
-    var make: String = "Mazda"
+                func _mproxy_set_make (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.make = value
+                	} else {
+                		GD.printErr ("Unable to set `make` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_make (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.make = value
-    	} else {
-    		GD.printErr ("Unable to set `make` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_make (args: [Variant]) -> Variant? {
+                    return Variant (make)
+                }
+                var model: String = "RX7"
 
-    func _mproxy_get_make (args: [Variant]) -> Variant? {
-        return Variant (make)
-    }
-    var model: String = "RX7"
+                func _mproxy_set_model (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.model = value
+                	} else {
+                		GD.printErr ("Unable to set `model` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_model (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.model = value
-    	} else {
-    		GD.printErr ("Unable to set `model` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_model (args: [Variant]) -> Variant? {
+                    return Variant (model)
+                }
 
-    func _mproxy_get_model (args: [Variant]) -> Variant? {
-        return Variant (model)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
-        let _pmake = PropInfo (
-            propertyType: .string,
-            propertyName: "make",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
-    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
-    	classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
-        let _pmodel = PropInfo (
-            propertyType: .string,
-            propertyName: "model",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-    	classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
-    } ()
-}
-""",
-   macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
+                    let _pmake = PropInfo (
+                        propertyType: .string,
+                        propertyName: "make",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
+                	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
+                	classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+                    let _pmodel = PropInfo (
+                        propertyType: .string,
+                        propertyName: "model",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+                	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+                	classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupOnlyProducesPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    @Export var vin: String = "00000000000000000"
-    #exportGroup("YMMS")
-    @Export var year: Int = 1997
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                @Export var vin: String = "00000000000000000"
+                #exportGroup("YMMS")
+                @Export var year: Int = 1997
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vin: String = "00000000000000000"
 
+                func _mproxy_set_vin (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.vin = value
+                	} else {
+                		GD.printErr ("Unable to set `vin` value: ", arg)
+                	}
+                	return nil
+                }
 
-class Car: Node {
-    var vin: String = "00000000000000000"
+                func _mproxy_get_vin (args: [Variant]) -> Variant? {
+                    return Variant (vin)
+                }
+                var year: Int = 1997
 
-    func _mproxy_set_vin (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vin = value
-    	} else {
-    		GD.printErr ("Unable to set `vin` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_set_year (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = Int (arg) {
+                		self.year = value
+                	} else {
+                		GD.printErr ("Unable to set `year` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_get_vin (args: [Variant]) -> Variant? {
-        return Variant (vin)
-    }
-    var year: Int = 1997
+                func _mproxy_get_year (args: [Variant]) -> Variant? {
+                    return Variant (year)
+                }
 
-    func _mproxy_set_year (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Int (arg) {
-    		self.year = value
-    	} else {
-    		GD.printErr ("Unable to set `year` value: ", arg)
-    	}
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    func _mproxy_get_year (args: [Variant]) -> Variant? {
-        return Variant (year)
-    }
-
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        let _pvin = PropInfo (
-            propertyType: .string,
-            propertyName: "vin",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
-        classInfo.addPropertyGroup(name: "YMMS", prefix: "")
-        let _pyear = PropInfo (
-            propertyType: .int,
-            propertyName: "year",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-    	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    let _pvin = PropInfo (
+                        propertyType: .string,
+                        propertyName: "vin",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+                	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+                	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+                    classInfo.addPropertyGroup(name: "YMMS", prefix: "")
+                    let _pyear = PropInfo (
+                        propertyType: .int,
+                        propertyName: "year",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+                	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+                	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    @Export var vin: String = "00000000000000000"
-    @Export var year: Int = 1997
-    #exportGroup("Pointless")
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                @Export var vin: String = "00000000000000000"
+                @Export var year: Int = 1997
+                #exportGroup("Pointless")
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vin: String = "00000000000000000"
 
-class Car: Node {
-    var vin: String = "00000000000000000"
+                func _mproxy_set_vin (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.vin = value
+                	} else {
+                		GD.printErr ("Unable to set `vin` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_vin (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vin = value
-    	} else {
-    		GD.printErr ("Unable to set `vin` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_vin (args: [Variant]) -> Variant? {
+                    return Variant (vin)
+                }
+                var year: Int = 1997
 
-    func _mproxy_get_vin (args: [Variant]) -> Variant? {
-        return Variant (vin)
-    }
-    var year: Int = 1997
+                func _mproxy_set_year (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = Int (arg) {
+                		self.year = value
+                	} else {
+                		GD.printErr ("Unable to set `year` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_year (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Int (arg) {
-    		self.year = value
-    	} else {
-    		GD.printErr ("Unable to set `year` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_year (args: [Variant]) -> Variant? {
+                    return Variant (year)
+                }
 
-    func _mproxy_get_year (args: [Variant]) -> Variant? {
-        return Variant (year)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        let _pvin = PropInfo (
-            propertyType: .string,
-            propertyName: "vin",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
-        let _pyear = PropInfo (
-            propertyType: .int,
-            propertyName: "year",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-    	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
-        classInfo.addPropertyGroup(name: "Pointless", prefix: "")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    let _pvin = PropInfo (
+                        propertyType: .string,
+                        propertyName: "vin",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+                	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+                	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+                    let _pyear = PropInfo (
+                        propertyType: .int,
+                        propertyName: "year",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+                	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+                	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+                    classInfo.addPropertyGroup(name: "Pointless", prefix: "")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    #exportGroup("VIN")
-    @Export var vin: String = ""
-    #exportGroup("YMM")
-    @Export var year: Int = 1997
-    @Export var make: String = "HONDA"
-    @Export var model: String = "ACCORD"
-    
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                #exportGroup("VIN")
+                @Export var vin: String = ""
+                #exportGroup("YMM")
+                @Export var year: Int = 1997
+                @Export var make: String = "HONDA"
+                @Export var model: String = "ACCORD"
+                
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vin: String = ""
 
-class Car: Node {
-    var vin: String = ""
+                func _mproxy_set_vin (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.vin = value
+                	} else {
+                		GD.printErr ("Unable to set `vin` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_vin (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vin = value
-    	} else {
-    		GD.printErr ("Unable to set `vin` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_vin (args: [Variant]) -> Variant? {
+                    return Variant (vin)
+                }
+                var year: Int = 1997
 
-    func _mproxy_get_vin (args: [Variant]) -> Variant? {
-        return Variant (vin)
-    }
-    var year: Int = 1997
+                func _mproxy_set_year (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = Int (arg) {
+                		self.year = value
+                	} else {
+                		GD.printErr ("Unable to set `year` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_year (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Int (arg) {
-    		self.year = value
-    	} else {
-    		GD.printErr ("Unable to set `year` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_year (args: [Variant]) -> Variant? {
+                    return Variant (year)
+                }
+                var make: String = "HONDA"
 
-    func _mproxy_get_year (args: [Variant]) -> Variant? {
-        return Variant (year)
-    }
-    var make: String = "HONDA"
+                func _mproxy_set_make (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.make = value
+                	} else {
+                		GD.printErr ("Unable to set `make` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_make (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.make = value
-    	} else {
-    		GD.printErr ("Unable to set `make` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_make (args: [Variant]) -> Variant? {
+                    return Variant (make)
+                }
+                var model: String = "ACCORD"
 
-    func _mproxy_get_make (args: [Variant]) -> Variant? {
-        return Variant (make)
-    }
-    var model: String = "ACCORD"
+                func _mproxy_set_model (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.model = value
+                	} else {
+                		GD.printErr ("Unable to set `model` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_model (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.model = value
-    	} else {
-    		GD.printErr ("Unable to set `model` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_model (args: [Variant]) -> Variant? {
+                    return Variant (model)
+                }
 
-    func _mproxy_get_model (args: [Variant]) -> Variant? {
-        return Variant (model)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        classInfo.addPropertyGroup(name: "VIN", prefix: "")
-        let _pvin = PropInfo (
-            propertyType: .string,
-            propertyName: "vin",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
-        classInfo.addPropertyGroup(name: "YMM", prefix: "")
-        let _pyear = PropInfo (
-            propertyType: .int,
-            propertyName: "year",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-    	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
-        let _pmake = PropInfo (
-            propertyType: .string,
-            propertyName: "make",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
-    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
-    	classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
-        let _pmodel = PropInfo (
-            propertyType: .string,
-            propertyName: "model",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-    	classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
-    } ()
-    
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    classInfo.addPropertyGroup(name: "VIN", prefix: "")
+                    let _pvin = PropInfo (
+                        propertyType: .string,
+                        propertyName: "vin",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+                	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+                	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+                    classInfo.addPropertyGroup(name: "YMM", prefix: "")
+                    let _pyear = PropInfo (
+                        propertyType: .int,
+                        propertyName: "year",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+                	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+                	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+                    let _pmake = PropInfo (
+                        propertyType: .string,
+                        propertyName: "make",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
+                	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
+                	classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+                    let _pmodel = PropInfo (
+                        propertyType: .string,
+                        propertyName: "model",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+                	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+                	classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+                } ()
+                
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesVariantCollectionPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    #exportGroup("Vehicle")
-    @Export var makes: VariantCollection<String> = ["Mazda"]
-    @Export var model: VariantCollection<String> = ["RX7"]
-}
-""",
-   expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                #exportGroup("Vehicle")
+                @Export var makes: VariantCollection<String> = ["Mazda"]
+                @Export var model: VariantCollection<String> = ["RX7"]
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var makes: VariantCollection<String> = ["Mazda"]
 
-class Car: Node {
-    var makes: VariantCollection<String> = ["Mazda"]
+                func _mproxy_get_makes(args: [Variant]) -> Variant? {
+                	return Variant(makes.array)
+                }
 
-    func _mproxy_get_makes(args: [Variant]) -> Variant? {
-    	return Variant(makes.array)
-    }
+                func _mproxy_set_makes(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	makes.array = gArray
+                	return nil
+                }
+                var model: VariantCollection<String> = ["RX7"]
 
-    func _mproxy_set_makes(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	makes.array = gArray
-    	return nil
-    }
-    var model: VariantCollection<String> = ["RX7"]
+                func _mproxy_get_model(args: [Variant]) -> Variant? {
+                	return Variant(model.array)
+                }
 
-    func _mproxy_get_model(args: [Variant]) -> Variant? {
-    	return Variant(model.array)
-    }
+                func _mproxy_set_model(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	model.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_model(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	model.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
-        let _pmakes = PropInfo (
-            propertyType: .array,
-            propertyName: "makes",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
-    	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
-    	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
-        let _pmodel = PropInfo (
-            propertyType: .array,
-            propertyName: "model",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-    	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-    	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
-    } ()
-}
-""",
-   macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
+                    let _pmakes = PropInfo (
+                        propertyType: .array,
+                        propertyName: "makes",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
+                	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
+                	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
+                    let _pmodel = PropInfo (
+                        propertyType: .array,
+                        propertyName: "model",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+                	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+                	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupOnlyProducesVariantCollectionPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    @Export var vins: VariantCollection<String> = ["00000000000000000"]
-    #exportGroup("YMMS")
-    @Export var years: VariantCollection<Int> = [1997]
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                @Export var vins: VariantCollection<String> = ["00000000000000000"]
+                #exportGroup("YMMS")
+                @Export var years: VariantCollection<Int> = [1997]
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vins: VariantCollection<String> = ["00000000000000000"]
 
+                func _mproxy_get_vins(args: [Variant]) -> Variant? {
+                	return Variant(vins.array)
+                }
 
-class Car: Node {
-    var vins: VariantCollection<String> = ["00000000000000000"]
+                func _mproxy_set_vins(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	vins.array = gArray
+                	return nil
+                }
+                var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
-    	return Variant(vins.array)
-    }
+                func _mproxy_get_years(args: [Variant]) -> Variant? {
+                	return Variant(years.array)
+                }
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
-    }
-    var years: VariantCollection<Int> = [1997]
+                func _mproxy_set_years(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Int.self)) else {
+                		return nil
+                	}
+                	years.array = gArray
+                	return nil
+                }
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
-    	return Variant(years.array)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Int.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
-    }
-
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
-        classInfo.addPropertyGroup(name: "YMMS", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    let _pvins = PropInfo (
+                        propertyType: .array,
+                        propertyName: "vins",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+                	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+                	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+                    classInfo.addPropertyGroup(name: "YMMS", prefix: "")
+                    let _pyears = PropInfo (
+                        propertyType: .array,
+                        propertyName: "years",
+                        className: StringName("Array[int]"),
+                        hint: .arrayType,
+                        hintStr: "int",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+                	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+                	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesVariantCollectionPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    @Export var vins: VariantCollection<String> = ["00000000000000000"]
-    @Export var years: VariantCollection<Int> = [1997]
-    #exportGroup("Pointless")
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                @Export var vins: VariantCollection<String> = ["00000000000000000"]
+                @Export var years: VariantCollection<Int> = [1997]
+                #exportGroup("Pointless")
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vins: VariantCollection<String> = ["00000000000000000"]
 
-class Car: Node {
-    var vins: VariantCollection<String> = ["00000000000000000"]
+                func _mproxy_get_vins(args: [Variant]) -> Variant? {
+                	return Variant(vins.array)
+                }
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
-    	return Variant(vins.array)
-    }
+                func _mproxy_set_vins(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	vins.array = gArray
+                	return nil
+                }
+                var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
-    }
-    var years: VariantCollection<Int> = [1997]
+                func _mproxy_get_years(args: [Variant]) -> Variant? {
+                	return Variant(years.array)
+                }
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
-    	return Variant(years.array)
-    }
+                func _mproxy_set_years(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Int.self)) else {
+                		return nil
+                	}
+                	years.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Int.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
-        classInfo.addPropertyGroup(name: "Pointless", prefix: "")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    let _pvins = PropInfo (
+                        propertyType: .array,
+                        propertyName: "vins",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+                	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+                	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+                    let _pyears = PropInfo (
+                        propertyType: .array,
+                        propertyName: "years",
+                        className: StringName("Array[int]"),
+                        hint: .arrayType,
+                        hintStr: "int",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+                	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+                	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+                    classInfo.addPropertyGroup(name: "Pointless", prefix: "")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesVariantCollectionPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    #exportGroup("VIN")
-    @Export var vins: VariantCollection<String> = [""]
-    #exportGroup("YMM")
-    @Export var years: VariantCollection<Int> = [1997]
-    @Export var makes: VariantCollection<String> = ["HONDA"]
-    @Export var models: VariantCollection<String> = ["ACCORD"]
-    
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                #exportGroup("VIN")
+                @Export var vins: VariantCollection<String> = [""]
+                #exportGroup("YMM")
+                @Export var years: VariantCollection<Int> = [1997]
+                @Export var makes: VariantCollection<String> = ["HONDA"]
+                @Export var models: VariantCollection<String> = ["ACCORD"]
+                
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vins: VariantCollection<String> = [""]
 
-class Car: Node {
-    var vins: VariantCollection<String> = [""]
+                func _mproxy_get_vins(args: [Variant]) -> Variant? {
+                	return Variant(vins.array)
+                }
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
-    	return Variant(vins.array)
-    }
+                func _mproxy_set_vins(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	vins.array = gArray
+                	return nil
+                }
+                var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
-    }
-    var years: VariantCollection<Int> = [1997]
+                func _mproxy_get_years(args: [Variant]) -> Variant? {
+                	return Variant(years.array)
+                }
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
-    	return Variant(years.array)
-    }
+                func _mproxy_set_years(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Int.self)) else {
+                		return nil
+                	}
+                	years.array = gArray
+                	return nil
+                }
+                var makes: VariantCollection<String> = ["HONDA"]
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Int.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
-    }
-    var makes: VariantCollection<String> = ["HONDA"]
+                func _mproxy_get_makes(args: [Variant]) -> Variant? {
+                	return Variant(makes.array)
+                }
 
-    func _mproxy_get_makes(args: [Variant]) -> Variant? {
-    	return Variant(makes.array)
-    }
+                func _mproxy_set_makes(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	makes.array = gArray
+                	return nil
+                }
+                var models: VariantCollection<String> = ["ACCORD"]
 
-    func _mproxy_set_makes(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	makes.array = gArray
-    	return nil
-    }
-    var models: VariantCollection<String> = ["ACCORD"]
+                func _mproxy_get_models(args: [Variant]) -> Variant? {
+                	return Variant(models.array)
+                }
 
-    func _mproxy_get_models(args: [Variant]) -> Variant? {
-    	return Variant(models.array)
-    }
+                func _mproxy_set_models(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	models.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_models(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	models.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        classInfo.addPropertyGroup(name: "VIN", prefix: "")
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
-        classInfo.addPropertyGroup(name: "YMM", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
-        let _pmakes = PropInfo (
-            propertyType: .array,
-            propertyName: "makes",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
-    	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
-    	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
-        let _pmodels = PropInfo (
-            propertyType: .array,
-            propertyName: "models",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
-    	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
-    	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
-    } ()
-    
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    classInfo.addPropertyGroup(name: "VIN", prefix: "")
+                    let _pvins = PropInfo (
+                        propertyType: .array,
+                        propertyName: "vins",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+                	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+                	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+                    classInfo.addPropertyGroup(name: "YMM", prefix: "")
+                    let _pyears = PropInfo (
+                        propertyType: .array,
+                        propertyName: "years",
+                        className: StringName("Array[int]"),
+                        hint: .arrayType,
+                        hintStr: "int",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+                	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+                	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+                    let _pmakes = PropInfo (
+                        propertyType: .array,
+                        propertyName: "makes",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
+                	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
+                	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
+                    let _pmodels = PropInfo (
+                        propertyType: .array,
+                        propertyName: "models",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
+                	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
+                	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
+                } ()
+                
+            }
+            """
+        }
     }
     
     // TODO: and ObjectCollection as well ...
     
     func testGodotExportGroupProducesObjectCollectionPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    #exportGroup("Vehicle")
-    @Export var makes: ObjectCollection<Node> = []
-    @Export var model: ObjectCollection<Node> = []
-}
-""",
-   expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                #exportGroup("Vehicle")
+                @Export var makes: ObjectCollection<Node> = []
+                @Export var model: ObjectCollection<Node> = []
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var makes: ObjectCollection<Node> = []
 
-class Car: Node {
-    var makes: ObjectCollection<Node> = []
+                func _mproxy_get_makes(args: [Variant]) -> Variant? {
+                	return Variant(makes.array)
+                }
 
-    func _mproxy_get_makes(args: [Variant]) -> Variant? {
-    	return Variant(makes.array)
-    }
+                func _mproxy_set_makes(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	makes.array = gArray
+                	return nil
+                }
+                var model: ObjectCollection<Node> = []
 
-    func _mproxy_set_makes(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	makes.array = gArray
-    	return nil
-    }
-    var model: ObjectCollection<Node> = []
+                func _mproxy_get_model(args: [Variant]) -> Variant? {
+                	return Variant(model.array)
+                }
 
-    func _mproxy_get_model(args: [Variant]) -> Variant? {
-    	return Variant(model.array)
-    }
+                func _mproxy_set_model(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	model.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_model(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	model.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
-        let _pmakes = PropInfo (
-            propertyType: .array,
-            propertyName: "makes",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
-    	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
-    	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
-        let _pmodel = PropInfo (
-            propertyType: .array,
-            propertyName: "model",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-    	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-    	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
-    } ()
-}
-""",
-   macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
+                    let _pmakes = PropInfo (
+                        propertyType: .array,
+                        propertyName: "makes",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
+                	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
+                	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
+                    let _pmodel = PropInfo (
+                        propertyType: .array,
+                        propertyName: "model",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+                	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+                	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupOnlyProducesObjectCollectionPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    @Export var vins: ObjectCollection<Node> = []
-    #exportGroup("YMMS")
-    @Export var years: ObjectCollection<Node> = []
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                @Export var vins: ObjectCollection<Node> = []
+                #exportGroup("YMMS")
+                @Export var years: ObjectCollection<Node> = []
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vins: ObjectCollection<Node> = []
 
-class Car: Node {
-    var vins: ObjectCollection<Node> = []
+                func _mproxy_get_vins(args: [Variant]) -> Variant? {
+                	return Variant(vins.array)
+                }
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
-    	return Variant(vins.array)
-    }
+                func _mproxy_set_vins(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	vins.array = gArray
+                	return nil
+                }
+                var years: ObjectCollection<Node> = []
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
-    }
-    var years: ObjectCollection<Node> = []
+                func _mproxy_get_years(args: [Variant]) -> Variant? {
+                	return Variant(years.array)
+                }
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
-    	return Variant(years.array)
-    }
+                func _mproxy_set_years(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	years.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
-        classInfo.addPropertyGroup(name: "YMMS", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    let _pvins = PropInfo (
+                        propertyType: .array,
+                        propertyName: "vins",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+                	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+                	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+                    classInfo.addPropertyGroup(name: "YMMS", prefix: "")
+                    let _pyears = PropInfo (
+                        propertyType: .array,
+                        propertyName: "years",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+                	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+                	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesObjectCollectionPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    @Export var vins: ObjectCollection<Node> = []
-    @Export var years: ObjectCollection<Node> = []
-    #exportGroup("Pointless")
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                @Export var vins: ObjectCollection<Node> = []
+                @Export var years: ObjectCollection<Node> = []
+                #exportGroup("Pointless")
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vins: ObjectCollection<Node> = []
 
-class Car: Node {
-    var vins: ObjectCollection<Node> = []
+                func _mproxy_get_vins(args: [Variant]) -> Variant? {
+                	return Variant(vins.array)
+                }
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
-    	return Variant(vins.array)
-    }
+                func _mproxy_set_vins(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	vins.array = gArray
+                	return nil
+                }
+                var years: ObjectCollection<Node> = []
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
-    }
-    var years: ObjectCollection<Node> = []
+                func _mproxy_get_years(args: [Variant]) -> Variant? {
+                	return Variant(years.array)
+                }
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
-    	return Variant(years.array)
-    }
+                func _mproxy_set_years(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	years.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
-        classInfo.addPropertyGroup(name: "Pointless", prefix: "")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    let _pvins = PropInfo (
+                        propertyType: .array,
+                        propertyName: "vins",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+                	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+                	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+                    let _pyears = PropInfo (
+                        propertyType: .array,
+                        propertyName: "years",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+                	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+                	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+                    classInfo.addPropertyGroup(name: "Pointless", prefix: "")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesObjectCollectionPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup() {
-        assertMacroExpansion(
-"""
-@Godot
-class Car: Node {
-    #exportGroup("VIN")
-    @Export var vins: ObjectCollection<Node> = []
-    #exportGroup("YMM")
-    @Export var years: ObjectCollection<Node> = []
-    @Export var makes: ObjectCollection<Node> = []
-    @Export var models: ObjectCollection<Node> = []
-    
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Car: Node {
+                #exportGroup("VIN")
+                @Export var vins: ObjectCollection<Node> = []
+                #exportGroup("YMM")
+                @Export var years: ObjectCollection<Node> = []
+                @Export var makes: ObjectCollection<Node> = []
+                @Export var models: ObjectCollection<Node> = []
+                
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vins: ObjectCollection<Node> = []
 
-class Car: Node {
-    var vins: ObjectCollection<Node> = []
+                func _mproxy_get_vins(args: [Variant]) -> Variant? {
+                	return Variant(vins.array)
+                }
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
-    	return Variant(vins.array)
-    }
+                func _mproxy_set_vins(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	vins.array = gArray
+                	return nil
+                }
+                var years: ObjectCollection<Node> = []
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
-    }
-    var years: ObjectCollection<Node> = []
+                func _mproxy_get_years(args: [Variant]) -> Variant? {
+                	return Variant(years.array)
+                }
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
-    	return Variant(years.array)
-    }
+                func _mproxy_set_years(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	years.array = gArray
+                	return nil
+                }
+                var makes: ObjectCollection<Node> = []
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
-    }
-    var makes: ObjectCollection<Node> = []
+                func _mproxy_get_makes(args: [Variant]) -> Variant? {
+                	return Variant(makes.array)
+                }
 
-    func _mproxy_get_makes(args: [Variant]) -> Variant? {
-    	return Variant(makes.array)
-    }
+                func _mproxy_set_makes(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	makes.array = gArray
+                	return nil
+                }
+                var models: ObjectCollection<Node> = []
 
-    func _mproxy_set_makes(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	makes.array = gArray
-    	return nil
-    }
-    var models: ObjectCollection<Node> = []
+                func _mproxy_get_models(args: [Variant]) -> Variant? {
+                	return Variant(models.array)
+                }
 
-    func _mproxy_get_models(args: [Variant]) -> Variant? {
-    	return Variant(models.array)
-    }
+                func _mproxy_set_models(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Node.self)) else {
+                		return nil
+                	}
+                	models.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_models(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	models.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        classInfo.addPropertyGroup(name: "VIN", prefix: "")
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
-        classInfo.addPropertyGroup(name: "YMM", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
-        let _pmakes = PropInfo (
-            propertyType: .array,
-            propertyName: "makes",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
-    	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
-    	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
-        let _pmodels = PropInfo (
-            propertyType: .array,
-            propertyName: "models",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
-    	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
-    	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
-    } ()
-    
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    classInfo.addPropertyGroup(name: "VIN", prefix: "")
+                    let _pvins = PropInfo (
+                        propertyType: .array,
+                        propertyName: "vins",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+                	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+                	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+                    classInfo.addPropertyGroup(name: "YMM", prefix: "")
+                    let _pyears = PropInfo (
+                        propertyType: .array,
+                        propertyName: "years",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+                	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+                	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+                    let _pmakes = PropInfo (
+                        propertyType: .array,
+                        propertyName: "makes",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
+                	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
+                	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
+                    let _pmodels = PropInfo (
+                        propertyType: .array,
+                        propertyName: "models",
+                        className: StringName("Array[Node]"),
+                        hint: .arrayType,
+                        hintStr: "Node",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
+                	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
+                	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
+                } ()
+                
+            }
+            """
+        }
     }
     
     func testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenMixingVariantCollectionObjectCollectionAndNormalVariableProperties() {
-        assertMacroExpansion(
-"""
-@Godot
-class Garage: Node {
-    #exportGroup("Front Page")
-    @Export var name: String = ""
-    @Export var rating: Float = 0.0
-    #exportGroup("More Details")
-    @Export var reviews: VariantCollection<String> = []
-    @Export var checkIns: ObjectCollection<CheckIn> = []
-    @Export var address: String = ""
-    #exportGroup("Hours and Insurance")
-    @Export var daysOfOperation: VariantCollection<String> = []
-    @Export var hours: VariantCollection<String> = []
-    @Export var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Garage: Node {
+                #exportGroup("Front Page")
+                @Export var name: String = ""
+                @Export var rating: Float = 0.0
+                #exportGroup("More Details")
+                @Export var reviews: VariantCollection<String> = []
+                @Export var checkIns: ObjectCollection<CheckIn> = []
+                @Export var address: String = ""
+                #exportGroup("Hours and Insurance")
+                @Export var daysOfOperation: VariantCollection<String> = []
+                @Export var hours: VariantCollection<String> = []
+                @Export var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
+            }
+            """
+        } expansion: {
+            """
+            class Garage: Node {
+                var name: String = ""
 
-class Garage: Node {
-    var name: String = ""
+                func _mproxy_set_name (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.name = value
+                	} else {
+                		GD.printErr ("Unable to set `name` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_name (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.name = value
-    	} else {
-    		GD.printErr ("Unable to set `name` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_name (args: [Variant]) -> Variant? {
+                    return Variant (name)
+                }
+                var rating: Float = 0.0
 
-    func _mproxy_get_name (args: [Variant]) -> Variant? {
-        return Variant (name)
-    }
-    var rating: Float = 0.0
+                func _mproxy_set_rating (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = Float (arg) {
+                		self.rating = value
+                	} else {
+                		GD.printErr ("Unable to set `rating` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_rating (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Float (arg) {
-    		self.rating = value
-    	} else {
-    		GD.printErr ("Unable to set `rating` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_rating (args: [Variant]) -> Variant? {
+                    return Variant (rating)
+                }
+                var reviews: VariantCollection<String> = []
 
-    func _mproxy_get_rating (args: [Variant]) -> Variant? {
-        return Variant (rating)
-    }
-    var reviews: VariantCollection<String> = []
+                func _mproxy_get_reviews(args: [Variant]) -> Variant? {
+                	return Variant(reviews.array)
+                }
 
-    func _mproxy_get_reviews(args: [Variant]) -> Variant? {
-    	return Variant(reviews.array)
-    }
+                func _mproxy_set_reviews(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	reviews.array = gArray
+                	return nil
+                }
+                var checkIns: ObjectCollection<CheckIn> = []
 
-    func _mproxy_set_reviews(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	reviews.array = gArray
-    	return nil
-    }
-    var checkIns: ObjectCollection<CheckIn> = []
+                func _mproxy_get_checkIns(args: [Variant]) -> Variant? {
+                	return Variant(checkIns.array)
+                }
 
-    func _mproxy_get_checkIns(args: [Variant]) -> Variant? {
-    	return Variant(checkIns.array)
-    }
+                func _mproxy_set_checkIns(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(CheckIn.self)) else {
+                		return nil
+                	}
+                	checkIns.array = gArray
+                	return nil
+                }
+                var address: String = ""
 
-    func _mproxy_set_checkIns(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(CheckIn.self)) else {
-    		return nil
-    	}
-    	checkIns.array = gArray
-    	return nil
-    }
-    var address: String = ""
+                func _mproxy_set_address (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.address = value
+                	} else {
+                		GD.printErr ("Unable to set `address` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_address (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.address = value
-    	} else {
-    		GD.printErr ("Unable to set `address` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_address (args: [Variant]) -> Variant? {
+                    return Variant (address)
+                }
+                var daysOfOperation: VariantCollection<String> = []
 
-    func _mproxy_get_address (args: [Variant]) -> Variant? {
-        return Variant (address)
-    }
-    var daysOfOperation: VariantCollection<String> = []
+                func _mproxy_get_daysOfOperation(args: [Variant]) -> Variant? {
+                	return Variant(daysOfOperation.array)
+                }
 
-    func _mproxy_get_daysOfOperation(args: [Variant]) -> Variant? {
-    	return Variant(daysOfOperation.array)
-    }
+                func _mproxy_set_daysOfOperation(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	daysOfOperation.array = gArray
+                	return nil
+                }
+                var hours: VariantCollection<String> = []
 
-    func _mproxy_set_daysOfOperation(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	daysOfOperation.array = gArray
-    	return nil
-    }
-    var hours: VariantCollection<String> = []
+                func _mproxy_get_hours(args: [Variant]) -> Variant? {
+                	return Variant(hours.array)
+                }
 
-    func _mproxy_get_hours(args: [Variant]) -> Variant? {
-    	return Variant(hours.array)
-    }
+                func _mproxy_set_hours(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	hours.array = gArray
+                	return nil
+                }
+                var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
 
-    func _mproxy_set_hours(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	hours.array = gArray
-    	return nil
-    }
-    var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
+                func _mproxy_get_insuranceProvidersAccepted(args: [Variant]) -> Variant? {
+                	return Variant(insuranceProvidersAccepted.array)
+                }
 
-    func _mproxy_get_insuranceProvidersAccepted(args: [Variant]) -> Variant? {
-    	return Variant(insuranceProvidersAccepted.array)
-    }
+                func _mproxy_set_insuranceProvidersAccepted(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(InsuranceProvider.self)) else {
+                		return nil
+                	}
+                	insuranceProvidersAccepted.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_insuranceProvidersAccepted(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(InsuranceProvider.self)) else {
-    		return nil
-    	}
-    	insuranceProvidersAccepted.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Garage")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Garage> (name: className)
-        classInfo.addPropertyGroup(name: "Front Page", prefix: "")
-        let _pname = PropInfo (
-            propertyType: .string,
-            propertyName: "name",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_name", flags: .default, returnValue: _pname, arguments: [], function: Garage._mproxy_get_name)
-    	classInfo.registerMethod (name: "_mproxy_set_name", flags: .default, returnValue: nil, arguments: [_pname], function: Garage._mproxy_set_name)
-    	classInfo.registerProperty (_pname, getter: "_mproxy_get_name", setter: "_mproxy_set_name")
-        let _prating = PropInfo (
-            propertyType: .float,
-            propertyName: "rating",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_rating", flags: .default, returnValue: _prating, arguments: [], function: Garage._mproxy_get_rating)
-    	classInfo.registerMethod (name: "_mproxy_set_rating", flags: .default, returnValue: nil, arguments: [_prating], function: Garage._mproxy_set_rating)
-    	classInfo.registerProperty (_prating, getter: "_mproxy_get_rating", setter: "_mproxy_set_rating")
-        classInfo.addPropertyGroup(name: "More Details", prefix: "")
-        let _previews = PropInfo (
-            propertyType: .array,
-            propertyName: "reviews",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_reviews", flags: .default, returnValue: _previews, arguments: [], function: Garage._mproxy_get_reviews)
-    	classInfo.registerMethod (name: "set_reviews", flags: .default, returnValue: nil, arguments: [_previews], function: Garage._mproxy_set_reviews)
-    	classInfo.registerProperty (_previews, getter: "get_reviews", setter: "set_reviews")
-        let _pcheckIns = PropInfo (
-            propertyType: .array,
-            propertyName: "check_ins",
-            className: StringName("Array[CheckIn]"),
-            hint: .arrayType,
-            hintStr: "CheckIn",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_check_ins", flags: .default, returnValue: _pcheckIns, arguments: [], function: Garage._mproxy_get_checkIns)
-    	classInfo.registerMethod (name: "set_check_ins", flags: .default, returnValue: nil, arguments: [_pcheckIns], function: Garage._mproxy_set_checkIns)
-    	classInfo.registerProperty (_pcheckIns, getter: "get_check_ins", setter: "set_check_ins")
-        let _paddress = PropInfo (
-            propertyType: .string,
-            propertyName: "address",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_address", flags: .default, returnValue: _paddress, arguments: [], function: Garage._mproxy_get_address)
-    	classInfo.registerMethod (name: "_mproxy_set_address", flags: .default, returnValue: nil, arguments: [_paddress], function: Garage._mproxy_set_address)
-    	classInfo.registerProperty (_paddress, getter: "_mproxy_get_address", setter: "_mproxy_set_address")
-        classInfo.addPropertyGroup(name: "Hours and Insurance", prefix: "")
-        let _pdaysOfOperation = PropInfo (
-            propertyType: .array,
-            propertyName: "days_of_operation",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_days_of_operation", flags: .default, returnValue: _pdaysOfOperation, arguments: [], function: Garage._mproxy_get_daysOfOperation)
-    	classInfo.registerMethod (name: "set_days_of_operation", flags: .default, returnValue: nil, arguments: [_pdaysOfOperation], function: Garage._mproxy_set_daysOfOperation)
-    	classInfo.registerProperty (_pdaysOfOperation, getter: "get_days_of_operation", setter: "set_days_of_operation")
-        let _phours = PropInfo (
-            propertyType: .array,
-            propertyName: "hours",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_hours", flags: .default, returnValue: _phours, arguments: [], function: Garage._mproxy_get_hours)
-    	classInfo.registerMethod (name: "set_hours", flags: .default, returnValue: nil, arguments: [_phours], function: Garage._mproxy_set_hours)
-    	classInfo.registerProperty (_phours, getter: "get_hours", setter: "set_hours")
-        let _pinsuranceProvidersAccepted = PropInfo (
-            propertyType: .array,
-            propertyName: "insurance_providers_accepted",
-            className: StringName("Array[InsuranceProvider]"),
-            hint: .arrayType,
-            hintStr: "InsuranceProvider",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_insurance_providers_accepted", flags: .default, returnValue: _pinsuranceProvidersAccepted, arguments: [], function: Garage._mproxy_get_insuranceProvidersAccepted)
-    	classInfo.registerMethod (name: "set_insurance_providers_accepted", flags: .default, returnValue: nil, arguments: [_pinsuranceProvidersAccepted], function: Garage._mproxy_set_insuranceProvidersAccepted)
-    	classInfo.registerProperty (_pinsuranceProvidersAccepted, getter: "get_insurance_providers_accepted", setter: "set_insurance_providers_accepted")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Garage")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Garage> (name: className)
+                    classInfo.addPropertyGroup(name: "Front Page", prefix: "")
+                    let _pname = PropInfo (
+                        propertyType: .string,
+                        propertyName: "name",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_name", flags: .default, returnValue: _pname, arguments: [], function: Garage._mproxy_get_name)
+                	classInfo.registerMethod (name: "_mproxy_set_name", flags: .default, returnValue: nil, arguments: [_pname], function: Garage._mproxy_set_name)
+                	classInfo.registerProperty (_pname, getter: "_mproxy_get_name", setter: "_mproxy_set_name")
+                    let _prating = PropInfo (
+                        propertyType: .float,
+                        propertyName: "rating",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_rating", flags: .default, returnValue: _prating, arguments: [], function: Garage._mproxy_get_rating)
+                	classInfo.registerMethod (name: "_mproxy_set_rating", flags: .default, returnValue: nil, arguments: [_prating], function: Garage._mproxy_set_rating)
+                	classInfo.registerProperty (_prating, getter: "_mproxy_get_rating", setter: "_mproxy_set_rating")
+                    classInfo.addPropertyGroup(name: "More Details", prefix: "")
+                    let _previews = PropInfo (
+                        propertyType: .array,
+                        propertyName: "reviews",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_reviews", flags: .default, returnValue: _previews, arguments: [], function: Garage._mproxy_get_reviews)
+                	classInfo.registerMethod (name: "set_reviews", flags: .default, returnValue: nil, arguments: [_previews], function: Garage._mproxy_set_reviews)
+                	classInfo.registerProperty (_previews, getter: "get_reviews", setter: "set_reviews")
+                    let _pcheckIns = PropInfo (
+                        propertyType: .array,
+                        propertyName: "check_ins",
+                        className: StringName("Array[CheckIn]"),
+                        hint: .arrayType,
+                        hintStr: "CheckIn",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_check_ins", flags: .default, returnValue: _pcheckIns, arguments: [], function: Garage._mproxy_get_checkIns)
+                	classInfo.registerMethod (name: "set_check_ins", flags: .default, returnValue: nil, arguments: [_pcheckIns], function: Garage._mproxy_set_checkIns)
+                	classInfo.registerProperty (_pcheckIns, getter: "get_check_ins", setter: "set_check_ins")
+                    let _paddress = PropInfo (
+                        propertyType: .string,
+                        propertyName: "address",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_address", flags: .default, returnValue: _paddress, arguments: [], function: Garage._mproxy_get_address)
+                	classInfo.registerMethod (name: "_mproxy_set_address", flags: .default, returnValue: nil, arguments: [_paddress], function: Garage._mproxy_set_address)
+                	classInfo.registerProperty (_paddress, getter: "_mproxy_get_address", setter: "_mproxy_set_address")
+                    classInfo.addPropertyGroup(name: "Hours and Insurance", prefix: "")
+                    let _pdaysOfOperation = PropInfo (
+                        propertyType: .array,
+                        propertyName: "days_of_operation",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_days_of_operation", flags: .default, returnValue: _pdaysOfOperation, arguments: [], function: Garage._mproxy_get_daysOfOperation)
+                	classInfo.registerMethod (name: "set_days_of_operation", flags: .default, returnValue: nil, arguments: [_pdaysOfOperation], function: Garage._mproxy_set_daysOfOperation)
+                	classInfo.registerProperty (_pdaysOfOperation, getter: "get_days_of_operation", setter: "set_days_of_operation")
+                    let _phours = PropInfo (
+                        propertyType: .array,
+                        propertyName: "hours",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_hours", flags: .default, returnValue: _phours, arguments: [], function: Garage._mproxy_get_hours)
+                	classInfo.registerMethod (name: "set_hours", flags: .default, returnValue: nil, arguments: [_phours], function: Garage._mproxy_set_hours)
+                	classInfo.registerProperty (_phours, getter: "get_hours", setter: "set_hours")
+                    let _pinsuranceProvidersAccepted = PropInfo (
+                        propertyType: .array,
+                        propertyName: "insurance_providers_accepted",
+                        className: StringName("Array[InsuranceProvider]"),
+                        hint: .arrayType,
+                        hintStr: "InsuranceProvider",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_insurance_providers_accepted", flags: .default, returnValue: _pinsuranceProvidersAccepted, arguments: [], function: Garage._mproxy_get_insuranceProvidersAccepted)
+                	classInfo.registerMethod (name: "set_insurance_providers_accepted", flags: .default, returnValue: nil, arguments: [_pinsuranceProvidersAccepted], function: Garage._mproxy_set_insuranceProvidersAccepted)
+                	classInfo.registerProperty (_pinsuranceProvidersAccepted, getter: "get_insurance_providers_accepted", setter: "set_insurance_providers_accepted")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupWithPrefixTerminatedWithNoMatchingExports() {
-        assertMacroExpansion(
-"""
-@Godot
-class Garage: Node {
-    #exportGroup("Example", prefix: "example")
-    @Export var bar: Bool = false
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Garage: Node {
+                #exportGroup("Example", prefix: "example")
+                @Export var bar: Bool = false
+            }
+            """
+        } expansion: {
+            """
+            class Garage: Node {
+                var bar: Bool = false
 
-class Garage: Node {
-    var bar: Bool = false
+                func _mproxy_set_bar (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = Bool (arg) {
+                		self.bar = value
+                	} else {
+                		GD.printErr ("Unable to set `bar` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_bar (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Bool (arg) {
-    		self.bar = value
-    	} else {
-    		GD.printErr ("Unable to set `bar` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_bar (args: [Variant]) -> Variant? {
+                    return Variant (bar)
+                }
 
-    func _mproxy_get_bar (args: [Variant]) -> Variant? {
-        return Variant (bar)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Garage")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Garage> (name: className)
-        classInfo.addPropertyGroup(name: "Example", prefix: "example")
-        let _pbar = PropInfo (
-            propertyType: .bool,
-            propertyName: "bar",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
-    	classInfo.registerMethod (name: "_mproxy_set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
-    	classInfo.registerProperty (_pbar, getter: "_mproxy_get_bar", setter: "_mproxy_set_bar")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Garage")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Garage> (name: className)
+                    classInfo.addPropertyGroup(name: "Example", prefix: "example")
+                    let _pbar = PropInfo (
+                        propertyType: .bool,
+                        propertyName: "bar",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
+                	classInfo.registerMethod (name: "_mproxy_set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
+                	classInfo.registerProperty (_pbar, getter: "_mproxy_get_bar", setter: "_mproxy_set_bar")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupWithPrefixTerminatedWithOneMatchingExport() {
-        assertMacroExpansion(
-"""
-@Godot
-public class Issue353: Node {
-    #exportGroup("Group With a Prefix", prefix: "prefix1")
-    @Export var prefix1_prefixed_bool: Bool = true
-    @Export var non_prefixed_bool: Bool = true
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            public class Issue353: Node {
+                #exportGroup("Group With a Prefix", prefix: "prefix1")
+                @Export var prefix1_prefixed_bool: Bool = true
+                @Export var non_prefixed_bool: Bool = true
+            }
+            """
+        } expansion: {
+            """
+            public class Issue353: Node {
+                var prefix1_prefixed_bool: Bool = true
 
-public class Issue353: Node {
-    var prefix1_prefixed_bool: Bool = true
+                func _mproxy_set_prefix1_prefixed_bool (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = Bool (arg) {
+                		self.prefix1_prefixed_bool = value
+                	} else {
+                		GD.printErr ("Unable to set `prefix1_prefixed_bool` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_prefix1_prefixed_bool (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Bool (arg) {
-    		self.prefix1_prefixed_bool = value
-    	} else {
-    		GD.printErr ("Unable to set `prefix1_prefixed_bool` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_prefix1_prefixed_bool (args: [Variant]) -> Variant? {
+                    return Variant (prefix1_prefixed_bool)
+                }
+                var non_prefixed_bool: Bool = true
 
-    func _mproxy_get_prefix1_prefixed_bool (args: [Variant]) -> Variant? {
-        return Variant (prefix1_prefixed_bool)
-    }
-    var non_prefixed_bool: Bool = true
+                func _mproxy_set_non_prefixed_bool (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = Bool (arg) {
+                		self.non_prefixed_bool = value
+                	} else {
+                		GD.printErr ("Unable to set `non_prefixed_bool` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_non_prefixed_bool (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Bool (arg) {
-    		self.non_prefixed_bool = value
-    	} else {
-    		GD.printErr ("Unable to set `non_prefixed_bool` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_non_prefixed_bool (args: [Variant]) -> Variant? {
+                    return Variant (non_prefixed_bool)
+                }
 
-    func _mproxy_get_non_prefixed_bool (args: [Variant]) -> Variant? {
-        return Variant (non_prefixed_bool)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Issue353")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Issue353> (name: className)
-        classInfo.addPropertyGroup(name: "Group With a Prefix", prefix: "prefix1")
-        let _pprefix1_prefixed_bool = PropInfo (
-            propertyType: .bool,
-            propertyName: "prefix1_prefixed_bool",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
-    	classInfo.registerMethod (name: "_mproxy_set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
-    	classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "_mproxy_get__prefixed_bool", setter: "_mproxy_set__prefixed_bool")
-        let _pnon_prefixed_bool = PropInfo (
-            propertyType: .bool,
-            propertyName: "non_prefixed_bool",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
-    	classInfo.registerMethod (name: "_mproxy_set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
-    	classInfo.registerProperty (_pnon_prefixed_bool, getter: "_mproxy_get_non_prefixed_bool", setter: "_mproxy_set_non_prefixed_bool")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Issue353")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Issue353> (name: className)
+                    classInfo.addPropertyGroup(name: "Group With a Prefix", prefix: "prefix1")
+                    let _pprefix1_prefixed_bool = PropInfo (
+                        propertyType: .bool,
+                        propertyName: "prefix1_prefixed_bool",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
+                	classInfo.registerMethod (name: "_mproxy_set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
+                	classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "_mproxy_get__prefixed_bool", setter: "_mproxy_set__prefixed_bool")
+                    let _pnon_prefixed_bool = PropInfo (
+                        propertyType: .bool,
+                        propertyName: "non_prefixed_bool",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
+                	classInfo.registerMethod (name: "_mproxy_set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
+                	classInfo.registerProperty (_pnon_prefixed_bool, getter: "_mproxy_get_non_prefixed_bool", setter: "_mproxy_set_non_prefixed_bool")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupWithPrefixTerminatedWithNoMatchingCollectionExports() {
-        assertMacroExpansion(
-"""
-@Godot
-class Garage: Node {
-    #exportGroup("Example", prefix: "example")
-    @Export var bar: VariantCollection<Bool> = [false]
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class Garage: Node {
+                #exportGroup("Example", prefix: "example")
+                @Export var bar: VariantCollection<Bool> = [false]
+            }
+            """
+        } expansion: {
+            """
+            class Garage: Node {
+                var bar: VariantCollection<Bool> = [false]
 
-class Garage: Node {
-    var bar: VariantCollection<Bool> = [false]
+                func _mproxy_get_bar(args: [Variant]) -> Variant? {
+                	return Variant(bar.array)
+                }
 
-    func _mproxy_get_bar(args: [Variant]) -> Variant? {
-    	return Variant(bar.array)
-    }
+                func _mproxy_set_bar(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Bool.self)) else {
+                		return nil
+                	}
+                	bar.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_bar(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Bool.self)) else {
-    		return nil
-    	}
-    	bar.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Garage")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Garage> (name: className)
-        classInfo.addPropertyGroup(name: "Example", prefix: "example")
-        let _pbar = PropInfo (
-            propertyType: .array,
-            propertyName: "bar",
-            className: StringName("Array[bool]"),
-            hint: .arrayType,
-            hintStr: "bool",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
-    	classInfo.registerMethod (name: "set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
-    	classInfo.registerProperty (_pbar, getter: "get_bar", setter: "set_bar")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Garage")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Garage> (name: className)
+                    classInfo.addPropertyGroup(name: "Example", prefix: "example")
+                    let _pbar = PropInfo (
+                        propertyType: .array,
+                        propertyName: "bar",
+                        className: StringName("Array[bool]"),
+                        hint: .arrayType,
+                        hintStr: "bool",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
+                	classInfo.registerMethod (name: "set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
+                	classInfo.registerProperty (_pbar, getter: "get_bar", setter: "set_bar")
+                } ()
+            }
+            """
+        }
     }
     
     func testGodotExportGroupWithPrefixTerminatedWithOneMatchingCollectionExport() {
-        assertMacroExpansion(
-"""
-@Godot
-public class Issue353: Node {
-    #exportGroup("Group With a Prefix", prefix: "prefix1")
-    @Export var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
-    @Export var non_prefixed_bool: VariantCollection<Bool> = [false]
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            public class Issue353: Node {
+                #exportGroup("Group With a Prefix", prefix: "prefix1")
+                @Export var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
+                @Export var non_prefixed_bool: VariantCollection<Bool> = [false]
+            }
+            """
+        } expansion: {
+            """
+            public class Issue353: Node {
+                var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
 
-public class Issue353: Node {
-    var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
+                func _mproxy_get_prefix1_prefixed_bool(args: [Variant]) -> Variant? {
+                	return Variant(prefix1_prefixed_bool.array)
+                }
 
-    func _mproxy_get_prefix1_prefixed_bool(args: [Variant]) -> Variant? {
-    	return Variant(prefix1_prefixed_bool.array)
-    }
+                func _mproxy_set_prefix1_prefixed_bool(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Bool.self)) else {
+                		return nil
+                	}
+                	prefix1_prefixed_bool.array = gArray
+                	return nil
+                }
+                var non_prefixed_bool: VariantCollection<Bool> = [false]
 
-    func _mproxy_set_prefix1_prefixed_bool(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Bool.self)) else {
-    		return nil
-    	}
-    	prefix1_prefixed_bool.array = gArray
-    	return nil
-    }
-    var non_prefixed_bool: VariantCollection<Bool> = [false]
+                func _mproxy_get_non_prefixed_bool(args: [Variant]) -> Variant? {
+                	return Variant(non_prefixed_bool.array)
+                }
 
-    func _mproxy_get_non_prefixed_bool(args: [Variant]) -> Variant? {
-    	return Variant(non_prefixed_bool.array)
-    }
+                func _mproxy_set_non_prefixed_bool(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Bool.self)) else {
+                		return nil
+                	}
+                	non_prefixed_bool.array = gArray
+                	return nil
+                }
 
-    func _mproxy_set_non_prefixed_bool(args: [Variant]) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Bool.self)) else {
-    		return nil
-    	}
-    	non_prefixed_bool.array = gArray
-    	return nil
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Issue353")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Issue353> (name: className)
-        classInfo.addPropertyGroup(name: "Group With a Prefix", prefix: "prefix1")
-        let _pprefix1_prefixed_bool = PropInfo (
-            propertyType: .array,
-            propertyName: "prefix1_prefixed_bool",
-            className: StringName("Array[bool]"),
-            hint: .arrayType,
-            hintStr: "bool",
-            usage: .default)
-    	classInfo.registerMethod (name: "get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
-    	classInfo.registerMethod (name: "set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
-    	classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "get__prefixed_bool", setter: "set__prefixed_bool")
-        let _pnon_prefixed_bool = PropInfo (
-            propertyType: .array,
-            propertyName: "non_prefixed_bool",
-            className: StringName("Array[bool]"),
-            hint: .arrayType,
-            hintStr: "bool",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
-    	classInfo.registerMethod (name: "set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
-    	classInfo.registerProperty (_pnon_prefixed_bool, getter: "get_non_prefixed_bool", setter: "set_non_prefixed_bool")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("Issue353")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Issue353> (name: className)
+                    classInfo.addPropertyGroup(name: "Group With a Prefix", prefix: "prefix1")
+                    let _pprefix1_prefixed_bool = PropInfo (
+                        propertyType: .array,
+                        propertyName: "prefix1_prefixed_bool",
+                        className: StringName("Array[bool]"),
+                        hint: .arrayType,
+                        hintStr: "bool",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
+                	classInfo.registerMethod (name: "set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
+                	classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "get__prefixed_bool", setter: "set__prefixed_bool")
+                    let _pnon_prefixed_bool = PropInfo (
+                        propertyType: .array,
+                        propertyName: "non_prefixed_bool",
+                        className: StringName("Array[bool]"),
+                        hint: .arrayType,
+                        hintStr: "bool",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
+                	classInfo.registerMethod (name: "set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
+                	classInfo.registerProperty (_pnon_prefixed_bool, getter: "get_non_prefixed_bool", setter: "set_non_prefixed_bool")
+                } ()
+            }
+            """
+        }
     }
 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -1,573 +1,546 @@
-//
-//  MacroGodotExportCollectionTests.swift
-//  SwiftGodotMacrosTests
-//
-//  Created by Estevan Hernandez on 11/29/23.
-//
-
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
-import SwiftGodotMacroLibrary
 
 final class MacroGodotExportCollectionTests: XCTestCase {
-	let testMacros: [String: Macro.Type] = [
-		"Godot": GodotMacro.self,
-		"Export": GodotExport.self,
-	]
-	
-	func testExportArrayStringGodotMacroFails() {
-		assertMacroExpansion(
-			"""
-			@Godot
-			class SomeNode: Node {
-				@Export var greetings: [String]
-			}
-			""",
-		expandedSource:
-			"""
 
-			class SomeNode: Node {
-				var greetings: [String]
-			}
-			""",
-			diagnostics: [
-				.init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 3, column: 2),
-				.init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 1, column: 1)
-			],
-			macros: testMacros
-		)
-	}
-	
-	func testExportArrayStringMacroFails() {
-		assertMacroExpansion(
-			"""
-			@Export
-			var greetings: [String]
-			""",
-		expandedSource:
-			"""
-
-			var greetings: [String]
-			""",
-			diagnostics: [
-				.init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 1, column: 1)
-			],
-			macros: testMacros
-		)
-	}
-
-	func testExportGenericArrayStringGodotMacro() {
-		assertMacroExpansion(
-"""
-@Godot
-class SomeNode: Node {
-	@Export
-	var greetings: VariantCollection<String> = []
-}
-""",
-			expandedSource:
-"""
-
-class SomeNode: Node {
-	var greetings: VariantCollection<String> = []
-
-	func _mproxy_get_greetings(args: [Variant]) -> Variant? {
-		return Variant(greetings.array)
-	}
-
-	func _mproxy_set_greetings(args: [Variant]) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(String.self)) else {
-			return nil
-		}
-		greetings.array = gArray
-		return nil
-	}
-
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
     }
 
-    private static let _initializeClass: Void = {
-        let className = StringName("SomeNode")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<SomeNode> (name: className)
-        let _pgreetings = PropInfo (
-            propertyType: .array,
-            propertyName: "greetings",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
-    	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
-    	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
-    } ()
-}
-""",
-			macros: testMacros
-		)
-	}
+    func testExportArrayStringGodotMacroFails() {
+        assertMacro {
+            """
+            @Godot
+            class SomeNode: Node {
+                @Export var greetings: [String]
+            }
+            """
+        } diagnostics: {
+            """
+            @Godot
+            ╰─ 🛑 @Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead
+            class SomeNode: Node {
+                @Export var greetings: [String]
+                ┬──────────────────────────────
+                ╰─ 🛑 @Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead
+            }
+            """
+        }
+    }
 	
-	func testExportArrayStringMacro() {
-		assertMacroExpansion(
-"""
-@Export var greetings: VariantCollection<String> = []
-""",
-			expandedSource:
-"""
+    func testExportArrayStringMacroFails() {
+        assertMacro {
+            """
+            @Export
+            var greetings: [String]
+            """
+        } diagnostics: {
+            """
+            @Export
+            ╰─ 🛑 @Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead
+            var greetings: [String]
+            """
+        }
+    }
 
-var greetings: VariantCollection<String> = []
+    func testExportGenericArrayStringGodotMacro() {
+        assertMacro {
+            """
+            @Godot
+            class SomeNode: Node {
+                @Export
+                var greetings: VariantCollection<String> = []
+            }
+            """
+        } expansion: {
+            """
+            class SomeNode: Node {
+                var greetings: VariantCollection<String> = []
 
-func _mproxy_get_greetings(args: [Variant]) -> Variant? {
-	return Variant(greetings.array)
-}
+                func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+                	return Variant(greetings.array)
+                }
 
-func _mproxy_set_greetings(args: [Variant]) -> Variant? {
-	guard let arg = args.first,
-		  let gArray = GArray(arg),
-		  gArray.isTyped(),
-		  gArray.isSameTyped(array: GArray(String.self)) else {
-		return nil
-	}
-	greetings.array = gArray
-	return nil
-}
-""",
-			macros: testMacros
-		)
-	}
+                func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	greetings.array = gArray
+                	return nil
+                }
+
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
+
+                private static let _initializeClass: Void = {
+                    let className = StringName("SomeNode")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<SomeNode> (name: className)
+                    let _pgreetings = PropInfo (
+                        propertyType: .array,
+                        propertyName: "greetings",
+                        className: StringName("Array[String]"),
+                        hint: .arrayType,
+                        hintStr: "String",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
+                	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
+                	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
+                } ()
+            }
+            """
+        }
+    }
+	
+    func testExportArrayStringMacro() {
+        assertMacro {
+            """
+            @Export var greetings: VariantCollection<String> = []
+            """
+        } expansion: {
+            """
+            var greetings: VariantCollection<String> = []
+
+            func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+            	return Variant(greetings.array)
+            }
+
+            func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+            	guard let arg = args.first,
+            		  let gArray = GArray(arg),
+            		  gArray.isTyped(),
+            		  gArray.isSameTyped(array: GArray(String.self)) else {
+            		return nil
+            	}
+            	greetings.array = gArray
+            	return nil
+            }
+            """
+        }
+    }
 	
 	func testExportGenericArrayStringMacro() {
-		assertMacroExpansion(
-"""
-@Export var greetings: VariantCollection<String> = []
-""",
-			expandedSource:
-"""
+            assertMacro {
+                """
+                @Export var greetings: VariantCollection<String> = []
+                """
+            } expansion: {
+                """
+                var greetings: VariantCollection<String> = []
 
-var greetings: VariantCollection<String> = []
+                func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+                	return Variant(greetings.array)
+                }
 
-func _mproxy_get_greetings(args: [Variant]) -> Variant? {
-	return Variant(greetings.array)
-}
-
-func _mproxy_set_greetings(args: [Variant]) -> Variant? {
-	guard let arg = args.first,
-		  let gArray = GArray(arg),
-		  gArray.isTyped(),
-		  gArray.isSameTyped(array: GArray(String.self)) else {
-		return nil
-	}
-	greetings.array = gArray
-	return nil
-}
-""",
-			macros: testMacros
-		)
+                func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	greetings.array = gArray
+                	return nil
+                }
+                """
+            }
 	}
 	
 	func testExportConstantGenericArrayStringMacro() {
-		assertMacroExpansion(
-"""
-@Export let greetings: VariantCollection<String> = []
-""",
-			expandedSource:
-"""
+            assertMacro {
+                """
+                @Export let greetings: VariantCollection<String> = []
+                """
+            } expansion: {
+                """
+                let greetings: VariantCollection<String> = []
 
-let greetings: VariantCollection<String> = []
+                func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+                	return Variant(greetings.array)
+                }
 
-func _mproxy_get_greetings(args: [Variant]) -> Variant? {
-	return Variant(greetings.array)
-}
-
-func _mproxy_set_greetings(args: [Variant]) -> Variant? {
-	guard let arg = args.first,
-		  let gArray = GArray(arg),
-		  gArray.isTyped(),
-		  gArray.isSameTyped(array: GArray(String.self)) else {
-		return nil
-	}
-	greetings.array = gArray
-	return nil
-}
-""",
-			macros: testMacros
-		)
+                func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(String.self)) else {
+                		return nil
+                	}
+                	greetings.array = gArray
+                	return nil
+                }
+                """
+            }
 	}
 	
 	func testExportOptionalGenericArrayStringMacro() {
-		assertMacroExpansion(
-			"@Export var greetings: VariantCollection<String>? = []",
-			expandedSource: "var greetings: VariantCollection<String>? = []",
-			diagnostics: [
-				.init(message: "@Export optional Collections are not supported", line: 1, column: 1)
-			],
-			macros: testMacros
-		)
+            assertMacro {
+                """
+                @Export var greetings: VariantCollection<String>? = []
+                """
+            } diagnostics: {
+                """
+                @Export var greetings: VariantCollection<String>? = []
+                ┬──────
+                ╰─ 🛑 @Export optional Collections are not supported
+                """
+            }
 	}
 	
     func testExportGArray() {
-        assertMacroExpansion(
-"""
-@Godot
-class SomeNode: Node {
-    @Export var someArray: GArray = GArray()
-}
-""",
-            expandedSource:
-"""
+        assertMacro {
+            """
+            @Godot
+            class SomeNode: Node {
+                @Export var someArray: GArray = GArray()
+            }
+            """
+        } expansion: {
+            """
+            class SomeNode: Node {
+                var someArray: GArray = GArray()
 
-class SomeNode: Node {
-    var someArray: GArray = GArray()
+                func _mproxy_set_someArray (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = GArray (arg) {
+                		self.someArray = value
+                	} else {
+                		GD.printErr ("Unable to set `someArray` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_someArray (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = GArray (arg) {
-    		self.someArray = value
-    	} else {
-    		GD.printErr ("Unable to set `someArray` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_someArray (args: [Variant]) -> Variant? {
+                    return Variant (someArray)
+                }
 
-    func _mproxy_get_someArray (args: [Variant]) -> Variant? {
-        return Variant (someArray)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("SomeNode")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<SomeNode> (name: className)
-        let _psomeArray = PropInfo (
-            propertyType: .array,
-            propertyName: "someArray",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_someArray", flags: .default, returnValue: _psomeArray, arguments: [], function: SomeNode._mproxy_get_someArray)
-    	classInfo.registerMethod (name: "_mproxy_set_someArray", flags: .default, returnValue: nil, arguments: [_psomeArray], function: SomeNode._mproxy_set_someArray)
-    	classInfo.registerProperty (_psomeArray, getter: "_mproxy_get_someArray", setter: "_mproxy_set_someArray")
-    } ()
-}
-""",
-            macros: testMacros
-        )
+                private static let _initializeClass: Void = {
+                    let className = StringName("SomeNode")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<SomeNode> (name: className)
+                    let _psomeArray = PropInfo (
+                        propertyType: .array,
+                        propertyName: "someArray",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_someArray", flags: .default, returnValue: _psomeArray, arguments: [], function: SomeNode._mproxy_get_someArray)
+                	classInfo.registerMethod (name: "_mproxy_set_someArray", flags: .default, returnValue: nil, arguments: [_psomeArray], function: SomeNode._mproxy_set_someArray)
+                	classInfo.registerProperty (_psomeArray, getter: "_mproxy_get_someArray", setter: "_mproxy_set_someArray")
+                } ()
+            }
+            """
+        }
     }
     
-	func testExportArrayIntGodotMacro() {
-		assertMacroExpansion(
-"""
-@Godot
-class SomeNode: Node {
-	@Export var someNumbers: VariantCollection<Int> = []
-}
-""",
-			expandedSource:
-"""
+    func testExportArrayIntGodotMacro() {
+        assertMacro {
+            """
+            @Godot
+            class SomeNode: Node {
+                @Export var someNumbers: VariantCollection<Int> = []
+            }
+            """
+        } expansion: {
+            """
+            class SomeNode: Node {
+                var someNumbers: VariantCollection<Int> = []
 
-class SomeNode: Node {
-	var someNumbers: VariantCollection<Int> = []
+                func _mproxy_get_someNumbers(args: [Variant]) -> Variant? {
+                	return Variant(someNumbers.array)
+                }
 
-	func _mproxy_get_someNumbers(args: [Variant]) -> Variant? {
-		return Variant(someNumbers.array)
-	}
+                func _mproxy_set_someNumbers(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Int.self)) else {
+                		return nil
+                	}
+                	someNumbers.array = gArray
+                	return nil
+                }
 
-	func _mproxy_set_someNumbers(args: [Variant]) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(Int.self)) else {
-			return nil
-		}
-		someNumbers.array = gArray
-		return nil
-	}
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
+                private static let _initializeClass: Void = {
+                    let className = StringName("SomeNode")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<SomeNode> (name: className)
+                    let _psomeNumbers = PropInfo (
+                        propertyType: .array,
+                        propertyName: "some_numbers",
+                        className: StringName("Array[int]"),
+                        hint: .arrayType,
+                        hintStr: "int",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
+                	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
+                	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
+                } ()
+            }
+            """
+        }
     }
 
-    private static let _initializeClass: Void = {
-        let className = StringName("SomeNode")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<SomeNode> (name: className)
-        let _psomeNumbers = PropInfo (
-            propertyType: .array,
-            propertyName: "some_numbers",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
-    	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
-    	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
-    } ()
-}
-""",
-			macros: testMacros
-		)
-	}
+    func testExportArraysIntGodotMacro() throws {
+        assertMacro {
+            """
+            @Godot
+            class SomeNode: Node {
+                @Export var someNumbers: VariantCollection<Int> = []
+                @Export var someOtherNumbers: VariantCollection<Int> = []
+            }
+            """
+        } expansion: {
+            """
+            class SomeNode: Node {
+                var someNumbers: VariantCollection<Int> = []
 
-	func testExportArraysIntGodotMacro() throws {
-		assertMacroExpansion(
-"""
-@Godot
-class SomeNode: Node {
-	@Export var someNumbers: VariantCollection<Int> = []
-	@Export var someOtherNumbers: VariantCollection<Int> = []
-}
-""",
-			expandedSource:
-"""
+                func _mproxy_get_someNumbers(args: [Variant]) -> Variant? {
+                	return Variant(someNumbers.array)
+                }
 
-class SomeNode: Node {
-	var someNumbers: VariantCollection<Int> = []
+                func _mproxy_set_someNumbers(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Int.self)) else {
+                		return nil
+                	}
+                	someNumbers.array = gArray
+                	return nil
+                }
+                var someOtherNumbers: VariantCollection<Int> = []
 
-	func _mproxy_get_someNumbers(args: [Variant]) -> Variant? {
-		return Variant(someNumbers.array)
-	}
+                func _mproxy_get_someOtherNumbers(args: [Variant]) -> Variant? {
+                	return Variant(someOtherNumbers.array)
+                }
 
-	func _mproxy_set_someNumbers(args: [Variant]) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(Int.self)) else {
-			return nil
-		}
-		someNumbers.array = gArray
-		return nil
-	}
-	var someOtherNumbers: VariantCollection<Int> = []
+                func _mproxy_set_someOtherNumbers(args: [Variant]) -> Variant? {
+                	guard let arg = args.first,
+                		  let gArray = GArray(arg),
+                		  gArray.isTyped(),
+                		  gArray.isSameTyped(array: GArray(Int.self)) else {
+                		return nil
+                	}
+                	someOtherNumbers.array = gArray
+                	return nil
+                }
 
-	func _mproxy_get_someOtherNumbers(args: [Variant]) -> Variant? {
-		return Variant(someOtherNumbers.array)
-	}
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-	func _mproxy_set_someOtherNumbers(args: [Variant]) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(Int.self)) else {
-			return nil
-		}
-		someOtherNumbers.array = gArray
-		return nil
-	}
-
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
+                private static let _initializeClass: Void = {
+                    let className = StringName("SomeNode")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<SomeNode> (name: className)
+                    let _psomeNumbers = PropInfo (
+                        propertyType: .array,
+                        propertyName: "some_numbers",
+                        className: StringName("Array[int]"),
+                        hint: .arrayType,
+                        hintStr: "int",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
+                	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
+                	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
+                    let _psomeOtherNumbers = PropInfo (
+                        propertyType: .array,
+                        propertyName: "some_other_numbers",
+                        className: StringName("Array[int]"),
+                        hint: .arrayType,
+                        hintStr: "int",
+                        usage: .default)
+                	classInfo.registerMethod (name: "get_some_other_numbers", flags: .default, returnValue: _psomeOtherNumbers, arguments: [], function: SomeNode._mproxy_get_someOtherNumbers)
+                	classInfo.registerMethod (name: "set_some_other_numbers", flags: .default, returnValue: nil, arguments: [_psomeOtherNumbers], function: SomeNode._mproxy_set_someOtherNumbers)
+                	classInfo.registerProperty (_psomeOtherNumbers, getter: "get_some_other_numbers", setter: "set_some_other_numbers")
+                } ()
+            }
+            """
+        }
     }
 
-    private static let _initializeClass: Void = {
-        let className = StringName("SomeNode")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<SomeNode> (name: className)
-        let _psomeNumbers = PropInfo (
-            propertyType: .array,
-            propertyName: "some_numbers",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
-    	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
-    	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
-        let _psomeOtherNumbers = PropInfo (
-            propertyType: .array,
-            propertyName: "some_other_numbers",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_some_other_numbers", flags: .default, returnValue: _psomeOtherNumbers, arguments: [], function: SomeNode._mproxy_get_someOtherNumbers)
-    	classInfo.registerMethod (name: "set_some_other_numbers", flags: .default, returnValue: nil, arguments: [_psomeOtherNumbers], function: SomeNode._mproxy_set_someOtherNumbers)
-    	classInfo.registerProperty (_psomeOtherNumbers, getter: "get_some_other_numbers", setter: "set_some_other_numbers")
-    } ()
-}
-""",
-			macros: testMacros
-		)
-	}
-	
-	func testGodotExportTwoStringArrays() throws {
-		assertMacroExpansion(
-"""
-import SwiftGodot
+    func testGodotExportTwoStringArrays() throws {
+        assertMacro {
+            """
+            import SwiftGodot
 
-@Godot
-class ArrayTest: Node {
-   @Export var firstNames: VariantCollection<String> = ["Thelonius"]
-   @Export var lastNames: VariantCollection<String> = ["Monk"]
-}
-"""
-		, expandedSource:
-"""
-import SwiftGodot
-class ArrayTest: Node {
-   var firstNames: VariantCollection<String> = ["Thelonius"]
+            @Godot
+            class ArrayTest: Node {
+               @Export var firstNames: VariantCollection<String> = ["Thelonius"]
+               @Export var lastNames: VariantCollection<String> = ["Monk"]
+            }
+            """
+        } expansion: {
+            """
+            import SwiftGodot
+            class ArrayTest: Node {
+               var firstNames: VariantCollection<String> = ["Thelonius"]
 
-   func _mproxy_get_firstNames(args: [Variant]) -> Variant? {
-   	return Variant(firstNames.array)
-   }
+               func _mproxy_get_firstNames(args: [Variant]) -> Variant? {
+               	return Variant(firstNames.array)
+               }
 
-   func _mproxy_set_firstNames(args: [Variant]) -> Variant? {
-   	guard let arg = args.first,
-   		  let gArray = GArray(arg),
-   		  gArray.isTyped(),
-   		  gArray.isSameTyped(array: GArray(String.self)) else {
-   		return nil
-   	}
-   	firstNames.array = gArray
-   	return nil
-   }
-   var lastNames: VariantCollection<String> = ["Monk"]
+               func _mproxy_set_firstNames(args: [Variant]) -> Variant? {
+               	guard let arg = args.first,
+               		  let gArray = GArray(arg),
+               		  gArray.isTyped(),
+               		  gArray.isSameTyped(array: GArray(String.self)) else {
+               		return nil
+               	}
+               	firstNames.array = gArray
+               	return nil
+               }
+               var lastNames: VariantCollection<String> = ["Monk"]
 
-   func _mproxy_get_lastNames(args: [Variant]) -> Variant? {
-   	return Variant(lastNames.array)
-   }
+               func _mproxy_get_lastNames(args: [Variant]) -> Variant? {
+               	return Variant(lastNames.array)
+               }
 
-   func _mproxy_set_lastNames(args: [Variant]) -> Variant? {
-   	guard let arg = args.first,
-   		  let gArray = GArray(arg),
-   		  gArray.isTyped(),
-   		  gArray.isSameTyped(array: GArray(String.self)) else {
-   		return nil
-   	}
-   	lastNames.array = gArray
-   	return nil
-   }
+               func _mproxy_set_lastNames(args: [Variant]) -> Variant? {
+               	guard let arg = args.first,
+               		  let gArray = GArray(arg),
+               		  gArray.isTyped(),
+               		  gArray.isSameTyped(array: GArray(String.self)) else {
+               		return nil
+               	}
+               	lastNames.array = gArray
+               	return nil
+               }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
+               override open class var classInitializer: Void {
+                   let _ = super.classInitializer
+                   return _initializeClass
+               }
+
+               private static let _initializeClass: Void = {
+                   let className = StringName("ArrayTest")
+                   assert(ClassDB.classExists(class: className))
+                   let classInfo = ClassInfo<ArrayTest> (name: className)
+                   let _pfirstNames = PropInfo (
+                       propertyType: .array,
+                       propertyName: "first_names",
+                       className: StringName("Array[String]"),
+                       hint: .arrayType,
+                       hintStr: "String",
+                       usage: .default)
+               	classInfo.registerMethod (name: "get_first_names", flags: .default, returnValue: _pfirstNames, arguments: [], function: ArrayTest._mproxy_get_firstNames)
+               	classInfo.registerMethod (name: "set_first_names", flags: .default, returnValue: nil, arguments: [_pfirstNames], function: ArrayTest._mproxy_set_firstNames)
+               	classInfo.registerProperty (_pfirstNames, getter: "get_first_names", setter: "set_first_names")
+                   let _plastNames = PropInfo (
+                       propertyType: .array,
+                       propertyName: "last_names",
+                       className: StringName("Array[String]"),
+                       hint: .arrayType,
+                       hintStr: "String",
+                       usage: .default)
+               	classInfo.registerMethod (name: "get_last_names", flags: .default, returnValue: _plastNames, arguments: [], function: ArrayTest._mproxy_get_lastNames)
+               	classInfo.registerMethod (name: "set_last_names", flags: .default, returnValue: nil, arguments: [_plastNames], function: ArrayTest._mproxy_set_lastNames)
+               	classInfo.registerProperty (_plastNames, getter: "get_last_names", setter: "set_last_names")
+               } ()
+            }
+            """
+        }
     }
 
-    private static let _initializeClass: Void = {
-        let className = StringName("ArrayTest")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<ArrayTest> (name: className)
-        let _pfirstNames = PropInfo (
-            propertyType: .array,
-            propertyName: "first_names",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_first_names", flags: .default, returnValue: _pfirstNames, arguments: [], function: ArrayTest._mproxy_get_firstNames)
-    	classInfo.registerMethod (name: "set_first_names", flags: .default, returnValue: nil, arguments: [_pfirstNames], function: ArrayTest._mproxy_set_firstNames)
-    	classInfo.registerProperty (_pfirstNames, getter: "get_first_names", setter: "set_first_names")
-        let _plastNames = PropInfo (
-            propertyType: .array,
-            propertyName: "last_names",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_last_names", flags: .default, returnValue: _plastNames, arguments: [], function: ArrayTest._mproxy_get_lastNames)
-    	classInfo.registerMethod (name: "set_last_names", flags: .default, returnValue: nil, arguments: [_plastNames], function: ArrayTest._mproxy_set_lastNames)
-    	classInfo.registerProperty (_plastNames, getter: "get_last_names", setter: "set_last_names")
-    } ()
-}
-"""
-		, macros: testMacros
-		)
-	}
-	
-	func testExportObjectCollection() throws {
-		assertMacroExpansion(
-"""
-@Export var greetings: ObjectCollection<Node3D> = []
-""",
-			expandedSource:
-"""
-var greetings: ObjectCollection<Node3D> = []
+    func testExportObjectCollection() throws {
+        assertMacro {
+            """
+            @Export var greetings: ObjectCollection<Node3D> = []
+            """
+        } expansion: {
+            """
+            var greetings: ObjectCollection<Node3D> = []
 
-func _mproxy_get_greetings(args: [Variant]) -> Variant? {
-	return Variant(greetings.array)
-}
+            func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+            	return Variant(greetings.array)
+            }
 
-func _mproxy_set_greetings(args: [Variant]) -> Variant? {
-	guard let arg = args.first,
-		  let gArray = GArray(arg),
-		  gArray.isTyped(),
-		  gArray.isSameTyped(array: GArray(Node3D.self)) else {
-		return nil
-	}
-	greetings.array = gArray
-	return nil
-}
-""",
-			macros: testMacros
-		)
-	}
-	
-	func testGodotExportObjectCollection() throws {
-		assertMacroExpansion(
-"""
-@Godot
-class SomeNode: Node {
-	@Export var greetings: ObjectCollection<Node3D> = []
-}
-""",
-			expandedSource:
-"""
-
-class SomeNode: Node {
-	var greetings: ObjectCollection<Node3D> = []
-
-	func _mproxy_get_greetings(args: [Variant]) -> Variant? {
-		return Variant(greetings.array)
-	}
-
-	func _mproxy_set_greetings(args: [Variant]) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(Node3D.self)) else {
-			return nil
-		}
-		greetings.array = gArray
-		return nil
-	}
-
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
+            func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+            	guard let arg = args.first,
+            		  let gArray = GArray(arg),
+            		  gArray.isTyped(),
+            		  gArray.isSameTyped(array: GArray(Node3D.self)) else {
+            		return nil
+            	}
+            	greetings.array = gArray
+            	return nil
+            }
+            """
+        }
     }
 
-    private static let _initializeClass: Void = {
-        let className = StringName("SomeNode")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<SomeNode> (name: className)
-        let _pgreetings = PropInfo (
-            propertyType: .array,
-            propertyName: "greetings",
-            className: StringName("Array[Node3D]"),
-            hint: .arrayType,
-            hintStr: "Node3D",
-            usage: .default)
-    	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
-    	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
-    	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
-    } ()
-}
-""",
-			macros: testMacros
-		)
-	}
+    func testGodotExportObjectCollection() throws {
+        assertMacro {
+            """
+            @Godot
+            class SomeNode: Node {
+                    @Export var greetings: ObjectCollection<Node3D> = []
+            }
+            """
+        } expansion: {
+            """
+            class SomeNode: Node {
+                    var greetings: ObjectCollection<Node3D> = []
+
+                    func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+                    	return Variant(greetings.array)
+                    }
+
+                    func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+                    	guard let arg = args.first,
+                    		  let gArray = GArray(arg),
+                    		  gArray.isTyped(),
+                    		  gArray.isSameTyped(array: GArray(Node3D.self)) else {
+                    		return nil
+                    	}
+                    	greetings.array = gArray
+                    	return nil
+                    }
+
+                    override open class var classInitializer: Void {
+                        let _ = super.classInitializer
+                        return _initializeClass
+                    }
+
+                    private static let _initializeClass: Void = {
+                        let className = StringName("SomeNode")
+                        assert(ClassDB.classExists(class: className))
+                        let classInfo = ClassInfo<SomeNode> (name: className)
+                        let _pgreetings = PropInfo (
+                            propertyType: .array,
+                            propertyName: "greetings",
+                            className: StringName("Array[Node3D]"),
+                            hint: .arrayType,
+                            hintStr: "Node3D",
+                            usage: .default)
+                    	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
+                    	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
+                    	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
+                    } ()
+            }
+            """
+        }
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
@@ -1,24 +1,17 @@
-//
-//  MacroGodotExportEnumTests.swift
-//  SwiftGodotMacrosTests
-//
-//  Created by Estevan Hernandez on 11/29/23.
-//
-
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
-import SwiftGodotMacroLibrary
 
 final class MacroGodotExportEnumTests: XCTestCase {
-    let testMacros: [String: Macro.Type] = [
-        "Godot": GodotMacro.self,
-        "Export": GodotExport.self,
-    ]
-    
+
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
+    }
+
     func testExportEnumGodot() {
-        assertMacroExpansion(
-    """
+        assertMacro {
+            """
             enum Demo: Int, CaseIterable {
                 case first
             }
@@ -30,82 +23,81 @@ final class MacroGodotExportEnumTests: XCTestCase {
                 @Export(.enum) var demo: Demo
                 @Export(.enum) var demo64: Demo64
             }
-    """,
-    expandedSource:
-    """
-        enum Demo: Int, CaseIterable {
-            case first
+            """
+        } expansion: {
+            #"""
+            enum Demo: Int, CaseIterable {
+                case first
+            }
+            enum Demo64: Int64, CaseIterable {
+                case first
+            }
+            class SomeNode: Node {
+                var demo: Demo
+
+                func _mproxy_set_demo (args: [Variant]) -> Variant? {
+                    if let iv = Int (args [0]), let ev = Demo(rawValue: numericCast (iv)) {
+                        self.demo = ev
+                    }
+                	return nil
+                }
+
+                func _mproxy_get_demo (args: [Variant]) -> Variant? {
+                    return Variant (demo.rawValue)
+                }
+                var demo64: Demo64
+
+                func _mproxy_set_demo64 (args: [Variant]) -> Variant? {
+                    if let iv = Int (args [0]), let ev = Demo64(rawValue: numericCast (iv)) {
+                        self.demo64 = ev
+                    }
+                	return nil
+                }
+
+                func _mproxy_get_demo64 (args: [Variant]) -> Variant? {
+                    return Variant (demo64.rawValue)
+                }
+
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
+
+                private static let _initializeClass: Void = {
+                    let className = StringName("SomeNode")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<SomeNode> (name: className)
+                    let _pdemo = PropInfo (
+                        propertyType: .int,
+                        propertyName: "demo",
+                        className: className,
+                        hint: .enum,
+                        hintStr: tryCase (Demo.self),
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_demo", flags: .default, returnValue: _pdemo, arguments: [], function: SomeNode._mproxy_get_demo)
+                	classInfo.registerMethod (name: "_mproxy_set_demo", flags: .default, returnValue: nil, arguments: [_pdemo], function: SomeNode._mproxy_set_demo)
+                	classInfo.registerProperty (_pdemo, getter: "_mproxy_get_demo", setter: "_mproxy_set_demo")
+                    let _pdemo64 = PropInfo (
+                        propertyType: .int,
+                        propertyName: "demo64",
+                        className: className,
+                        hint: .enum,
+                        hintStr: tryCase (Demo64.self),
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_demo64", flags: .default, returnValue: _pdemo64, arguments: [], function: SomeNode._mproxy_get_demo64)
+                	classInfo.registerMethod (name: "_mproxy_set_demo64", flags: .default, returnValue: nil, arguments: [_pdemo64], function: SomeNode._mproxy_set_demo64)
+                	classInfo.registerProperty (_pdemo64, getter: "_mproxy_get_demo64", setter: "_mproxy_set_demo64")
+                    func tryCase <T : RawRepresentable & CaseIterable> (_ type: T.Type) -> GString {
+                        GString (type.allCases.map { v in
+                            "\(v):\(v.rawValue)"
+                        } .joined(separator: ","))
+                    }
+                    func tryCase <T : RawRepresentable> (_ type: T.Type) -> String {
+                        ""
+                    }
+                } ()
+            }
+            """#
         }
-        enum Demo64: Int64, CaseIterable {
-            case first
-        }
-        class SomeNode: Node {
-            var demo: Demo
-
-            func _mproxy_set_demo (args: [Variant]) -> Variant? {
-                if let iv = Int (args [0]), let ev = Demo(rawValue: numericCast (iv)) {
-                    self.demo = ev
-                }
-            	return nil
-            }
-
-            func _mproxy_get_demo (args: [Variant]) -> Variant? {
-                return Variant (demo.rawValue)
-            }
-            var demo64: Demo64
-
-            func _mproxy_set_demo64 (args: [Variant]) -> Variant? {
-                if let iv = Int (args [0]), let ev = Demo64(rawValue: numericCast (iv)) {
-                    self.demo64 = ev
-                }
-            	return nil
-            }
-
-            func _mproxy_get_demo64 (args: [Variant]) -> Variant? {
-                return Variant (demo64.rawValue)
-            }
-
-            override open class var classInitializer: Void {
-                let _ = super.classInitializer
-                return _initializeClass
-            }
-
-            private static let _initializeClass: Void = {
-                let className = StringName("SomeNode")
-                assert(ClassDB.classExists(class: className))
-                let classInfo = ClassInfo<SomeNode> (name: className)
-                let _pdemo = PropInfo (
-                    propertyType: .int,
-                    propertyName: "demo",
-                    className: className,
-                    hint: .enum,
-                    hintStr: tryCase (Demo.self),
-                    usage: .default)
-            	classInfo.registerMethod (name: "_mproxy_get_demo", flags: .default, returnValue: _pdemo, arguments: [], function: SomeNode._mproxy_get_demo)
-            	classInfo.registerMethod (name: "_mproxy_set_demo", flags: .default, returnValue: nil, arguments: [_pdemo], function: SomeNode._mproxy_set_demo)
-            	classInfo.registerProperty (_pdemo, getter: "_mproxy_get_demo", setter: "_mproxy_set_demo")
-                let _pdemo64 = PropInfo (
-                    propertyType: .int,
-                    propertyName: "demo64",
-                    className: className,
-                    hint: .enum,
-                    hintStr: tryCase (Demo64.self),
-                    usage: .default)
-            	classInfo.registerMethod (name: "_mproxy_get_demo64", flags: .default, returnValue: _pdemo64, arguments: [], function: SomeNode._mproxy_get_demo64)
-            	classInfo.registerMethod (name: "_mproxy_set_demo64", flags: .default, returnValue: nil, arguments: [_pdemo64], function: SomeNode._mproxy_set_demo64)
-            	classInfo.registerProperty (_pdemo64, getter: "_mproxy_get_demo64", setter: "_mproxy_set_demo64")
-                func tryCase <T : RawRepresentable & CaseIterable> (_ type: T.Type) -> GString {
-                    GString (type.allCases.map { v in
-                        "\\(v):\\(v.rawValue)"
-                    } .joined(separator: ","))
-                }
-                func tryCase <T : RawRepresentable> (_ type: T.Type) -> String {
-                    ""
-                }
-            } ()
-        }
-""",
-    macros: testMacros
-        )
     }
 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
@@ -1,191 +1,182 @@
-//
-//  MacroGodotExportSubgroupTests.swift
-//  SwiftGodotMacrosTests
-//
-//  Created by Estevan Hernandez on 1/20/24.
-//
-
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
-import SwiftGodotMacroLibrary
 
-final class MacroGodotExportSubroupTests: XCTestCase {
-    let testMacros: [String: Macro.Type] = [
-        "Godot": GodotMacro.self,
-        "Export": GodotExport.self,
-        "exportGroup": GodotMacroExportGroup.self,
-        "exportSubgroup": GodotMacroExportSubgroup.self
-    ]
-    
+final class MacroGodotExportSubgroupTests: XCTestCase {
+
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
+    }
+
     func testGodotExportSubgroupWithAndWithoutPrefixWithGroup() {
-        assertMacroExpansion(
-"""
-@Godot class Car: Node {
-    #exportGroup("Vehicle")
-    #exportSubgroup("VIN")
-    @Export var vin: String = ""
-    #exportSubgroup("YMMS", prefix: "ymms_")
-    @Export var ymms_year: Int = 1998
-    @Export var ymms_make: String = "Honda"
-    @Export var ymms_model: String = "Odyssey"
-    @Export var ymms_series: String = "LX"
-}
-""",
-        expandedSource: """
+        assertMacro {
+            """
+            @Godot class Car: Node {
+                #exportGroup("Vehicle")
+                #exportSubgroup("VIN")
+                @Export var vin: String = ""
+                #exportSubgroup("YMMS", prefix: "ymms_")
+                @Export var ymms_year: Int = 1998
+                @Export var ymms_make: String = "Honda"
+                @Export var ymms_model: String = "Odyssey"
+                @Export var ymms_series: String = "LX"
+            }
+            """
+        } expansion: {
+            """
+            class Car: Node {
+                var vin: String = ""
 
-class Car: Node {
-    var vin: String = ""
+                func _mproxy_set_vin (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.vin = value
+                	} else {
+                		GD.printErr ("Unable to set `vin` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_vin (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vin = value
-    	} else {
-    		GD.printErr ("Unable to set `vin` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_vin (args: [Variant]) -> Variant? {
+                    return Variant (vin)
+                }
+                var ymms_year: Int = 1998
 
-    func _mproxy_get_vin (args: [Variant]) -> Variant? {
-        return Variant (vin)
-    }
-    var ymms_year: Int = 1998
+                func _mproxy_set_ymms_year (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = Int (arg) {
+                		self.ymms_year = value
+                	} else {
+                		GD.printErr ("Unable to set `ymms_year` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_ymms_year (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Int (arg) {
-    		self.ymms_year = value
-    	} else {
-    		GD.printErr ("Unable to set `ymms_year` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_ymms_year (args: [Variant]) -> Variant? {
+                    return Variant (ymms_year)
+                }
+                var ymms_make: String = "Honda"
 
-    func _mproxy_get_ymms_year (args: [Variant]) -> Variant? {
-        return Variant (ymms_year)
-    }
-    var ymms_make: String = "Honda"
+                func _mproxy_set_ymms_make (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.ymms_make = value
+                	} else {
+                		GD.printErr ("Unable to set `ymms_make` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_ymms_make (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.ymms_make = value
-    	} else {
-    		GD.printErr ("Unable to set `ymms_make` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_ymms_make (args: [Variant]) -> Variant? {
+                    return Variant (ymms_make)
+                }
+                var ymms_model: String = "Odyssey"
 
-    func _mproxy_get_ymms_make (args: [Variant]) -> Variant? {
-        return Variant (ymms_make)
-    }
-    var ymms_model: String = "Odyssey"
+                func _mproxy_set_ymms_model (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.ymms_model = value
+                	} else {
+                		GD.printErr ("Unable to set `ymms_model` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_ymms_model (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.ymms_model = value
-    	} else {
-    		GD.printErr ("Unable to set `ymms_model` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_ymms_model (args: [Variant]) -> Variant? {
+                    return Variant (ymms_model)
+                }
+                var ymms_series: String = "LX"
 
-    func _mproxy_get_ymms_model (args: [Variant]) -> Variant? {
-        return Variant (ymms_model)
-    }
-    var ymms_series: String = "LX"
+                func _mproxy_set_ymms_series (args: [Variant]) -> Variant? {
+                	guard let arg = args.first else {
+                		return nil
+                	}
+                	if let value = String (arg) {
+                		self.ymms_series = value
+                	} else {
+                		GD.printErr ("Unable to set `ymms_series` value: ", arg)
+                	}
+                	return nil
+                }
 
-    func _mproxy_set_ymms_series (args: [Variant]) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.ymms_series = value
-    	} else {
-    		GD.printErr ("Unable to set `ymms_series` value: ", arg)
-    	}
-    	return nil
-    }
+                func _mproxy_get_ymms_series (args: [Variant]) -> Variant? {
+                    return Variant (ymms_series)
+                }
 
-    func _mproxy_get_ymms_series (args: [Variant]) -> Variant? {
-        return Variant (ymms_series)
-    }
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
 
-    override open class var classInitializer: Void {
-        let _ = super.classInitializer
-        return _initializeClass
-    }
-
-    private static let _initializeClass: Void = {
-        let className = StringName("Car")
-        assert(ClassDB.classExists(class: className))
-        let classInfo = ClassInfo<Car> (name: className)
-        classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
-        classInfo.addPropertySubgroup(name: "VIN", prefix: "")
-        let _pvin = PropInfo (
-            propertyType: .string,
-            propertyName: "vin",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
-        classInfo.addPropertySubgroup(name: "YMMS", prefix: "ymms_")
-        let _pymms_year = PropInfo (
-            propertyType: .int,
-            propertyName: "ymms_year",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pymms_year, arguments: [], function: Car._mproxy_get_ymms_year)
-    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pymms_year], function: Car._mproxy_set_ymms_year)
-    	classInfo.registerProperty (_pymms_year, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
-        let _pymms_make = PropInfo (
-            propertyType: .string,
-            propertyName: "ymms_make",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pymms_make, arguments: [], function: Car._mproxy_get_ymms_make)
-    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pymms_make], function: Car._mproxy_set_ymms_make)
-    	classInfo.registerProperty (_pymms_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
-        let _pymms_model = PropInfo (
-            propertyType: .string,
-            propertyName: "ymms_model",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pymms_model, arguments: [], function: Car._mproxy_get_ymms_model)
-    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pymms_model], function: Car._mproxy_set_ymms_model)
-    	classInfo.registerProperty (_pymms_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
-        let _pymms_series = PropInfo (
-            propertyType: .string,
-            propertyName: "ymms_series",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_series", flags: .default, returnValue: _pymms_series, arguments: [], function: Car._mproxy_get_ymms_series)
-    	classInfo.registerMethod (name: "_mproxy_set_series", flags: .default, returnValue: nil, arguments: [_pymms_series], function: Car._mproxy_set_ymms_series)
-    	classInfo.registerProperty (_pymms_series, getter: "_mproxy_get_series", setter: "_mproxy_set_series")
-    } ()
-}
-""",
-        macros: testMacros)
+                private static let _initializeClass: Void = {
+                    let className = StringName("Car")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<Car> (name: className)
+                    classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
+                    classInfo.addPropertySubgroup(name: "VIN", prefix: "")
+                    let _pvin = PropInfo (
+                        propertyType: .string,
+                        propertyName: "vin",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+                	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+                	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+                    classInfo.addPropertySubgroup(name: "YMMS", prefix: "ymms_")
+                    let _pymms_year = PropInfo (
+                        propertyType: .int,
+                        propertyName: "ymms_year",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pymms_year, arguments: [], function: Car._mproxy_get_ymms_year)
+                	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pymms_year], function: Car._mproxy_set_ymms_year)
+                	classInfo.registerProperty (_pymms_year, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+                    let _pymms_make = PropInfo (
+                        propertyType: .string,
+                        propertyName: "ymms_make",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pymms_make, arguments: [], function: Car._mproxy_get_ymms_make)
+                	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pymms_make], function: Car._mproxy_set_ymms_make)
+                	classInfo.registerProperty (_pymms_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+                    let _pymms_model = PropInfo (
+                        propertyType: .string,
+                        propertyName: "ymms_model",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pymms_model, arguments: [], function: Car._mproxy_get_ymms_model)
+                	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pymms_model], function: Car._mproxy_set_ymms_model)
+                	classInfo.registerProperty (_pymms_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+                    let _pymms_series = PropInfo (
+                        propertyType: .string,
+                        propertyName: "ymms_series",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: .default)
+                	classInfo.registerMethod (name: "_mproxy_get_series", flags: .default, returnValue: _pymms_series, arguments: [], function: Car._mproxy_get_ymms_series)
+                	classInfo.registerMethod (name: "_mproxy_set_series", flags: .default, returnValue: nil, arguments: [_pymms_series], function: Car._mproxy_set_ymms_series)
+                	classInfo.registerProperty (_pymms_series, getter: "_mproxy_get_series", setter: "_mproxy_set_series")
+                } ()
+            }
+            """
+        }
     }
 }

--- a/Tests/SwiftGodotMacrosTests/NativeHandleDiscardingMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/NativeHandleDiscardingMacroTests.swift
@@ -1,59 +1,50 @@
-//
-//  SwiftGodotNativeHandleDiscardingMacroTests.swift
-//  SwiftGodot
-//
-//  Created by Marquis Kurt on 6/9/23.
-//
-
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
-import SwiftGodotMacroLibrary
 
 final class NativeHandleDiscardingMacroTests: XCTestCase {
-    let testMacros: [String: Macro.Type] = [
-        "NativeHandleDiscarding": NativeHandleDiscardingMacro.self
-    ]
+
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
+    }
 
     func testNativeHandleDiscardingMacro() {
-        assertMacroExpansion(
+        assertMacro {
             """
             @NativeHandleDiscarding
             class MyNode: Sprite2D {
                 var collider: CollisionShape2D?
             }
-            """,
-            expandedSource: """
-
+            """
+        } expansion: {
+            """
             class MyNode: Sprite2D {
                 var collider: CollisionShape2D?
 
                 required init(nativeHandle _: UnsafeRawPointer) {fatalError("init(nativeHandle:) has not been implemented")
                 }
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testNativeHandleDiscardingMacroDiagnostics() {
-        assertMacroExpansion(
+        assertMacro {
             """
             @NativeHandleDiscarding
             struct MyNode: Sprite2D {
                 var collider: CollisionShape2D?
             }
-            """,
-            expandedSource: """
-            
+            """
+        } diagnostics: {
+            """
+            @NativeHandleDiscarding
+            ╰─ 🛑 @NativeHandleDiscarding can only be applied to a 'class'
             struct MyNode: Sprite2D {
                 var collider: CollisionShape2D?
             }
-            """,
-            diagnostics: [
-                DiagnosticSpec(message: "@NativeHandleDiscarding can only be applied to a 'class'", line: 1, column: 1)
-            ],
-            macros: testMacros
-        )
+            """
+        }
     }
 }

--- a/Tests/SwiftGodotMacrosTests/PickerNameProviderMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/PickerNameProviderMacroTests.swift
@@ -1,22 +1,16 @@
-//
-//  SwiftGodotNamePickerMacroTests.swift
-//  SwiftGodot
-//
-//  Created by Marquis Kurt on 6/9/23.
-//
-
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
-import SwiftGodotMacroLibrary
 
 final class PickerNameProviderMacroTests: XCTestCase {
-    let testMacros: [String: Macro.Type] = [
-        "PickerNameProvider": PickerNameProviderMacro.self
-    ]
-    
+
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
+    }
+
     func testPickerNameProviderMacro() {
-        assertMacroExpansion(
+        assertMacro {
             """
             @PickerNameProvider
             enum Character: Int64 {
@@ -28,9 +22,9 @@ final class PickerNameProviderMacroTests: XCTestCase {
                 case chelsea
                 case sky
             }
-            """,
-            expandedSource: """
-
+            """
+        } expansion: {
+            """
             enum Character: Int64 {
                 case chelsea
                 case sky
@@ -67,27 +61,24 @@ final class PickerNameProviderMacroTests: XCTestCase {
                     }
                 }
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testPickerNameProviderMacroDiagnostics() {
-        assertMacroExpansion(
+        assertMacro {
             """
             @PickerNameProvider
             struct Character {
             }
-            """,
-            expandedSource: """
-
+            """
+        } diagnostics: {
+            """
+            @PickerNameProvider
+            ╰─ 🛑 @PickerNameProvider can only be applied to an 'enum'
             struct Character {
             }
-            """,
-            diagnostics: [
-                DiagnosticSpec(message: "@PickerNameProvider can only be applied to an 'enum'", line: 1, column: 1)
-            ],
-            macros: testMacros
-        )
+            """
+        }
     }
 }

--- a/Tests/SwiftGodotMacrosTests/SceneTreeMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/SceneTreeMacroTests.swift
@@ -1,29 +1,24 @@
-//
-//  SceneTreeMacroTests.swift
-//  SwiftGodot
-//
-//  Created by Marquis Kurt on 21/6/23.
-//
-
-import SwiftGodotMacroLibrary
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
 
 final class SceneTreeMacroTests: XCTestCase {
-    let testMacros: [String: Macro.Type] = [
-        "SceneTree": SceneTreeMacro.self,
-    ]
+
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
+    }
 
     func testMacroExpansion() {
-        assertMacroExpansion(
+        assertMacro {
             """
             class MyNode: Node {
                 @SceneTree(path: "Entities/CharacterBody2D")
                 var character: CharacterBody2D?
             }
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             class MyNode: Node {
                 var character: CharacterBody2D? {
                     get {
@@ -31,20 +26,20 @@ final class SceneTreeMacroTests: XCTestCase {
                     }
                 }
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testMacroExpansionWithImplicitlyUnwrappedOptional() {
-        assertMacroExpansion(
+        assertMacro {
             """
             class MyNode: Node {
                 @SceneTree(path: "Entities/CharacterBody2D")
                 var character: CharacterBody2D!
             }
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             class MyNode: Node {
                 var character: CharacterBody2D! {
                     get {
@@ -52,19 +47,19 @@ final class SceneTreeMacroTests: XCTestCase {
                     }
                 }
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testMacroExpansionWithDefaultArgument() {
-        assertMacroExpansion(
+        assertMacro {
             """
             class MyNode: Node {
                 @SceneTree var character: CharacterBody2D?
             }
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             class MyNode: Node {
                 var character: CharacterBody2D? {
                     get {
@@ -72,37 +67,44 @@ final class SceneTreeMacroTests: XCTestCase {
                     }
                 }
             }
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testMacroNotOptionalDiagnostic() {
-        assertMacroExpansion(
+        assertMacro {
             """
             class MyNode: Node {
                 @SceneTree(path: "Entities/CharacterBody2D")
                 var character: CharacterBody2D
             }
-            """,
-            expandedSource: """
+            """
+        } diagnostics: {
+            """
             class MyNode: Node {
-                var character: CharacterBody2D {
+                @SceneTree(path: "Entities/CharacterBody2D")
+                ╰─ 🛑 Stored properties with SceneTree must be marked as Optional
+                   ✏️ Mark as Optional
+                var character: CharacterBody2D
+            }
+            """
+        } fixes: {
+            """
+            class MyNode: Node {
+                @SceneTree(path: "Entities/CharacterBody2D")
+                var character: CharacterBody2D?
+            }
+            """
+        } expansion: {
+            """
+            class MyNode: Node {
+                var character: CharacterBody2D? {
                     get {
                         getNodeOrNull(path: NodePath(stringLiteral: "Entities/CharacterBody2D")) as? CharacterBody2D
                     }
                 }
             }
-            """,
-            diagnostics: [
-                .init(message: "Stored properties with SceneTree must be marked as Optional",
-                      line: 2,
-                      column: 5,
-                      fixIts: [
-                          .init(message: "Mark as Optional"),
-                      ]),
-            ],
-            macros: testMacros
-        )
+            """
+        }
     }
 }

--- a/Tests/SwiftGodotMacrosTests/TextureLiteralMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/TextureLiteralMacroTests.swift
@@ -1,53 +1,46 @@
-//
-//  TextureLiteralMacroTests.swift
-//  SwiftGodot
-//
-//  Created by Marquis Kurt on 6/11/23.
-//
-
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
+import MacroTesting
 import XCTest
-import SwiftGodotMacroLibrary
 
 final class TextureLiteralMacroTests: XCTestCase {
-    let testMacros: [String: Macro.Type] = [
-        "texture2DLiteral": Texture2DLiteralMacro.self
-    ]
+
+    override func invokeTest() {
+        withMacroTesting(macros: allMacros) {
+            super.invokeTest()
+        }
+    }
 
     func testMacroExpansion() {
-        assertMacroExpansion(
+        assertMacro {
             """
             let spriteTexture = #texture2DLiteral("res://assets/icon.png")
-            """,
-            expandedSource: """
+            """
+        } expansion: {
+            """
             let spriteTexture = {
                 guard let texture: Texture2D = GD.load(path: "res://assets/icon.png") else {
-                    GD.pushError("Texture could not be loaded.", "TestModule/test.swift", 1)
+                    GD.pushError("Texture could not be loaded.", "TestModule/Test.swift", 1)
                     preconditionFailure(
                         "Texture could not be loaded.",
-                        file: "TestModule/test.swift",
+                        file: "TestModule/Test.swift",
                         line: 1)
                 }
                 return texture
             }()
-            """,
-            macros: testMacros
-        )
+            """
+        }
     }
 
     func testMacroExpansionFailure() {
-        assertMacroExpansion(
+        assertMacro {
             """
             let spriteTexture = #texture2DLiteral()
-            """,
-            expandedSource: """
-            let spriteTexture = ""
-            """,
-            diagnostics: [
-                .init(message: "Argument 'path' is missing.", line: 1, column: 21)
-            ],
-            macros: testMacros
-        )
+            """
+        } diagnostics: {
+            """
+            let spriteTexture = #texture2DLiteral()
+                                ┬──────────────────
+                                ╰─ 🛑 Argument 'path' is missing.
+            """
+        }
     }
 }

--- a/Tests/SwiftGodotMacrosTests/allMacros.swift
+++ b/Tests/SwiftGodotMacrosTests/allMacros.swift
@@ -1,0 +1,16 @@
+import SwiftGodotMacroLibrary
+import SwiftSyntaxMacros
+
+let allMacros: [String : any Macro.Type] = [
+    "Callable": GodotCallable.self,
+    "Export": GodotExport.self,
+    "Godot": GodotMacro.self,
+    "NativeHandleDiscarding": NativeHandleDiscardingMacro.self,
+    "PickerNameProvider": PickerNameProviderMacro.self,
+    "SceneTree": SceneTreeMacro.self,
+    "exportGroup": GodotMacroExportGroup.self,
+    "exportSubgroup": GodotMacroExportSubgroup.self,
+    "initSwiftExtension": InitSwiftExtensionMacro.self,
+    "signal": SignalMacro.self,
+    "texture2DLiteral": Texture2DLiteralMacro.self,
+]


### PR DESCRIPTION
This pull request converts all macro expansion tests to use the MacroTesting library from the swift-macro-testing package.

I want to do some cleanup and enhancement of SwiftGodot's macros. In particular I want to make `@Export` automatically infer hints for subclasses of `Node` and `Resource` (both built-in and user-defined) and provide better, type-safe syntax for other hints (like `@Export(.range(0 ... 10, step: 2, .orGreater))` instead of `@Export(.range, "0,10,2,or_greater")`).

To facilitate that work, I propose this patch to migrate the macro tests to a much friendlier testing library. The swift-macro-testing library has several advantages over SwiftSyntaxMacrosTestSupport:

-   It is much easier to create new test cases. The library can update the test case with in the actual macro output the first time a test is run.

-   It is much easier to update test cases when we intentionally change the code generated by a macro. The library can update the test case by replacing the old macro output with the new macro output if you set `record: failed` in the `assertMacro` invocation.

-   It is much easier to verify that diagnostics and fix-its emitted by a macro are attached to the correct part of the input. Check out `testMacroNotOptionalDiagnostic` in `SceneTreeMacroTests.swift` for a great example!

For a full explanation of the design of swift-macro-testing, check out these videos:

https://www.pointfree.co/collections/macros/testing-and-debugging-macros

The video pages include full hand-written transcripts in case you'd rather read than watch.
