### PR TITLE
fix building under Xcode 16.0 beta 6

### DIFF
--- a/Sources/SwiftGodotTestability/GodotRuntime.swift
+++ b/Sources/SwiftGodotTestability/GodotRuntime.swift
@@ -5,6 +5,22 @@
 //  Created by Mikhail Tishin on 22.10.2023.
 //
 
+// Imports for low-level C functions setenv, strdup, free.
+// These #ifs were shamelessly stolen from swift-system's CInterop.swift.
+#if os(Windows)
+import CSystem
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Bionic)
+@_implementationOnly import CSystem
+#endif
+
 import libgodot
 @testable import SwiftGodot
 


### PR DESCRIPTION
Xcode 16.0 beta 6 gives the following errors:

```
.../GodotRuntime.swift:83:9: error: cannot find 'setenv' in scope
        setenv("__CFBundleIdentifier", "SwiftGodotKit", 0)
        ^~~~~~
.../GodotRuntime.swift:95:13: error: cannot find 'strdup' in scope
            strdup (string)
            ^~~~~~
.../GodotRuntime.swift:108:13: error: cannot find 'free' in scope
            free (cStringArray[i])
            ^~~~
```

Importing Darwin fixes it on macOS and I have guessed what to import for other environments based on what swift-system does.

This might be something wrong with this beta that is fixed in the next. I have no idea if these imports are necessary long term. I don't think they should cause problems though.