### PR TITLE
remove GodotObject protocol

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -651,18 +651,7 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
     }
     
     let inherits = cdef.inherits ?? "Wrapped"
-    var conformances: [String] = []
-    if cdef.name == "Object" {
-        conformances.append("GodotObject")
-    }
-    var proto = ""
-    if conformances.count > 0 {
-        proto = ", " + conformances.joined(separator: ", ")
-    } else {
-        proto = ""
-    }
-    
-    let typeDecl = "open class \(cdef.name): \(inherits)\(proto)"
+    let typeDecl = "open class \(cdef.name): \(inherits)"
     
     var virtuals: [String: (String, JGodotClassMethod)] = [:]
     if cdef.brief_description == "" {

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -14,9 +14,6 @@ extension ObjectCollection: VariantStorable {
     }
 }
 
-/// Protocol implemented by the built-in classes in Godot to allow to be wrapped in a ``Variant``
-public protocol GodotObject: Wrapped {}
-
 /// This represents a typed array of one of the built-in types from Godot
 public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLiteral, GArrayCollection {
 	public typealias ArrayLiteralElement = Element

--- a/Sources/SwiftGodot/Core/VariantRepresentable.swift
+++ b/Sources/SwiftGodot/Core/VariantRepresentable.swift
@@ -32,7 +32,7 @@ extension VariantRepresentable {
 
 extension VariantRepresentable where Self: Object {
     public init? (_ variant: Variant) {
-        GD.printErr ("Attempted to initialize a new `\(Self.self)` with \(variant.description) but it is not possible to initialize a GodotObject in a Swift initializer. Instead, use `\(Self.self).makeOrUnwrap(variant)`.")
+        GD.printErr ("Attempted to initialize a new `\(Self.self)` with \(variant.description) but it is not possible to initialize a SwiftGodot.Object in a Swift initializer. Instead, use `\(Self.self).makeOrUnwrap(variant)`.")
         return nil
     }
 }

--- a/Sources/SwiftGodot/Core/VariantStorable.swift
+++ b/Sources/SwiftGodot/Core/VariantStorable.swift
@@ -27,7 +27,7 @@ public protocol VariantStorable {
 
 extension VariantStorable {
     /// Unwraps an object from a variant. This is useful when you want one method to call that
-    /// will return the unwrapped Variant, regardless of whether it is a GodotObject or not.
+    /// will return the unwrapped Variant, regardless of whether it is a SwiftGodot.Object or not.
     public static func makeOrUnwrap(_ variant: Variant) -> Self? {
         guard variant.gtype != .object else {
             return nil
@@ -36,7 +36,7 @@ extension VariantStorable {
     }
 
     /// Unwraps an object from a variant.
-    public static func makeOrUnwrap(_ variant: Variant) -> Self? where Self: GodotObject {
+    public static func makeOrUnwrap(_ variant: Variant) -> Self? where Self: Object {
         return variant.asObject()
     }
 }

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -379,7 +379,7 @@ func objectFromHandle (nativeHandle: UnsafeRawPointer) -> Wrapped? {
     }
 }
 
-func lookupObject<T:GodotObject> (nativeHandle: UnsafeRawPointer) -> T? {
+func lookupObject<T: Object> (nativeHandle: UnsafeRawPointer) -> T? {
     if let a = objectFromHandle(nativeHandle: nativeHandle) {
         return a as? T
     }

--- a/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
@@ -42,7 +42,7 @@ GArray:
 
 * ``VariantCollection`` that holds any ``Variant`` instances.
 
-* ``ObjectCollection`` that holds any ``GodotObject`` instances.
+* ``ObjectCollection`` that holds any ``SwiftGodot.Object`` instances.
 
 ## GDScript Helper Functions
 
@@ -183,7 +183,7 @@ let pressed = Input.isActionPressed(ui_down)
 ```
 
 However, in some very rare cases this is not enough. For example, you may want 
-to access a member from the base class GodotObject, like `connect`. For such
+to access a member from the base class SwiftGodot.Object, like `connect`. For such
 use cases we provide a static property named `shared` that returns the singleton
 instance. 
 

--- a/Sources/SwiftGodot/SwiftGodot.docc/Exports.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Exports.md
@@ -32,7 +32,7 @@ visible and editable in the editor. This way, artists and game designers can
 modify values that later influence how the program runs. For this, a special export syntax is provided.
 
 Exporting can only be applied to ``Variant``-compatible types.  The Godot
-core-structures and classes, as well as objects that subclass ``GodotObject``.
+core-structures and classes, as well as objects that subclass ``SwiftGodot.Object``.
 
 The `@Export` macro only works in your class definition, and will not work
 on Swift class extensions.

--- a/Sources/SwiftGodot/SwiftGodot.docc/Variants.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Variants.md
@@ -7,7 +7,7 @@ Follow up on the fundamental building block of Godot's data types.
 You will often find the type ``Variant`` in Godot source code.   Variants are
 Godot's way of passing around certain data types.  They are similar to Swift's
 `Any` type, but they can only hold Godot types (most structures and classes
-that derive from ``GodotObject``). 
+that derive from ``SwiftGodot.Object``). 
 
 ## Creating Variant values
 
@@ -171,7 +171,7 @@ type of the variant by accessing the `.gtype` property of the variant.
 ## Extracting Godot-derived objects from Variants
 
 Godot-derived objects are slightly different. If you know you have a
-``GodotObject`` stored in the variant, you can call the ``Variant/asObject(_:)``
+``SwiftGodot.Object`` stored in the variant, you can call the ``Variant/asObject(_:)``
 instead.  This is a generic method, so you would invoke it like this:
 
 ```swift

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -146,14 +146,14 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
     }
     
     ///
-    /// Attempts to cast the Variant into a GodotObject, if the variant contains a value of type `.object`, then
+    /// Attempts to cast the Variant into a SwiftGodot.Object, if the variant contains a value of type `.object`, then
     // this will return the object.  If the variant contains the nil value, or the content of the variant is not
     /// a `.object, the value `nil` is returned.
     ///
     /// - Parameter type: the desired type eg. `.asObject(Node.self)`
     /// - Returns: nil on error, or the type on success
     ///
-    public func asObject<T:GodotObject> (_ type: T.Type = T.self) -> T? {
+    public func asObject<T: Object> (_ type: T.Type = T.self) -> T? {
         guard gtype == .object else {
             return nil
         }


### PR DESCRIPTION
It doesn't seem like the GodotObject protocol has any reason to exist. This patch removes it.

-   The protocol has no requirements.

-   There is exactly one directly conforming type: Object. All
    descendants of Object inherit the conformance, but any constraint
    requiring GodotObject conformance can be rewritten to instead
    require Object inheritance.

-   There are three functions with GodotObject constraints:

    -   `VariantStorable.makeOrUnwrap`
    -   `Variant.asObject`
    -   `lookupObject`

    All test cases pass if I change these constraints to require Object
    inheritance instead of GodotObject conformance.