### PR TITLE
eliminate warnings

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -206,7 +206,7 @@ func generateVirtualProxy (_ p: Printer,
 // the mapped name (it is "Array", not "GArray"):
 let discardableResultList: [String: Set<String>] = [
     "Object": ["emit_signal"],
-    "Array": ["append", "resize"],
+    "Array": ["resize"],
     "PackedByteArray": ["append", "push_back"],
     "PackedColorArray": ["append", "push_back", "resize"],
     "PackedFloat32Array": ["append", "push_back", "resize"],
@@ -697,7 +697,7 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
         if cdef.name == "RefCounted" {
             p ("public required init ()") {
                 p ("super.init ()")
-                p ("initRef ()")
+                p ("_ = initRef()")
             }
             p ("public required init(nativeHandle: UnsafeRawPointer)") {
                 p ("super.init (nativeHandle: nativeHandle)")

--- a/Sources/SwiftGodot/Core/Packed.swift
+++ b/Sources/SwiftGodot/Core/Packed.swift
@@ -10,7 +10,7 @@ extension PackedStringArray {
     public convenience init (_ values: [String]) {
         self.init ()
         for x in values {
-            append(value: x)
+            append(x)
         }
     }
     

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -140,7 +140,7 @@ open class Wrapped: Equatable, Identifiable, Hashable {
 #endif
                     }
                 } else {
-                    if let node = self as? Node {
+                    if self is Node {
                         // TODO: I seem to recall that Nodes that are added to a scene are managed by the scene
                         // and they are owned by the scene.   I do indeed not get leaks from those.
                         //
@@ -508,7 +508,7 @@ func userTypeBindingReference(_ token: UnsafeMutableRawPointer?, _ binding: Unsa
 
     let wrapped = Unmanaged<Wrapped>.fromOpaque(binding)
     if reference == 0 {
-        wrapped.retain()
+        _ = wrapped.retain()
     } else {
         wrapped.release()
     }

--- a/Sources/SwiftGodotMacroLibrary/PickerNameProviderMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/PickerNameProviderMacro.swift
@@ -49,14 +49,11 @@ public struct PickerNameProviderMacro: ExtensionMacro {
             return []
         }
 
-        guard let inheritors = enumDecl.inheritanceClause?.inheritedTypes else {
+        guard enumDecl.inheritanceClause != nil else {
             let missingInt = Diagnostic(node: declaration.root, message: ProviderDiagnostic.missingInt)
             context.diagnose(missingInt)
             return []
         }
-
-        let types = inheritors.map { $0.type.as(IdentifierTypeSyntax.self) }
-        //let names = types.map { $0?.name.text }
 
         let members = enumDecl.memberBlock.members
         let cases = members.compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }

--- a/Tests/SwiftGodotTests/ObjectCollectionTests.swift
+++ b/Tests/SwiftGodotTests/ObjectCollectionTests.swift
@@ -38,7 +38,7 @@ final class ObjectCollectionTests: GodotTestCase {
         let sut: ObjectCollection<Node> = [.init()]
         
         let otherNode = Node()
-        let newArray: GArray = [otherNode].reduce(into: GArray(Node.self)) { $0.append(value: Variant($1)) }
+        let newArray: GArray = [otherNode].reduce(into: GArray(Node.self)) { $0.append(Variant($1)) }
 
         sut.array = newArray
         
@@ -53,7 +53,7 @@ final class ObjectCollectionTests: GodotTestCase {
         let sut: ObjectCollection<Node> = []
         
         let node = Node()
-        sut.array.append(value: Variant(node))
+        sut.array.append(Variant(node))
         
         XCTAssertEqual(sut.count, 1, "The collection count should be 1 after a Variant was appended to the \(GArray.self)")
         XCTAssertEqual(sut[0], node, "The first element in the collection should be the appended node")

--- a/Tests/SwiftGodotTests/VariantCollectionTests.swift
+++ b/Tests/SwiftGodotTests/VariantCollectionTests.swift
@@ -35,7 +35,7 @@ final class VariantCollectionTests: GodotTestCase {
     func testArrayCanBeModifiedOutsideOfTheCollection() {
         let sut: VariantCollection<Int> = []
         
-        sut.array.append(value: Variant(222))
+        sut.array.append(Variant(222))
         
         XCTAssertEqual(sut.count, 1, "The collection count should be 1 after appending an element")
         XCTAssertEqual(sut[0], 222, "After 222 is appended to the \(GArray.self), the first value should be to 222")
@@ -45,6 +45,6 @@ final class VariantCollectionTests: GodotTestCase {
 private extension GArray {
     convenience init(_ elements: [Int]) {
         self.init(Int.self)
-        elements.forEach { append(value: Variant($0)) }
+        elements.forEach { append(Variant($0)) }
     }
 }


### PR DESCRIPTION
This patch eliminates all the compiler warninsg I get under Xcode 16.0 beta 4:

PickerNameProviderMacro.swift:58:13
Initialization of immutable value 'types' was never used; consider replacing with assignment to '_' or removing it

RefCounted.swift:24:9
Result of call to 'initRef()' is unused

Array.swift:301:5
@discardableResult declared on a function returning Void is unnecessary

Packed.swift:13:13
'append(value:)' is deprecated: This method signature has been deprecated in favor of append(_:)

Wrapped.swift:143:28
Value 'node' was defined but never used; consider replacing with boolean test

Wrapped.swift:511:17
Result of call to 'retain()' is unused