### PR TITLE
Add tests cases for, and fix, #513

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build-docs.log
 *rej
 *orig
 \#*
+/libgodot.xcframework/

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -643,6 +643,10 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                         p ("\(typeName).constructor1 (&self.content, &args)")
                     }
                 }
+                p ("// Used to construct objects when the underlying built-in's ref count has already been incremented for me")
+                p ("public required init(alreadyOwnedContent content: ContentType)") {
+                    p ("self.content = content")
+                }
             }
            
             func memberDoc (_ name: String) {

--- a/Package.swift
+++ b/Package.swift
@@ -120,15 +120,32 @@ targets.append(
 
 // libgodot is only available for macOS
 #if os(macOS)
+
+/// You might want to build your own libgodot, so you can step into it in the debugger when fixing failing tests. Here's how:
+///
+/// 1. Check out the appropriate branch of https://github.com/migueldeicaza/libgodot
+/// 2. Build with `scons platform=macos target=template_debug dev_build=yes library_type=shared_library`. The `target=template_debug` is important, because `target=editor` will get you a `TOOLS_ENABLED` build that breaks some test cases.
+/// 3. Use `scripts/make-libgodot.framework` to build an `xcframework` and put it at the root of your SwiftGodot work tree.
+/// 4. Change `#if true` to `#if false` below.
+///
+#if true
+let libgodot_tests = Target.binaryTarget(
+    name: "libgodot_tests",
+    url: "https://github.com/migueldeicaza/SwiftGodotKit/releases/download/v4.1.99/libgodot.xcframework.zip",
+    checksum: "c8ddf62be6c00eacc36bd2dafe8d424c0b374833efe80546f6ee76bd27cee84e"
+)
+#else
+let libgodot_tests = Target .binaryTarget(
+    name: "libgodot_tests",
+    path: "libgodot.xcframework"
+)
+#endif
+
 targets.append(contentsOf: [
     // Godot runtime as a library
 
-    .binaryTarget(
-        name: "libgodot_tests",
-        url: "https://github.com/migueldeicaza/SwiftGodotKit/releases/download/v4.1.99/libgodot.xcframework.zip",
-        checksum: "c8ddf62be6c00eacc36bd2dafe8d424c0b374833efe80546f6ee76bd27cee84e"
-    ),
-    
+    libgodot_tests,
+
     // Base functionality for Godot runtime dependant tests
     .target(
         name: "SwiftGodotTestability",

--- a/Sources/SwiftGodot/Core/GArray.swift
+++ b/Sources/SwiftGodot/Core/GArray.swift
@@ -24,12 +24,11 @@ extension GArray {
     
     public subscript (index: Int) -> Variant {
         get {
-            // array_operator_index returns a copy of the Variant, we own it.
             guard let ret = gi.array_operator_index (&content, Int64 (index)) else {
                 return Variant()
             }
             let ptr = ret.assumingMemoryBound(to: Variant.ContentType.self)
-            return Variant(fromContentNoCopy: ptr.pointee)
+            return Variant(fromContent: ptr.pointee)
         }
         set {
             guard let ret = gi.array_operator_index (&content, Int64 (index)) else {

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -30,18 +30,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     }
     
     init (content: Int64) {
-        array = GArray (content: content)
-        
-        // Explanation: we already own this reference, and what we were doing here was
-        // creating a nested array that was taking a reference.
-        //
-        // I should add support to the generator to produce a GArray internal constructor
-        // that can take this existing reference, rather than calling the constructor that
-        // makes the copy.
-        var copy = content
-        // Array took a reference, we do not need to take it.
-        GArray.destructor (&copy)
-
+        array = GArray(alreadyOwnedContent: content)
     }
     
     /// Initializes the collection with an empty typed GArray

--- a/Sources/SwiftGodot/Core/VariantRepresentable.swift
+++ b/Sources/SwiftGodot/Core/VariantRepresentable.swift
@@ -53,14 +53,14 @@ extension SelfVariantRepresentable {
     }
 }
 
-/// Some of Godot's build-in classes use ContentType for storage.
+/// Some of Godot's builtin classes use ContentType for storage.
 /// This needs to be public because it affects their initialization, but
 /// SwiftGodot users should never need to conform their types
 /// to`ContentVariantRepresentable`.
 public protocol ContentVariantRepresentable: VariantRepresentable {
     static var zero: VariantContent { get }
     
-    init (content: VariantContent)
+    init (alreadyOwnedContent: VariantContent)
 }
 
 extension ContentVariantRepresentable {
@@ -69,10 +69,11 @@ extension ContentVariantRepresentable {
         
         var content = Self.zero
         withUnsafeMutablePointer(to: &content) { ptr in
+            // This copies the builtin's content out of the Variant and increments its internal retain count (if it has one).
             variant.toType(Self.godotType, dest: ptr)
         }
         
-        self.init(content: content)
+        self.init(alreadyOwnedContent: content)
     }
 }
 

--- a/Sources/SwiftGodot/Core/VariantStorable.swift
+++ b/Sources/SwiftGodot/Core/VariantStorable.swift
@@ -51,7 +51,7 @@ public struct GStringRaw: ContentVariantRepresentable {
     public init () {
         content = GString.zero
     }
-    public init (content: GString.ContentType) {
+    public init (alreadyOwnedContent content: GString.ContentType) {
         self.content = content
     }
     public static var godotType: Variant.GType { .string }

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -163,10 +163,6 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
             return nil
         }
         let ret: T? = lookupObject(nativeHandle: value)
-        if let rc = ret as? RefCounted {
-            // When we pull out a refcounted out of a Variant, take a reference
-            rc.reference ()
-        }
         return ret
     }
     

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -73,11 +73,6 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
         gi.variant_new_copy (&content, &copy)
     }
 
-    /// Initializes from the raw contents of another Variant, this will not make a copy of the variant contents
-    init (fromContentNoCopy: ContentType) {
-        content = fromContentNoCopy
-    }
-
     /// Initializes from the raw contents of another Variant, this will make a copy of the variant contents
     init (fromContentPtr: inout ContentType) {
         gi.variant_new_copy (&content, &fromContentPtr)
@@ -252,7 +247,7 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
             if valid == 0 || oob != 0 {
                 return nil
             }
-            return Variant(fromContentNoCopy: _result)
+            return Variant(fromContent: _result)
         }
         set {
             guard let newValue else {

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -1,0 +1,32 @@
+import SwiftGodot
+import SwiftGodotTestability
+import XCTest
+
+final class MemoryLeakTests: GodotTestCase {
+
+    // https://github.com/migueldeicaza/SwiftGodot/issues/513
+    func test_513_leak1() {
+        func oneIteration(object: Object) {
+            let list = object.getPropertyList()
+            let it = list.makeIterator()
+            for prop: GDictionary in it {
+                _ = prop
+            }
+        }
+
+        let object = Object()
+
+        oneIteration(object: object)
+
+        let before = Performance.getMonitor(.memoryStatic)
+
+        for _ in 0 ..< 10_000 {
+            oneIteration(object: object)
+        }
+
+        let after = Performance.getMonitor(.memoryStatic)
+
+        XCTAssertEqual(before, after)
+    }
+
+}

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -16,17 +16,48 @@ final class MemoryLeakTests: GodotTestCase {
 
         let object = Object()
 
+        // Warm-up the code path in case it performs any one-time permanent allocations.
         oneIteration(object: object)
 
         let before = Performance.getMonitor(.memoryStatic)
+        let count = 1_000
 
-        for _ in 0 ..< 10_000 {
+        for _ in 0 ..< count {
             oneIteration(object: object)
         }
 
         let after = Performance.getMonitor(.memoryStatic)
 
-        XCTAssertEqual(before, after)
+        XCTAssertEqual(before, after, "Leaked \(Int((after - before) / Double(count))) bytes per iteration.")
+    }
+
+    // https://github.com/migueldeicaza/SwiftGodot/issues/513
+    func test_513_leak2() {
+
+        func oneIteration(bytes: PackedByteArray) {
+            let image0 = SwiftGodot.Image()
+            let variant = Variant(image0)
+            let image: SwiftGodot.Image = variant.asObject()!
+            _ = image.loadPngFromBuffer(bytes)
+            // Doesn't leak with line below uncommented
+            // image.unreference()
+        }
+
+        let bytes = PackedByteArray([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 1, 3, 0, 0, 0, 37, 219, 86, 202, 0, 0, 0, 3, 80, 76, 84, 69, 0, 0, 0, 167, 122, 61, 218, 0, 0, 0, 1, 116, 82, 78, 83, 0, 64, 230, 216, 102, 0, 0, 0, 10, 73, 68, 65, 84, 8, 215, 99, 96, 0, 0, 0, 2, 0, 1, 226, 33, 188, 51, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130])
+
+        // Warm-up the code path in case it performs any one-time permanent allocations.
+        oneIteration(bytes: bytes)
+
+        let before = Performance.getMonitor(.memoryStatic)
+        let count = 1_000
+
+        for _ in 0 ..< count {
+            oneIteration(bytes: bytes)
+        }
+
+        let after = Performance.getMonitor(.memoryStatic)
+
+        XCTAssertEqual(before, after, "Leaked \(Int((after - before) / Double(count))) bytes per iteration.")
     }
 
 }


### PR DESCRIPTION
This patch addresses both leaks discussed in #513.

### First leak

The changes in https://github.com/migueldeicaza/SwiftGodot/commit/d1d6ca47f0fc5bb16948017e1a6b2c6c8838b3b5 made several `Geometry2DTests` fail.

The actual unbalanced retain causing the leak in `VariantRepresentable.swift`:

```swift
extension ContentVariantRepresentable {
    public init? (_ variant: Variant) {
        guard Self.godotType == variant.gtype else { return nil }

        var content = Self.zero
        withUnsafeMutablePointer(to: &content) { ptr in
            variant.toType(Self.godotType, dest: ptr) // <-- THIS IS THE UNBALANCED RETAIN
        }

        self.init(content: content)
    }
}
```

The `variant.toType` function calls into Godot to copy out the built-in type stored in `variant`. If that built-in type has an internal reference count, Godot increments it. Then, the call to `self.init(content: content)` increments the count again. The retain performed by `variant.toType` is never balanced.

This patch fixes the bug by generating a new `init(alreadyOwnedContent:)` initializer for each Godot builtin class type. This needs to be on the builtin wrappers (like `GDictionary`, `GArray`, etc.), rather than on `Variant` which is where https://github.com/migueldeicaza/SwiftGodot/commit/d1d6ca47f0fc5bb16948017e1a6b2c6c8838b3b5 put it.

This patch also adds a test case to check for the leak by looking at Godot's `MEMORY_STATIC` performance counter, which is only enabled if Godot was built with `DEBUG_ENABLED`.

### Second leak

This patch adds a test for the second leak described in https://github.com/migueldeicaza/SwiftGodot/issues/513, and fixes the leak.

Without this patch, the leak happens because `Variant.asObject` has an unneeded call to `rc.reference()` which increments the `RefCounted` object's reference count. As far as I can tell, nothing balances this increment.

`Variant.asObject` calls `lookupObject(nativeHandle:)`, which returns a Swift wrapper for an object whose reference count has already been incremented (if the object is `RefCounted`). The Swift wrapper balances that increment with a decrement in its `deinit`.
