### PR TITLE
die if a class name has already been registered

### DIFF
--- a/Sources/SwiftGodot/EntryPoint.swift
+++ b/Sources/SwiftGodot/EntryPoint.swift
@@ -116,6 +116,7 @@ struct GodotInterface {
     
     let classdb_construct_object: GDExtensionInterfaceClassdbConstructObject
     let classdb_get_method_bind: GDExtensionInterfaceClassdbGetMethodBind
+    let classdb_get_class_tag: GDExtensionInterfaceClassdbGetClassTag
     let classdb_register_extension_class: GDExtensionInterfaceClassdbRegisterExtensionClass2
     let classdb_register_extension_class_signal: GDExtensionInterfaceClassdbRegisterExtensionClassSignal
     let classdb_register_extension_class_method: GDExtensionInterfaceClassdbRegisterExtensionClassMethod
@@ -247,6 +248,7 @@ func loadGodotInterface (_ godotGetProcAddrPtr: GDExtensionInterfaceGetProcAddre
         
         classdb_construct_object: load ("classdb_construct_object"),
         classdb_get_method_bind: load ("classdb_get_method_bind"),
+        classdb_get_class_tag: load("classdb_get_class_tag"),
         classdb_register_extension_class: load ("classdb_register_extension_class2"),
         classdb_register_extension_class_signal: load ("classdb_register_extension_class_signal"),
         classdb_register_extension_class_method: load ("classdb_register_extension_class_method"),

--- a/Tests/SwiftGodotTests/WrappedTests.swift
+++ b/Tests/SwiftGodotTests/WrappedTests.swift
@@ -40,7 +40,7 @@ final class WrappedTests: GodotTestCase {
         await scene.processFrame.emitted
         checker.assertDisposed ()
     }
-    
+
 }
 
 @Godot
@@ -54,4 +54,29 @@ final class ReferenceChecker {
         XCTAssertTrue (reference == nil, "Object was not disposed", file: file, line: line)
     }
     
+}
+
+@Godot
+private class DuplicateClassTestNode: Node { }
+
+final class DuplicateClassRegistrationTests: GodotTestCase {
+
+    var duplicateClassNames: [StringName] = []
+
+    func testDuplicateClassNameIsDetected() {
+        register(type: DuplicateClassTestNode.self)
+        defer { unregister(type: DuplicateClassTestNode.self) }
+
+        let old = duplicateClassNameDetected
+        defer { duplicateClassNameDetected = old }
+
+        duplicateClassNameDetected = { [weak self] name, type in
+            self?.duplicateClassNames.append(name)
+        }
+
+        register(type: DuplicateClassTestNode.self)
+
+        XCTAssertEqual(duplicateClassNames, ["DuplicateClassTestNode"])
+    }
+
 }


### PR DESCRIPTION
I noticed this comment:

```
    // TODO: what happens if the user subclasses but the name conflicts with the Godot type?
    // say "class Sprite2D: Godot.Sprite2D"
```

The only way SwiftGodot can find out the type for some pointer passed from Godot is by checking the class name, we really can't allow class name conflicts: we could end up casting a pointer to the wrong type, leading to difficult-to-diagnose crashes. I think it's better to crash immediately if the extension tries to register a class name that's already been registered.
