### PR TITLE
Allocation-less marshaling for built-in and class types methods, and `Callable` changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build-docs.log
 *orig
 \#*
 /libgodot.xcframework/
+Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build-docs.log
 /libgodot.xcframework/
 Package.resolved
 /.vscode
+.swiftpm/xcode/xcshareddata/xcschemes

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build-docs.log
 \#*
 /libgodot.xcframework/
 Package.resolved
+/.vscode

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>2.830000</real>
+					<real>2.190000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -21,7 +21,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>4.510000</real>
+					<real>4.530000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
@@ -21,7 +21,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>5.180000</real>
+					<real>4.510000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>MarshalTests</key>
+		<dict>
+			<key>testBuiltinsTypesMethodsPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>4.599057</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testClassesMethodsPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>6.230999</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>4.599057</real>
+					<real>2.830000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -21,7 +21,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>6.230999</real>
+					<real>5.180000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
@@ -21,7 +21,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>4.530000</real>
+					<real>4.504656</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -31,7 +31,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>3.220758</real>
+					<real>3.270000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/53914494-654F-4AE6-BFE1-6777D0E5FBA3.plist
@@ -26,6 +26,16 @@
 					<string>Local Baseline</string>
 				</dict>
 			</dict>
+			<key>testVarargMethodsPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>3.220758</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
 		</dict>
 	</dict>
 </dict>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/Info.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/SwiftGodotTests.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>53914494-654F-4AE6-BFE1-6777D0E5FBA3</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M3 Max</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>16</integer>
+				<key>modelCode</key>
+				<string>Mac15,9</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>16</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64e</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -300,8 +300,8 @@ func generateArgPrepare (isVararg: Bool, _ args: [JGodotArgument], methodHasRetu
             getArgRef(arg: arg)
         }.joined(separator: ", ")
         
-        body += "\(prefix)\(retFromWith)withUnsafePointerToUnsafePointers(\(argsString)) { nPtrs in nPtrs.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(args.count)) { args in"
-        withUnsafeCallNestLevel += 2
+        body += "\(prefix)\(retFromWith)withUnsafeArgumentsPointer(\(argsString)) { args in"
+        withUnsafeCallNestLevel += 1
     }
     
     return (body, withUnsafeCallNestLevel)

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -232,7 +232,7 @@ func generateCopies (_ args: [JGodotArgument]) -> String {
     return body
 }
 
-#if LEGACY_MARSHALING || !os(macOS)
+#if LEGACY_MARSHALING || !canImport(Darwin)
 
 func generateArgPrepare (isVararg: Bool, _ args: [JGodotArgument], methodHasReturn: Bool) -> (String, Int) {
     var body = ""

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -232,7 +232,7 @@ func generateCopies (_ args: [JGodotArgument]) -> String {
     return body
 }
 
-#if LEGACY_MARSHALING
+#if LEGACY_MARSHALING || !os(macOS)
 
 func generateArgPrepare (isVararg: Bool, _ args: [JGodotArgument], methodHasReturn: Bool) -> (String, Int) {
     var body = ""

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -300,7 +300,7 @@ func generateArgPrepare (isVararg: Bool, _ args: [JGodotArgument], methodHasRetu
             getArgRef(arg: arg)
         }.joined(separator: ", ")
         
-        body += "\(prefix)\(retFromWith)withUnsafePointerToUnsafePointers(storing: \(argsString)) { nPtrs in nPtrs.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(args.count)) { args in"
+        body += "\(prefix)\(retFromWith)withUnsafePointerToUnsafePointers(\(argsString)) { nPtrs in nPtrs.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(args.count)) { args in"
         withUnsafeCallNestLevel += 2
     }
     

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -298,7 +298,7 @@ func generateArgPrepareNew(isVararg: Bool, _ args: [JGodotArgument], methodHasRe
     
     // TODO: this case should get the same treatment as a second branch.
     if isVararg {
-        body += generateCopies (args)
+        body += generateCopies(args)
         body += "var args: [UnsafeRawPointer?] = []\n"
         body += "let cptr = UnsafeMutableBufferPointer<Variant.ContentType>.allocate(capacity: arguments.count)\n"
         body += "defer { cptr.deallocate () }\n\n"        
@@ -309,14 +309,14 @@ func generateArgPrepareNew(isVararg: Bool, _ args: [JGodotArgument], methodHasRe
             body += "\(prefix)\(retFromWith)withUnsafePointer (to: \(ar)) { p\(withUnsafeCallNestLevel) in\n\(prefix)    args.append (p\(withUnsafeCallNestLevel))\n"
             withUnsafeCallNestLevel += 1
         }
-        body += "for idx in 0..<arguments.count {\n"
-        body += "    cptr [idx] = arguments [idx].content\n"
-        body += "    args.append (cptr.baseAddress! + idx)\n"
-        body += "}\n"
+        body += "for idx in 0..<arguments.count {\n".indented(by: withUnsafeCallNestLevel)
+        body += "    cptr [idx] = arguments [idx].content\n".indented(by: withUnsafeCallNestLevel)
+        body += "    args.append (cptr.baseAddress! + idx)\n".indented(by: withUnsafeCallNestLevel)
+        body += "}\n".indented(by: withUnsafeCallNestLevel)
         
         argsRef = "&args"
     } else if args.count > 0 {
-        body += generateCopies (args)
+        body += generateCopies(args)
         
         let prefix = String(repeating: " ", count: withUnsafeCallNestLevel * 4)
         

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -274,10 +274,8 @@ func generateArgPrepare (isVararg: Bool, _ args: [JGodotArgument], methodHasRetu
     if isVararg {
         body += generateCopies (args)
         body += "var args: [UnsafeRawPointer?] = []\n"
-        if isVararg {
-            body += "let cptr = UnsafeMutableBufferPointer<Variant.ContentType>.allocate(capacity: arguments.count)\n"
-            body += "defer { cptr.deallocate () }\n\n"
-        }
+        body += "let cptr = UnsafeMutableBufferPointer<Variant.ContentType>.allocate(capacity: arguments.count)\n"
+        body += "defer { cptr.deallocate () }\n\n"        
         
         for arg in args {
             let prefix = String(repeating: " ", count: withUnsafeCallNestLevel * 4)
@@ -285,12 +283,10 @@ func generateArgPrepare (isVararg: Bool, _ args: [JGodotArgument], methodHasRetu
             body += "\(prefix)\(retFromWith)withUnsafePointer (to: \(ar)) { p\(withUnsafeCallNestLevel) in\n\(prefix)    args.append (p\(withUnsafeCallNestLevel))\n"
             withUnsafeCallNestLevel += 1
         }
-        if isVararg {
-            body += "for idx in 0..<arguments.count {\n"
-            body += "    cptr [idx] = arguments [idx].content\n"
-            body += "    args.append (cptr.baseAddress! + idx)\n"
-            body += "}\n"
-        }
+        body += "for idx in 0..<arguments.count {\n"
+        body += "    cptr [idx] = arguments [idx].content\n"
+        body += "    args.append (cptr.baseAddress! + idx)\n"
+        body += "}\n"        
     } else if args.count > 0 {
         body += generateCopies (args)
         

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -9,7 +9,7 @@ import Foundation
 import ExtensionApi
 
 
-#if LEGACY_MARSHALING
+#if LEGACY_MARSHALING || !os(macOS)
 // Legacy marshaling passes a [UnsafeRawPointer?] named args, that requires a &
 let argsRef = "&args"
 #else

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -601,7 +601,7 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
             if bc.name == "Callable" {
                 p ("/// Creates a Callable instance from a Swift function")
                 p ("/// - Parameter callback: the swift function that receives an array of Variant arguments, and returns an optional Variant")
-                p ("public init (_ callback: @escaping ([Variant])->Variant?)") {
+                p ("public init (_ callback: @escaping (borrowing Arguments)->Variant?)") {
                     p ("content = CallableWrapper.makeCallable (callback)")
                 }
             }

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -9,7 +9,7 @@ import Foundation
 import ExtensionApi
 
 
-#if LEGACY_MARSHALING || !os(macOS)
+#if LEGACY_MARSHALING || !canImport(Darwin)
 // Legacy marshaling passes a [UnsafeRawPointer?] named args, that requires a &
 let argsRef = "&args"
 #else

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -601,8 +601,8 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
             if bc.name == "Callable" {
                 p ("/// Creates a Callable instance from a Swift function")
                 p ("/// - Parameter callback: the swift function that receives an array of Variant arguments, and returns an optional Variant")
-                p ("public init (_ callback: @escaping (borrowing Arguments)->Variant?)") {
-                    p ("content = CallableWrapper.makeCallable (callback)")
+                p ("public init(_ callback: @escaping (borrowing Arguments) -> Variant?)") {
+                    p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
                 }
             }
             if bc.hasDestructor {

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -443,7 +443,7 @@ func generateBuiltinMethods (_ p: Printer,
                 p ("var result = Variant.zero")
                 p ("if Self.keyed_checker (&content, &keyCopy.content) != 0") {
                     p ("Self.keyed_getter (&content, &keyCopy.content, &result)")
-                    p ("return Variant (fromContentPtr: &result)")
+                    p ("return Variant(copying: result)")
                 }
                 p ("else") {
                     p ("return nil")

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -600,8 +600,17 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
             }
             if bc.name == "Callable" {
                 p ("/// Creates a Callable instance from a Swift function")
+                p ("/// - Parameter callback: the swift function that receives `Arguments`, and returns a `Variant`")
+                p ("public init(_ callback: @escaping (borrowing Arguments) -> Variant)") {
+                    p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
+                }
+                
+                p ("/// Creates a Callable instance from a Swift function")
                 p ("/// - Parameter callback: the swift function that receives an array of Variant arguments, and returns an optional Variant")
-                p ("public init(_ callback: @escaping (borrowing Arguments) -> Variant?)") {
+                p("""
+                @available(*, deprecated, message: "Use `init(_ callback: @escaping (borrowing Arguments) -> Variant)` instead.")
+                """)
+                p ("public init (_ callback: @escaping ([Variant])->Variant?)") {
                     p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
                 }
             }

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -286,7 +286,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                     let methodArgsCount = "GDExtensionInt(\(builder.args.count))"
                     
                     return """
-                    withUnsafePointerToUnsafePointers(storing: \(methodArgs)) { nPtrs in 
+                    withUnsafePointerToUnsafePointers(\(methodArgs)) { nPtrs in 
                         nPtrs.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(builder.args.count)) { args in
                             gi.object_method_bind_call(\([methodName, instance, "args", methodArgsCount, ptrResult, "nil"].joined(separator: ", ")))
                         }                        
@@ -302,7 +302,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                 #else
                 if hasArgs {
                     return """
-                    withUnsafePointerToUnsafePointers(storing: \(methodArgs)) { nPtrs in 
+                    withUnsafePointerToUnsafePointers(\(methodArgs)) { nPtrs in 
                         nPtrs.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(builder.args.count)) { args in
                             gi.object_method_bind_ptrcall(\([methodName, instance, "args", ptrResult].joined(separator: ", ")))
                         }                        

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -357,11 +357,11 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
         guard returnType != "" else { return "" }
         if method.isVararg {
             if returnType == "Variant" {
-                return "return Variant (fromContentPtr: &_result)"
+                return "return Variant(copying: _result)"
             } else if returnType == "GodotError" {
-                return "return GodotError (rawValue: Int64 (Variant (fromContentPtr: &_result))!)!"
+                return "return GodotError(rawValue: Int64(Variant(copying: _result))!)!"
             } else if returnType == "String" {
-                return "return GString (Variant (fromContentPtr: &_result))?.description ?? \"\""
+                return "return GString(Variant(copying: _result))?.description ?? \"\""
             } else {
                 fatalError("Do not support this return type = \(returnType)")
             }

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -279,7 +279,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
             let methodArgs = builder.args.joined(separator: ", ")
             
             if method.isVararg {
-                #if LEGACY_MARSHALING
+                #if LEGACY_MARSHALING || !os(macOS)
                 return "gi.object_method_bind_call_v(\([methodName, instance, ptrResult, "nil", methodArgs].joined(separator: ", ")))"
                 #else
                 if hasArgs {
@@ -295,7 +295,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                 }
                 #endif
             } else {
-                #if LEGACY_MARSHALING
+                #if LEGACY_MARSHALING || !os(macOS)
                 return "gi.object_method_bind_ptrcall_v(\([methodName, instance, ptrResult, methodArgs].joined(separator: ", ")))"
                 #else
                 if hasArgs {

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -8,6 +8,18 @@
 import Foundation
 import ExtensionApi
 
+extension String {
+    func indented(by indentation: Int) -> String {
+        let indentationString = String(repeating: "    ", count: indentation)
+        let lines = split(separator: "\n", omittingEmptySubsequences: false)
+        return lines
+            .map {
+                "\(indentationString)\($0)"
+            }
+            .joined(separator: "\n")
+    }
+}
+
 enum MethodGenType {
     case `class`
     case `utility`
@@ -510,8 +522,8 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                 builder.args.append("\(needAddress)\(escapeSwift(argref))\(optstorage)")
             }
         }
-        argSetup += varArgSetupInit
-        argSetup += varArgSetup
+        argSetup += varArgSetupInit.indented(by: withUnsafeCallNestLevel)
+        argSetup += varArgSetup.indented(by: withUnsafeCallNestLevel)
         builder.call =
         """
         \(call_object_method_bind_v(hasArgs: args != "", ptrResult: getResultPtr()))
@@ -524,8 +536,8 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
             args = "_ arguments: Variant..."
         }
         argSetup += "var _args: [UnsafeRawPointer?] = []\n"
-        argSetup += varArgSetupInit
-        argSetup += varArgSetup
+        argSetup += varArgSetupInit.indented(by: withUnsafeCallNestLevel)
+        argSetup += varArgSetup.indented(by: withUnsafeCallNestLevel)
     }
     
     if inline != "" {

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -427,7 +427,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
         // We can modularize this by creating functions that generate the return type and return
         // statements.
 
-#if os(Windows)
+#if os(Windows) && LEGACY_MARSHALING
         // Workaround for: https://github.com/migueldeicaza/SwiftGodot/issues/299
         builder.setup = "#if false\n\n"
 #else

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -279,7 +279,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
             let methodArgs = builder.args.joined(separator: ", ")
             
             if method.isVararg {
-                #if LEGACY_MARSHALING || !os(macOS)
+                #if LEGACY_MARSHALING || !canImport(Darwin)
                 return "gi.object_method_bind_call_v(\([methodName, instance, ptrResult, "nil", methodArgs].joined(separator: ", ")))"
                 #else
                 if hasArgs {
@@ -295,7 +295,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                 }
                 #endif
             } else {
-                #if LEGACY_MARSHALING || !os(macOS)
+                #if LEGACY_MARSHALING || !canImport(Darwin)
                 return "gi.object_method_bind_ptrcall_v(\([methodName, instance, ptrResult, methodArgs].joined(separator: ", ")))"
                 #else
                 if hasArgs {

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -427,7 +427,7 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
         // We can modularize this by creating functions that generate the return type and return
         // statements.
 
-#if os(Windows) && LEGACY_MARSHALING
+#if os(Windows)
         // Workaround for: https://github.com/migueldeicaza/SwiftGodot/issues/299
         builder.setup = "#if false\n\n"
 #else

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -98,6 +98,518 @@ func isRefParameterOptional (className: String, method: String, arg: String) -> 
 ///  - usedMethods: a set of methods that have been referenced by properties, to determine whether we make this public or private
 /// - Returns: nil, or the method we surfaced that needs to have the virtual supporting infrastructured wired up
 func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef: JClassInfo?, usedMethods: Set<String>, kind: MethodGenType, asSingleton: Bool) -> String? {
+    // A runtime hook for opt-out from using new marshaling in case some specific method breaks
+    var useLegacyMarshaling = false
+    
+    #if LEGACY_MARSHALING //  || !canImport(Darwin) will be used inside new implementation only for a piece that actually crashes Swift compiler on non-Darwin platforms
+    useLegacyMarshaling = true
+    #endif
+    
+    if useLegacyMarshaling {
+        return methodGenLegacy(p, method: method, className: className, cdef: cdef, usedMethods: usedMethods, kind: kind, asSingleton: asSingleton)
+    } else {
+        return methodGenNew(p, method: method, className: className, cdef: cdef, usedMethods: usedMethods, kind: kind, asSingleton: asSingleton)
+    }
+}
+
+func methodGenNew(_ p: Printer, method: MethodDefinition, className: String, cdef: JClassInfo?, usedMethods: Set<String>, kind: MethodGenType, asSingleton: Bool) -> String? {
+    var registerVirtualMethodName: String? = nil
+    
+    //let loc = "\(cdef.name).\(method.name)"
+    if let arguments = method.arguments, arguments.contains(where: { $0.type.contains("*")}) {
+        var fault = false
+        for arg in arguments {
+            if arg.type.contains ("*") {
+                switch arg.type {
+                case "const void*":
+                    break
+                case "AudioFrame*":
+                    break
+                default:
+                    if !fault {
+                        fault = true
+                        //print ("TODO: do not currently have support for C pointer types \(cdef?.name ?? "").\(method.name):")
+                    }
+                    //print ("     \(arg.name): \(arg.type)")
+                    break
+                }
+            }
+        }
+        if fault {
+            return nil
+        }
+    }
+    let bindName = "method_\(method.name)"
+    var visibility: String
+    var allEliminate: String
+    var finalp: String
+    // Default method name
+    var methodName: String = godotMethodToSwift (method.name)
+    let instanceOrStatic = method.isStatic || asSingleton ? " static" : ""
+    var inline = ""
+    if let methodHash = method.optionalHash {
+        let staticVarVisibility = if bindName != "method_get_class" { "fileprivate " } else { "" }
+        assert (!method.isVirtual)
+        switch kind {
+        case .class:
+            p.staticVar(visibility: staticVarVisibility, name: bindName, type: "GDExtensionMethodBindPtr") {
+                p ("let methodName = StringName (\"\(method.name)\")")
+            
+                p ("return withUnsafePointer (to: &\(className).godotClassName.content)", arg: " classPtr in") {
+                    p ("withUnsafePointer (to: &methodName.content)", arg: " mnamePtr in") {
+                        p ("gi.classdb_get_method_bind (classPtr, mnamePtr, \(methodHash))!")
+                    }
+                }
+            }
+        case .utility:
+            p.staticVar(visibility: staticVarVisibility, name: bindName, type: "GDExtensionPtrUtilityFunction") {
+                p ("let methodName = StringName (\"\(method.name)\")")
+                p ("return withUnsafePointer (to: &methodName.content)", arg: " ptr in") {
+                    p ("return gi.variant_get_ptr_utility_function (ptr, \(methodHash))!")
+                }
+            }
+        }
+        
+        // If this is an internal, and being reference by a property, hide it
+        if usedMethods.contains (method.name) {
+            inline = "@inline(__always)"
+            // Try to hide as much as possible, but we know that Godot child nodes will want to use these
+            // (DirectionalLight3D and Light3D) rely on this.
+            visibility = method.name == "get_param" || method.name == "set_param" ? "internal" : "fileprivate"
+            allEliminate = "_ "
+            methodName = method.name
+        } else {
+            visibility = "public"
+            allEliminate = ""
+        }
+        if instanceOrStatic == "" {
+            finalp = "final "
+        } else {
+            finalp = ""
+        }
+    } else {
+        assert (method.isVirtual)
+        // virtual overwrittable method
+        finalp = ""
+        visibility = "@_documentation(visibility: public)\nopen"
+        allEliminate = ""
+            
+        registerVirtualMethodName = methodName
+    }
+    
+    struct Builder {
+        var setup = ""      // all variable copies and _result go here
+        var args: [String] = []
+        var call = ""       // call to helper goes here.
+        var result = ""     // return of _result goes here.
+    }
+    var builder = Builder()
+    
+    var args = ""
+    var argSetup = ""
+    var varArgSetup = ""
+    var varArgSetupInit = ""
+    if method.isVararg {
+        varArgSetupInit = "\nlet content = UnsafeMutableBufferPointer<Variant.ContentType>.allocate(capacity: arguments.count)\n" +
+        "defer { content.deallocate () }\n"
+    
+        varArgSetup += "for idx in 0..<arguments.count {\n"
+        varArgSetup += "    content [idx] = arguments [idx].content\n"
+        varArgSetup += "    _args.append (content.baseAddress! + idx)\n"
+        varArgSetup += "}\n"
+    }
+    let godotReturnType = method.returnValue?.type
+    let godotReturnTypeIsReferenceType = classMap [godotReturnType ?? ""] != nil
+    let returnOptional = godotReturnTypeIsReferenceType && isReturnOptional(className: className, method: method.name)
+    let returnType = getGodotType (method.returnValue) + (returnOptional ? "?" : "")
+
+    /// returns appropriate declaration of the return type, used by the helper function.
+    let frameworkType = godotReturnTypeIsReferenceType
+    func returnTypeDecl() -> String {
+        if returnType != "" {
+            guard let godotReturnType else {
+                fatalError ("If the returnType is not empty, we should have a godotReturnType")
+            }
+            if method.isVararg {
+                return "var _result: Variant.ContentType = Variant.zero"
+            } else if godotReturnType.starts(with: "typedarray::") {
+                let (storage, initialize) = getBuiltinStorage ("Array")
+                return "var _result: \(storage)\(initialize)"
+            } else if godotReturnType == "String" {
+                return "let _result = GString ()"
+            } else {
+                if godotReturnTypeIsReferenceType {
+                    // frameworkType = true
+                    return "var _result = UnsafeRawPointer (bitPattern: 0)"
+                } else {
+                    if godotReturnType.starts(with: "enum::") {
+                        return "var _result: Int64 = 0 // to avoid packed enums on the stack"
+                    } else {
+                        
+                        var declType: String = "let"
+                        if (argTypeNeedsCopy(godotType: godotReturnType)) {
+                            if builtinGodotTypeNames [godotReturnType] != .isClass {
+                                declType = "var"
+                            }
+                        }
+                        return "\(declType) _result: \(returnType) = \(makeDefaultInit(godotType: godotReturnType))"
+                    }
+                }
+            }
+        }
+        return ""
+    }
+    
+    func getArgsPtr() -> String {
+        (args != "") ? "&_args" : "nil"
+    }
+    
+    func getResultPtr() -> String {
+        let ptrResult: String
+        if returnType != "" {
+            guard let godotReturnType else { fatalError("godotReturnType is nil!") }
+
+            if method.isVararg {
+                ptrResult = "&_result"
+            } else if argTypeNeedsCopy(godotType: godotReturnType) {
+                let isClass = builtinGodotTypeNames [godotReturnType] == .isClass
+                
+                ptrResult = isClass ? "&_result.content" : "&_result"
+            } else {
+                if godotReturnType.starts (with: "typedarray::") {
+                    ptrResult = "&_result"
+                } else if frameworkType {
+                    ptrResult = "&_result"
+                } else if builtinSizes [godotReturnType] != nil {
+                    ptrResult = "&_result.content"
+                } else {
+                    ptrResult = "&_result.handle"
+                }
+            }
+        } else {
+            if method.isVararg {
+                ptrResult = "&_result"
+            } else {
+                ptrResult = "nil"
+            }
+        }
+        return ptrResult
+    }
+
+    /// this version inlines withArgPointers by calling `object_method_bind_call_v` or `gi.object_method_bind_ptrcall_v`
+    /// which builds the argument list using variadic arguments.
+    func call_object_method_bind_v(hasArgs: Bool, ptrResult: String) -> String {
+        switch kind {
+        case .class:
+            let instance = method.isStatic ? "nil" : "UnsafeMutableRawPointer (mutating: \(asSingleton ? "shared." : "")handle)"
+            let methodName = "\(className).method_\(method.name)"
+            let methodArgs = builder.args.joined(separator: ", ")
+                        
+            if method.isVararg {
+                // Large generics cause issues on Windows compiler, legacy approach is used
+                #if canImport(Darwin)
+                if hasArgs {
+                    let methodArgsCount = "GDExtensionInt(\(builder.args.count))"
+                    
+                    return """
+                    withUnsafeArgumentsPointer(\(methodArgs)) { args in 
+                        gi.object_method_bind_call(\([methodName, instance, "args", methodArgsCount, ptrResult, "nil"].joined(separator: ", ")))                        
+                    }
+                    """
+                } else {
+                    return "gi.object_method_bind_call(\([methodName, instance, "nil", "0", ptrResult, "nil"].joined(separator: ", ")))"
+                }
+                #else
+                return "gi.object_method_bind_call_v(\([methodName, instance, ptrResult, "nil", methodArgs].joined(separator: ", ")))"
+                #endif
+            } else {
+                // Large generics cause issues on Windows compiler, legacy approach is used
+                #if canImport(Darwin)
+                if hasArgs {
+                    return """
+                    withUnsafeArgumentsPointer(\(methodArgs)) { args in
+                        gi.object_method_bind_ptrcall(\([methodName, instance, "args", ptrResult].joined(separator: ", ")))
+                    }
+                    """
+                } else {
+                    return "gi.object_method_bind_ptrcall(\([methodName, instance, "nil", ptrResult].joined(separator: ", ")))"
+                }
+                #else
+                return "gi.object_method_bind_ptrcall_v(\([methodName, instance, ptrResult, methodArgs].joined(separator: ", ")))"
+                #endif
+            }
+        case .utility:
+            let ptrArgs = hasArgs ? "_args" : "nil"
+            let call_object_method_bind = if method.isVararg {
+                "\(bindName) (\(ptrResult), \(ptrArgs), Int32 (_args.count))"
+            } else {
+                "\(bindName) (\(ptrResult), \(ptrArgs), Int32 (\(method.arguments?.count ?? 0)))"
+            }
+            return
+                """
+                withArgPointers(\(builder.args.joined(separator: ", "))) { _args in
+                    \(call_object_method_bind)
+                }
+                """
+        }
+    }
+    
+    func call_object_method_bind(ptrArgs: String, ptrResult: String) -> String {
+        switch kind {
+        case .class:
+            let instanceHandle = method.isStatic ? "nil, " : "UnsafeMutableRawPointer (mutating: \(asSingleton ? "shared." : "")handle), "
+            if method.isVararg {
+                return "gi.object_method_bind_call (\(className).method_\(method.name), \(instanceHandle)\(ptrArgs), Int64 (_args.count), \(ptrResult), nil)"
+            } else {
+                return "gi.object_method_bind_ptrcall (\(className).method_\(method.name), \(instanceHandle)\(ptrArgs), \(ptrResult))"
+            }
+        case .utility:
+            if method.isVararg {
+                return "\(bindName) (\(ptrResult), \(ptrArgs), Int32 (_args.count))"
+            } else {
+                return "\(bindName) (\(ptrResult), \(ptrArgs), Int32 (\(method.arguments?.count ?? 0)))"
+            }
+        }
+    }
+    
+    func getReturnResult() -> String {
+        if returnType == "" {
+            return ""
+        }
+        guard returnType != "" else { return "" }
+        if method.isVararg {
+            if returnType == "Variant" {
+                return "return Variant(copying: _result)"
+            } else if returnType == "GodotError" {
+                return "return GodotError(rawValue: Int64(Variant(copying: _result))!)!"
+            } else if returnType == "String" {
+                return "return GString(Variant(copying: _result))?.description ?? \"\""
+            } else {
+                fatalError("Do not support this return type = \(returnType)")
+            }
+        } else if frameworkType {
+            //print ("OBJ RETURN: \(className) \(method.name)")
+            return "guard let _result else { \(returnOptional ? "return nil" : "fatalError (\"Unexpected nil return from a method that should never return nil\")") } ; return lookupObject (nativeHandle: _result)!"
+        } else if godotReturnType?.starts(with: "typedarray::") ?? false {
+            let defaultInit = makeDefaultInit(godotType: godotReturnType!, initCollection: "content: _result")
+            return "return \(defaultInit)"
+        } else if godotReturnType?.starts(with: "enum::") ?? false {
+            return "return \(returnType) (rawValue: _result)!"
+        } else if godotReturnType == "String" {
+            return "return _result.description"
+        } else {
+            return "return _result"
+        }
+    }
+    
+    var withUnsafeCallNestLevel = 0
+    var eliminate: String = allEliminate
+    if let margs = method.arguments {
+        var firstArg: String? = nil
+        for arg in margs {
+            if args != "" { args += ", " }
+            var isRefOptional = false
+            if classMap [arg.type] != nil {
+                isRefOptional = isRefParameterOptional (className: className, method: method.name, arg: arg.name)
+            }
+            
+            // Omit first argument label, if necessary
+            if firstArg == nil {
+                if shouldOmitFirstArgLabel(typeName: className, methodName: method.name, argName: arg.name) {
+                    eliminate = "_ "
+                } else {
+                    eliminate = allEliminate
+                }
+            } else {
+                eliminate = allEliminate
+            }
+            firstArg = arg.name
+            args += getArgumentDeclaration(arg, eliminate: eliminate, isOptional: isRefOptional)
+            var reference = escapeSwift (snakeToCamel (arg.name))
+
+            if method.isVararg {
+                if isRefOptional {
+                    argSetup += "let copy_\(arg.name) = \(reference) == nil ? Variant() : Variant (\(reference)!)\n"
+                } else {
+                    argSetup += "let copy_\(arg.name) = Variant (\(reference))\n"
+                }
+            } else if arg.type == "String" {
+                argSetup += "let gstr_\(arg.name) = GString (\(reference))\n"
+            } else if argTypeNeedsCopy(godotType: arg.type) {
+                // Wrap in an Int
+                if arg.type.starts(with: "enum::") {
+                    reference = "Int64 (\(reference).rawValue)"
+                }
+                if isSmallInt (arg) {
+                    argSetup += "var copy_\(arg.name): Int = Int (\(reference))\n"
+                } else {
+                    argSetup += "var copy_\(arg.name) = \(reference)\n"
+                }
+            }
+        }
+        if method.isVararg {
+            if args != "" { args += ", "}
+            args += "_ arguments: Variant..."
+        }
+        // generate a helper function, a la withUnsafePointers() above, which
+        // combines extracting the parameters into pointers and packing them into the _args array.
+        // We can modularize this by creating functions that generate the return type and return
+        // statements.
+
+#if os(Windows)
+        // Workaround for: https://github.com/migueldeicaza/SwiftGodot/issues/299
+        builder.setup = "#if false\n\n"
+#else
+        if method.isVararg {
+            builder.setup = "#if false\n\n"
+        } else {
+            builder.setup = "#if true\n\n"
+        }
+#endif
+        builder.setup += argSetup
+        // Use implicit bridging to build _args array of type [UnsafeMutableRawPointer?]. This preserves the
+        // values of the parameters, because they are treated as inout parameters. Then cast to [UnsafeRawPointer?],
+        // because of how GDExtensionInterfaceObjectMethodBindPtrcall is declared:
+        // public typealias GDExtensionInterfaceObjectMethodBindPtrcall = @convention(c) (GDExtensionMethodBindPtr?, GDExtensionObjectPtr?, UnsafePointer<GDExtensionConstTypePtr?>?, GDExtensionTypePtr?) -> Void
+        // UnsafePointer<GDExtensionConstTypePtr?>? is equivalent to UnsafePointer<UnsafeRawPointer?>? or [UnsafeRawPointer?].
+        argSetup += "var _args: [UnsafeRawPointer?] = []\n"
+        for arg in margs {
+            // When we move from GString to String in the public API
+            //                if arg.type == "String" {
+            //                    argSetup += "stringToGodotHandle (\(arg.name))\n"
+            //                } else
+            //                {
+            var argref: String
+            var optstorage: String
+            var needAddress = "&"
+            //var isRefParameter = false
+            var refParameterIsOptional = false
+            if method.isVararg {
+                argref = "copy_\(arg.name)"
+                optstorage = ".content"
+            } else if arg.type == "String" {
+                argref = "gstr_\(arg.name)"
+                optstorage = ".content"
+            } else if argTypeNeedsCopy(godotType: arg.type) {
+                argref = "copy_\(arg.name)"
+                optstorage = ""
+            } else {
+                argref = escapeSwift (snakeToCamel (arg.name))
+                if isStructMap [arg.type] ?? false {
+                    optstorage = ""
+                } else {
+                    if builtinSizes [arg.type] != nil && arg.type != "Object" {
+                        optstorage = ".content"
+                    } else if arg.type.starts(with: "typedarray::") {
+                        optstorage = ".array.content"
+                    } else {
+                        // The next two are unused, because we set isRefParameter,
+                        // but for documentation/clarity purposes
+                        optstorage = ".handle"
+                        needAddress = ""
+                        //isRefParameter = true
+                        
+                        refParameterIsOptional = isRefParameterOptional (className: className, method: method.name, arg: arg.name)
+                    }
+                }
+            }
+            // With Godot 4.1 we need to pass the address of the handle
+            let prefix = String(repeating: " ", count: withUnsafeCallNestLevel * 4)
+            let retFromWith = returnType != "" ? "return " : ""
+
+            if refParameterIsOptional || optstorage == ".handle" {
+                let ea = escapeSwift(argref)
+                let deref = refParameterIsOptional ? "?" : ""
+                let accessPar = refParameterIsOptional ? "\(ea) == nil ? nil : p\(withUnsafeCallNestLevel)" : "p\(withUnsafeCallNestLevel)"
+                argSetup += "\(prefix)\(retFromWith)withUnsafePointer (to: \(ea)\(deref).handle) { p\(withUnsafeCallNestLevel) in\n\(prefix)_args.append (\(accessPar))\n"
+                withUnsafeCallNestLevel += 1
+                let handle_ref = "copy_\(arg.name)_handle"
+                builder.setup += "var \(handle_ref) = \(ea)\(deref).handle\n"
+                builder.args.append("&\(handle_ref)")
+            } else {
+                argSetup += "\(prefix)\(retFromWith)withUnsafePointer (to: \(needAddress)\(escapeSwift(argref))\(optstorage)) { p\(withUnsafeCallNestLevel) in\n\(prefix)    _args.append (p\(withUnsafeCallNestLevel))\n"
+                withUnsafeCallNestLevel += 1
+                builder.args.append("\(needAddress)\(escapeSwift(argref))\(optstorage)")
+            }
+        }
+        argSetup += varArgSetupInit.indented(by: withUnsafeCallNestLevel)
+        argSetup += varArgSetup.indented(by: withUnsafeCallNestLevel)
+        builder.call =
+        """
+        \(call_object_method_bind_v(hasArgs: args != "", ptrResult: getResultPtr()))
+        \(getReturnResult())
+        #else\n
+        """
+    } else if method.isVararg {
+        // No regular arguments, check if these are varargs
+        if method.isVararg {
+            args = "_ arguments: Variant..."
+        }
+        argSetup += "var _args: [UnsafeRawPointer?] = []\n"
+        argSetup += varArgSetupInit.indented(by: withUnsafeCallNestLevel)
+        argSetup += varArgSetup.indented(by: withUnsafeCallNestLevel)
+    }
+    
+    if inline != "" {
+        p (inline)
+    }
+    // Sadly, the parameters have no useful documentation
+    doc (p, cdef, method.description)
+    // Generate the method entry point
+    if let classDiscardables = discardableResultList [className] {
+        if classDiscardables.contains(method.name) == true {
+            p ("@discardableResult /* discardable per discardableList: \(className), \(method.name) */ ")
+        }
+    }
+    p ("\(visibility)\(instanceOrStatic) \(finalp)func \(methodName) (\(args))\(returnType != "" ? "-> " + returnType : "")") {
+        // We will change the nest level in the body after we print out the prefix of the nested withUnsafe calls
+        
+        if method.optionalHash == nil {
+            if let godotReturnType {
+                p (makeDefaultReturn (godotType: godotReturnType))
+            }
+        } else {
+            if returnType != "" {
+                p(returnTypeDecl())
+            } else if (method.isVararg) {
+                p ("var _result: Variant.ContentType = Variant.zero")
+            }
+            
+            if builder.setup != "" {
+                p(builder.setup)
+                p(builder.call)
+            }
+            
+            if argSetup != "" {
+                p (argSetup)
+            }
+            if withUnsafeCallNestLevel > 0 {
+                p.indent += withUnsafeCallNestLevel
+            }
+
+            p(call_object_method_bind(ptrArgs: getArgsPtr(), ptrResult: getResultPtr()))
+            
+            if returnType != "" {
+                p (getReturnResult())
+            }
+            
+            // Unwrap the nested calls to 'withUnsafePointer'
+            while withUnsafeCallNestLevel > 0 {
+                withUnsafeCallNestLevel -= 1
+                p.indent -= 1
+                p ("}")
+            }
+            
+// REFACTOR: just so we can see the two side-by-side
+            if builder.setup != "" {
+                p ("\n#endif")
+            }
+        }
+    }
+    return registerVirtualMethodName
+}
+
+func methodGenLegacy(_ p: Printer, method: MethodDefinition, className: String, cdef: JClassInfo?, usedMethods: Set<String>, kind: MethodGenType, asSingleton: Bool) -> String? {
     var registerVirtualMethodName: String? = nil
     
     //let loc = "\(cdef.name).\(method.name)"
@@ -290,43 +802,10 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
             let methodName = "\(className).method_\(method.name)"
             let methodArgs = builder.args.joined(separator: ", ")
             
-            // A runtime hook for opt-out from using new marshaling in case some specific method breaks
-            var useLegacyMarshaling = false
-            
-            #if LEGACY_MARSHALING || !canImport(Darwin)
-            useLegacyMarshaling = true
-            #endif
-            
             if method.isVararg {
-                if useLegacyMarshaling {
-                    return "gi.object_method_bind_call_v(\([methodName, instance, ptrResult, "nil", methodArgs].joined(separator: ", ")))"
-                } else {
-                    if hasArgs {
-                        let methodArgsCount = "GDExtensionInt(\(builder.args.count))"
-                        
-                        return """
-                        withUnsafeArgumentsPointer(\(methodArgs)) { args in 
-                            gi.object_method_bind_call(\([methodName, instance, "args", methodArgsCount, ptrResult, "nil"].joined(separator: ", ")))                        
-                        }
-                        """
-                    } else {
-                        return "gi.object_method_bind_call(\([methodName, instance, "nil", "0", ptrResult, "nil"].joined(separator: ", ")))"
-                    }
-                }
+                return "gi.object_method_bind_call_v(\([methodName, instance, ptrResult, "nil", methodArgs].joined(separator: ", ")))"
             } else {
-                if useLegacyMarshaling {
-                    return "gi.object_method_bind_ptrcall_v(\([methodName, instance, ptrResult, methodArgs].joined(separator: ", ")))"
-                } else {
-                    if hasArgs {
-                        return """
-                        withUnsafeArgumentsPointer(\(methodArgs)) { args in
-                            gi.object_method_bind_ptrcall(\([methodName, instance, "args", ptrResult].joined(separator: ", ")))
-                        }
-                        """
-                    } else {
-                        return "gi.object_method_bind_ptrcall(\([methodName, instance, "nil", ptrResult].joined(separator: ", ")))"
-                    }
-                }
+                return "gi.object_method_bind_ptrcall_v(\([methodName, instance, ptrResult, methodArgs].joined(separator: ", ")))"
             }
         case .utility:
             let ptrArgs = hasArgs ? "_args" : "nil"

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -286,10 +286,8 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                     let methodArgsCount = "GDExtensionInt(\(builder.args.count))"
                     
                     return """
-                    withUnsafePointerToUnsafePointers(\(methodArgs)) { nPtrs in 
-                        nPtrs.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(builder.args.count)) { args in
-                            gi.object_method_bind_call(\([methodName, instance, "args", methodArgsCount, ptrResult, "nil"].joined(separator: ", ")))
-                        }                        
+                    withUnsafeArgumentsPointer(\(methodArgs)) { args in 
+                        gi.object_method_bind_call(\([methodName, instance, "args", methodArgsCount, ptrResult, "nil"].joined(separator: ", ")))                        
                     }
                     """
                 } else {
@@ -302,10 +300,8 @@ func methodGen (_ p: Printer, method: MethodDefinition, className: String, cdef:
                 #else
                 if hasArgs {
                     return """
-                    withUnsafePointerToUnsafePointers(\(methodArgs)) { nPtrs in 
-                        nPtrs.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(builder.args.count)) { args in
-                            gi.object_method_bind_ptrcall(\([methodName, instance, "args", ptrResult].joined(separator: ", ")))
-                        }                        
+                    withUnsafeArgumentsPointer(\(methodArgs)) { args in
+                        gi.object_method_bind_ptrcall(\([methodName, instance, "args", ptrResult].joined(separator: ", ")))
                     }
                     """
                 } else {

--- a/Generator/Generator/UnsafePointerHelpers.swift
+++ b/Generator/Generator/UnsafePointerHelpers.swift
@@ -54,6 +54,7 @@ private func generateUnsafeRawPointersN(pointerCount count: Int) -> String {
 private func generateWithUnsafeArgumentsPointer(argumentsCount count: Int) -> String {
     let funcDecl = FunctionDeclSyntax(
         attributes: "@inline(__always)",
+        funcKeyword: .keyword(.func, leadingTrivia: .newline),
         name: "withUnsafeArgumentsPointer",
         genericParameterClause: GenericParameterClauseSyntax(parameters: GenericParameterListSyntax {
             for i in 0..<count {
@@ -82,10 +83,8 @@ private func generateWithUnsafeArgumentsPointer(argumentsCount count: Int) -> St
             "p\(i): p\(i)"
         }.joined(separator: ", ")
                 
-        "var storage = UnsafeRawPointersN\(raw: count)(\(raw: storageInitParameters))"
-        
         """
-        return withUnsafePointer(to: &storage) { ptr in
+        return withUnsafePointer(to: UnsafeRawPointersN\(raw: count)(\(raw: storageInitParameters))) { ptr in
             ptr.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(raw: count)) { rawPtr in
                 body(rawPtr)
             }                

--- a/Generator/Generator/UnsafePointerHelpers.swift
+++ b/Generator/Generator/UnsafePointerHelpers.swift
@@ -1,0 +1,176 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+/// Generate methods to help marshaling arguments to Godot while keeping things civil and on stack
+func generateUnsafePointerHelpers(_ p: Printer) {
+    let maxNestingDepth = 16
+    
+    for i in 1..<maxNestingDepth {
+        p(generateWithUnsafePointers(withDepth: i))
+        p("")
+    }
+    
+    for i in 1..<maxNestingDepth {
+        p(generateUnsafeRawPointersN(pointerCount: i))
+        p("")
+    }
+    
+    for i in 1..<maxNestingDepth {
+        p(generateWithUnsafePointerToUnsafePointersStoring(argumentsCount: i))
+        p("")
+    }
+}
+
+/// Generate a method nesting access to unsafe pointers to passed inout parameters and to allow executing a lambda in scope where all of these pointers are valid.
+///
+/// ```swift
+/// func withUnsafePointers<T0, T1, T2, R>(to v0: inout T0, _ v1: inout T1, _ v2: inout T2, _ body: (UnsafePointer<T0>, UnsafePointer<T1>, UnsafePointer<T2>) -> R) -> R {
+///     withUnsafePointer(to: v0) { p0 in
+///         withUnsafePointer(to: v1) { p1 in
+///             withUnsafePointer(to: v2) { p2 in
+///                 body(p0, p1, p2)
+///             }
+///         }
+///     }
+/// }
+/// ```
+private func generateWithUnsafePointers(withDepth depth: Int) -> String {
+    func codeBlockItemSyntax(currentDepth: Int = 0, maxDepth: Int) -> String {
+        if currentDepth == maxDepth {
+            let args = (0...maxDepth).map { i in
+                "p\(i)"
+            }.joined(separator: ", ")
+            
+            return "withUnsafePointer(to: v\(currentDepth)) { p\(currentDepth) in body(\(args)) }"
+        } else {
+            return "withUnsafePointer(to: v\(currentDepth)) { p\(currentDepth) in \(codeBlockItemSyntax(currentDepth: currentDepth + 1, maxDepth: maxDepth)) }"
+        }
+    }
+    
+    let funcDecl = FunctionDeclSyntax(
+        name: "withUnsafePointers",
+        genericParameterClause: GenericParameterClauseSyntax(parameters: GenericParameterListSyntax {
+            for i in 0..<depth {
+                GenericParameterSyntax(name: "T\(raw: i)")
+            }
+            
+            GenericParameterSyntax(name: "R")
+        }),
+        signature: FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax {
+                for i in 0..<depth {
+                    FunctionParameterSyntax(
+                        
+                        firstName: i == 0 ? "to" : "_",
+                        secondName: "v\(raw: i)",
+                        type: AttributedTypeSyntax(
+                            specifier: TokenSyntax(stringLiteral: "inout"),
+                            baseType: TypeSyntax(stringLiteral: "T\(i)")
+                        )
+                    )
+                }
+                
+                let bodyParameters = (0..<depth).map { i in
+                    "UnsafePointer<T\(i)>"
+                }.joined(separator: ", ")
+                
+                FunctionParameterSyntax(stringLiteral: "_ body: (\(bodyParameters)) -> R")
+            },
+            returnClause: ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "R"))
+        )
+    ) {
+        CodeBlockItemSyntax(stringLiteral: codeBlockItemSyntax(maxDepth: depth - 1))
+    }
+    
+    return funcDecl.formatted().description
+}
+
+
+/// Generate a struct that serves as a stack storage for multiple pointers, so that a pointer to it can be passed to Godot as `pargs` parameter.
+///
+/// ```swift
+/// struct UnsafeRawPointersN3 {
+///     let p0: UnsafeRawPointer?
+///     let p1: UnsafeRawPointer?
+///     let p2: UnsafeRawPointer?
+/// }
+/// ```
+
+private func generateUnsafeRawPointersN(pointerCount count: Int) -> String {
+    let syntax = StructDeclSyntax(name: "UnsafeRawPointersN\(raw: count)") {
+        for i in 0..<count {
+            "let p\(raw: i): UnsafeRawPointer?"
+        }
+    }
+        
+    return syntax.formatted().description
+}
+
+
+/// Generate methods to put the unsafe pointers into the `UnsafeRawPointersN#` to provide a scope to execute logic using the unsafe pointer to that struct.
+///
+/// ```swift
+/// func withUnsafePointerToUnsafePointers<T0, T1, T2, R>(storing v0: inout T0, _ v1: inout T1, _ v2: inout T2, _ body: (UnsafePointer<UnsafeRawPointersN3>) -> R) -> R {
+///     withUnsafePointers(to: &v0, &v1, &v2) { p0, p1, p2 in
+///         var storage = UnsafeRawPointersN3(p0: p0, p1: p1, p2: p2)
+///
+///         return withUnsafePointer(to: &storage) { ptr in
+///             body(ptr)
+///         }
+///     }
+/// }
+/// ```
+private func generateWithUnsafePointerToUnsafePointersStoring(argumentsCount count: Int) -> String {
+    let funcDecl = FunctionDeclSyntax(
+        name: "withUnsafePointerToUnsafePointers",
+        genericParameterClause: GenericParameterClauseSyntax(parameters: GenericParameterListSyntax {
+            for i in 0..<count {
+                GenericParameterSyntax(name: "T\(raw: i)")
+            }
+            
+            GenericParameterSyntax(name: "R")
+        }),
+        signature: FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax {
+                for i in 0..<count {
+                    FunctionParameterSyntax(
+                        
+                        firstName: i == 0 ? "storing" : "_",
+                        secondName: "v\(raw: i)",
+                        type: AttributedTypeSyntax(
+                            specifier: TokenSyntax(stringLiteral: "inout"),
+                            baseType: TypeSyntax(stringLiteral: "T\(i)")
+                        )
+                    )
+                }
+                
+                FunctionParameterSyntax(stringLiteral: "_ body: (UnsafePointer<UnsafeRawPointersN\(count)>) -> R")
+            },
+            returnClause: ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "R"))
+        )
+    ) {
+        let vParameters = (0..<count).map { i in
+            "&v\(i)"
+        }.joined(separator: ", ")
+        
+        let pParameters = (0..<count).map { i in
+            "p\(i)"
+        }.joined(separator: ", ")
+        
+        let storageInitParameters = (0..<count).map { i in
+            "p\(i): p\(i)"
+        }.joined(separator: ", ")
+        
+        """
+        withUnsafePointers(to: \(raw: vParameters)) { \(raw: pParameters) in
+            var storage = UnsafeRawPointersN\(raw: count)(\(raw: storageInitParameters))
+        
+            return withUnsafePointer(to: &storage) { ptr in
+                body(ptr)
+            }
+        }
+        """
+    }
+    
+    return funcDecl.formatted().description
+}

--- a/Generator/Generator/UnsafePointerHelpers.swift
+++ b/Generator/Generator/UnsafePointerHelpers.swift
@@ -6,85 +6,15 @@ func generateUnsafePointerHelpers(_ p: Printer) {
     let maxNestingDepth = 16
     
     for i in 1..<maxNestingDepth {
-        p(generateWithUnsafePointers(withDepth: i))
-        p("")
-    }
-    
-    for i in 1..<maxNestingDepth {
         p(generateUnsafeRawPointersN(pointerCount: i))
         p("")
     }
     
     for i in 1..<maxNestingDepth {
-        p(generateWithUnsafePointerToUnsafePointersStoring(argumentsCount: i))
+        p(generateWithUnsafeArgumentsPointer(argumentsCount: i))
         p("")
     }
 }
-
-/// Generate a method nesting access to unsafe pointers to passed inout parameters and to allow executing a lambda in scope where all of these pointers are valid.
-///
-/// ```swift
-/// func withUnsafePointers<T0, T1, T2, R>(to v0: inout T0, _ v1: inout T1, _ v2: inout T2, _ body: (UnsafePointer<T0>, UnsafePointer<T1>, UnsafePointer<T2>) -> R) -> R {
-///     withUnsafePointer(to: v0) { p0 in
-///         withUnsafePointer(to: v1) { p1 in
-///             withUnsafePointer(to: v2) { p2 in
-///                 body(p0, p1, p2)
-///             }
-///         }
-///     }
-/// }
-/// ```
-private func generateWithUnsafePointers(withDepth depth: Int) -> String {
-    func codeBlockItemSyntax(currentDepth: Int = 0, maxDepth: Int) -> String {
-        if currentDepth == maxDepth {
-            let args = (0...maxDepth).map { i in
-                "p\(i)"
-            }.joined(separator: ", ")
-            
-            return "withUnsafePointer(to: v\(currentDepth)) { p\(currentDepth) in body(\(args)) }"
-        } else {
-            return "withUnsafePointer(to: v\(currentDepth)) { p\(currentDepth) in \(codeBlockItemSyntax(currentDepth: currentDepth + 1, maxDepth: maxDepth)) }"
-        }
-    }
-    
-    let funcDecl = FunctionDeclSyntax(
-        name: "withUnsafePointers",
-        genericParameterClause: GenericParameterClauseSyntax(parameters: GenericParameterListSyntax {
-            for i in 0..<depth {
-                GenericParameterSyntax(name: "T\(raw: i)")
-            }
-            
-            GenericParameterSyntax(name: "R")
-        }),
-        signature: FunctionSignatureSyntax(
-            parameterClause: FunctionParameterClauseSyntax {
-                for i in 0..<depth {
-                    FunctionParameterSyntax(
-                        
-                        firstName: i == 0 ? "to" : "_",
-                        secondName: "v\(raw: i)",
-                        type: AttributedTypeSyntax(
-                            specifier: TokenSyntax(stringLiteral: "inout"),
-                            baseType: TypeSyntax(stringLiteral: "T\(i)")
-                        )
-                    )
-                }
-                
-                let bodyParameters = (0..<depth).map { i in
-                    "UnsafePointer<T\(i)>"
-                }.joined(separator: ", ")
-                
-                FunctionParameterSyntax(stringLiteral: "_ body: (\(bodyParameters)) -> R")
-            },
-            returnClause: ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "R"))
-        )
-    ) {
-        CodeBlockItemSyntax(stringLiteral: codeBlockItemSyntax(maxDepth: depth - 1))
-    }
-    
-    return funcDecl.formatted().description
-}
-
 
 /// Generate a struct that serves as a stack storage for multiple pointers, so that a pointer to it can be passed to Godot as `pargs` parameter.
 ///
@@ -107,22 +37,23 @@ private func generateUnsafeRawPointersN(pointerCount count: Int) -> String {
 }
 
 
-/// Generate methods to put the unsafe pointers into the `UnsafeRawPointersN#` to provide a scope to execute logic using the unsafe pointer to that struct.
+/// Generate methods to put the unsafe pointers into the `UnsafeRawPointersN#` to provide a scope to execute logic using the unsafe pointer to that struct, rebound to a
+/// `UnsafeRawPointer`. This approach works on assumption, that the struct has the same layout as a static size array of `const void *` with the same element count..
 ///
 /// ```swift
-/// func withUnsafePointerToUnsafePointers<T0, T1, T2, R>(storing v0: inout T0, _ v1: inout T1, _ v2: inout T2, _ body: (UnsafePointer<UnsafeRawPointersN3>) -> R) -> R {
-///     withUnsafePointers(to: &v0, &v1, &v2) { p0, p1, p2 in
-///         var storage = UnsafeRawPointersN3(p0: p0, p1: p1, p2: p2)
+/// func withArgumentsUnsafeRawPointer<T0, T1, T2, R>(_ p0: UnsafePointer<T0>, _ p1: UnsafePointer<T1>, _ p2: UnsafePointer<T2>, _ body: (UnsafePointer<UnsafeRawPointer?>) -> R) -> R {
+///     var storage = UnsafeRawPointersN3(p0: p0, p1: p1, p2: p2)
 ///
-///         return withUnsafePointer(to: &storage) { ptr in
-///             body(ptr)
+///     return withUnsafePointer(to: &storage) { ptr in
+///         ptr.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: 3) { rawPtr in
+///             body(rawPtr)
 ///         }
 ///     }
 /// }
 /// ```
-private func generateWithUnsafePointerToUnsafePointersStoring(argumentsCount count: Int) -> String {
+private func generateWithUnsafeArgumentsPointer(argumentsCount count: Int) -> String {
     let funcDecl = FunctionDeclSyntax(
-        name: "withUnsafePointerToUnsafePointers",
+        name: "withUnsafeArgumentsPointer",
         genericParameterClause: GenericParameterClauseSyntax(parameters: GenericParameterListSyntax {
             for i in 0..<count {
                 GenericParameterSyntax(name: "T\(raw: i)")
@@ -141,19 +72,11 @@ private func generateWithUnsafePointerToUnsafePointersStoring(argumentsCount cou
                     )
                 }
                 
-                FunctionParameterSyntax(stringLiteral: "_ body: (UnsafePointer<UnsafeRawPointersN\(count)>) -> R")
+                FunctionParameterSyntax(stringLiteral: "_ body: (UnsafePointer<UnsafeRawPointer?>) -> R")
             },
             returnClause: ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "R"))
         )
     ) {
-//        let vParameters = (0..<count).map { i in
-//            "&v\(i)"
-//        }.joined(separator: ", ")
-//        
-//        let pParameters = (0..<count).map { i in
-//            "p\(i)"
-//        }.joined(separator: ", ")
-//        
         let storageInitParameters = (0..<count).map { i in
             "p\(i): p\(i)"
         }.joined(separator: ", ")
@@ -162,7 +85,9 @@ private func generateWithUnsafePointerToUnsafePointersStoring(argumentsCount cou
             var storage = UnsafeRawPointersN\(raw: count)(\(raw: storageInitParameters))
         
             return withUnsafePointer(to: &storage) { ptr in
-                body(ptr)
+                ptr.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(raw: count)) { rawPtr in
+                    body(rawPtr)
+                }                
             }
         """
     }

--- a/Generator/Generator/UnsafePointerHelpers.swift
+++ b/Generator/Generator/UnsafePointerHelpers.swift
@@ -53,6 +53,7 @@ private func generateUnsafeRawPointersN(pointerCount count: Int) -> String {
 /// ```
 private func generateWithUnsafeArgumentsPointer(argumentsCount count: Int) -> String {
     let funcDecl = FunctionDeclSyntax(
+        attributes: "@inline(__always)",
         name: "withUnsafeArgumentsPointer",
         genericParameterClause: GenericParameterClauseSyntax(parameters: GenericParameterListSyntax {
             for i in 0..<count {

--- a/Generator/Generator/UnsafePointerHelpers.swift
+++ b/Generator/Generator/UnsafePointerHelpers.swift
@@ -135,12 +135,9 @@ private func generateWithUnsafePointerToUnsafePointersStoring(argumentsCount cou
                 for i in 0..<count {
                     FunctionParameterSyntax(
                         
-                        firstName: i == 0 ? "storing" : "_",
-                        secondName: "v\(raw: i)",
-                        type: AttributedTypeSyntax(
-                            specifier: TokenSyntax(stringLiteral: "inout"),
-                            baseType: TypeSyntax(stringLiteral: "T\(i)")
-                        )
+                        firstName: "_",
+                        secondName: "p\(raw: i)",
+                        type: TypeSyntax(stringLiteral: "UnsafePointer<T\(i)>")
                     )
                 }
                 
@@ -149,26 +146,24 @@ private func generateWithUnsafePointerToUnsafePointersStoring(argumentsCount cou
             returnClause: ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "R"))
         )
     ) {
-        let vParameters = (0..<count).map { i in
-            "&v\(i)"
-        }.joined(separator: ", ")
-        
-        let pParameters = (0..<count).map { i in
-            "p\(i)"
-        }.joined(separator: ", ")
-        
+//        let vParameters = (0..<count).map { i in
+//            "&v\(i)"
+//        }.joined(separator: ", ")
+//        
+//        let pParameters = (0..<count).map { i in
+//            "p\(i)"
+//        }.joined(separator: ", ")
+//        
         let storageInitParameters = (0..<count).map { i in
             "p\(i): p\(i)"
         }.joined(separator: ", ")
         
         """
-        withUnsafePointers(to: \(raw: vParameters)) { \(raw: pParameters) in
             var storage = UnsafeRawPointersN\(raw: count)(\(raw: storageInitParameters))
         
             return withUnsafePointer(to: &storage) { ptr in
                 body(ptr)
             }
-        }
         """
     }
     

--- a/Generator/Generator/UnsafePointerHelpers.swift
+++ b/Generator/Generator/UnsafePointerHelpers.swift
@@ -38,10 +38,10 @@ private func generateUnsafeRawPointersN(pointerCount count: Int) -> String {
 
 
 /// Generate methods to put the unsafe pointers into the `UnsafeRawPointersN#` to provide a scope to execute logic using the unsafe pointer to that struct, rebound to a
-/// `UnsafeRawPointer`. This approach works on assumption, that the struct has the same layout as a static size array of `const void *` with the same element count..
+/// `UnsafeRawPointer`. This approach works on assumption, that the struct has the same layout as a static size array of `const void *` with the same element count.
 ///
 /// ```swift
-/// func withArgumentsUnsafeRawPointer<T0, T1, T2, R>(_ p0: UnsafePointer<T0>, _ p1: UnsafePointer<T1>, _ p2: UnsafePointer<T2>, _ body: (UnsafePointer<UnsafeRawPointer?>) -> R) -> R {
+/// func withUnsafeArgumentsPointer<T0, T1, T2, R>(_ p0: UnsafePointer<T0>, _ p1: UnsafePointer<T1>, _ p2: UnsafePointer<T2>, _ body: (UnsafePointer<UnsafeRawPointer?>) -> R) -> R {
 ///     var storage = UnsafeRawPointersN3(p0: p0, p1: p1, p2: p2)
 ///
 ///     return withUnsafePointer(to: &storage) { ptr in

--- a/Generator/Generator/UnsafePointerHelpers.swift
+++ b/Generator/Generator/UnsafePointerHelpers.swift
@@ -80,15 +80,15 @@ private func generateWithUnsafeArgumentsPointer(argumentsCount count: Int) -> St
         let storageInitParameters = (0..<count).map { i in
             "p\(i): p\(i)"
         }.joined(separator: ", ")
+                
+        "var storage = UnsafeRawPointersN\(raw: count)(\(raw: storageInitParameters))"
         
         """
-            var storage = UnsafeRawPointersN\(raw: count)(\(raw: storageInitParameters))
-        
-            return withUnsafePointer(to: &storage) { ptr in
-                ptr.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(raw: count)) { rawPtr in
-                    body(rawPtr)
-                }                
-            }
+        return withUnsafePointer(to: &storage) { ptr in
+            ptr.withMemoryRebound(to: UnsafeRawPointer?.self, capacity: \(raw: count)) { rawPtr in
+                body(rawPtr)
+            }                
+        }
         """
     }
     

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -122,6 +122,7 @@ let semaphore = DispatchSemaphore(value: 0)
 let _ = Task {
     let coreDefPrinter = await PrinterFactory.shared.initPrinter("core-defs")
     coreDefPrinter.preamble()
+    generateUnsafePointerHelpers(coreDefPrinter)
     generateEnums(coreDefPrinter, cdef: nil, values: jsonApi.globalEnums, prefix: "")
     await generateBuiltinClasses(values: jsonApi.builtinClasses, outputDir: generatedBuiltinDir)
     await generateUtility(values: jsonApi.utilityFunctions, outputDir: generatedBuiltinDir)

--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,8 @@ var targets: [Target] = [
         name: "Generator",
         dependencies: [
             "ExtensionApi",
+            .product(name: "SwiftSyntax", package: "swift-syntax"),
+            .product(name: "SwiftSyntaxBuilder", package: "swift-syntax")
         ],
         path: "Generator",
         exclude: ["README.md"]),

--- a/Package.swift
+++ b/Package.swift
@@ -69,7 +69,12 @@ var targets: [Target] = [
             .product(name: "SwiftSyntaxBuilder", package: "swift-syntax")
         ],
         path: "Generator",
-        exclude: ["README.md"]),
+        exclude: ["README.md"],
+        swiftSettings: [
+            // Uncomment for using legacy array-based marshalling
+            //.define("LEGACY_MARSHALING")
+        ]
+    ),
     
     // This is a build-time plugin that invokes the generator and produces
     // the bindings that are compiled into SwiftGodot

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ func setupScene (level: GDExtension.InitializationLevel) {
 }
 
 // Export our entry point to Godot:
-@_cdecl ("swift_entry_point")
+@_cdecl("swift_entry_point")
 public func swift_entry_point(
     interfacePtr: OpaquePointer?,
     libraryPtr: OpaquePointer?,

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -186,7 +186,7 @@ func setupScene (level: GDExtension.InitializationLevel) {
 }
 
 // Set the swift.gdextension's entry_symbol to "swift_entry_point
-@_cdecl ("swift_entry_point")
+@_cdecl("swift_entry_point")
 public func swift_entry_point(
     godotGetProcAddr: OpaquePointer?,
     libraryPtr: OpaquePointer?,

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -141,7 +141,7 @@ class SwiftSprite2: Sprite2D {
     // This callback style receives the arguments from Godot as an array of Variants, and returns a Variant
     // harder than using the macros above
     var food: String = "none"
-    func demoSetFavoriteFood (args: [Variant]) -> Variant? {
+    func demoSetFavoriteFood (args: borrowing Arguments) -> Variant? {
         guard let arg = args.first else {
             print ("Method registered taking one argument got none")
             return nil
@@ -151,7 +151,7 @@ class SwiftSprite2: Sprite2D {
         return nil
     }
     
-    func demoGetFavoriteFood (args: [Variant]) -> Variant? {
+    func demoGetFavoriteFood (args: borrowing Arguments) -> Variant? {
         return Variant(food)
     }
 

--- a/Sources/SwiftGodot/Core/Arguments.swift
+++ b/Sources/SwiftGodot/Core/Arguments.swift
@@ -1,0 +1,114 @@
+/// A lightweight non-copyable storage for arguments marshalled to implementations where a sequence of `Variant`s is expected.
+/// If you need a copy of `Variant`s inside, you can construct an array using `Array.init(_ args: borrowing Arguments)`
+/// Elements can be accessed using subscript operator.
+public struct Arguments: ~Copyable {
+    enum Contents {
+        struct UnsafeGodotArgs {
+            let pargs: UnsafePointer<UnsafeRawPointer?>
+            let count: Int
+            
+            var first: Variant? {
+                if count > 0 {
+                    return retrieveVariant(at: 0)
+                } else {
+                    return nil
+                }
+            }
+            
+            /// Lazily reconstruct variant at `index`
+            func retrieveVariant(at index: Int) -> Variant {
+                precondition(index >= 0 && index < count, "Index \(index) out of bounds")
+                
+                guard let ptr = pargs[index] else {
+                    return Variant()
+                }
+                
+                return Variant(fromContent: ptr.assumingMemoryBound(to: Variant.ContentType.self).pointee)
+            }
+        }
+        /// User constructed and passed an array, reuse it
+        case array([Variant])
+        
+        /// Godot passed internally managed buffer, retrieve values lazily
+        case unsafeGodotArgs(UnsafeGodotArgs)
+    }
+    
+    let contents: Contents
+    
+    /// Arguments count
+    public var count: Int {
+        switch contents {
+        case .array(let array):
+            return array.count
+        case .unsafeGodotArgs(let contents):
+            return contents.count
+        }
+    }
+    
+    /// The first argument.
+    ///
+    /// If the `Arguments` is empty, the value of this property is `nil`.
+    public var first: Variant? {
+        switch contents {
+        case .unsafeGodotArgs(let contents):
+            if contents.count > 0 {
+                return contents.retrieveVariant(at: 0)
+            } else {
+                return nil
+            }
+        case .array(let array):
+            return array.first
+        }
+    }
+    
+    init(from array: [Variant]) {
+        contents = .array(array)
+    }
+    
+    init(pargs: UnsafePointer<UnsafeRawPointer?>?, argc: Int64) {
+        if let pargs, argc > 0 {
+            contents = .unsafeGodotArgs(.init(pargs: pargs, count: Int(argc)))
+        } else {
+            contents = .array([])
+        }
+    }
+    
+    init() {
+        contents = .array([])
+    }
+    
+    public subscript(_ index: Int) -> Variant {
+        get {
+            switch contents {
+            case .array(let array):
+                return array[index]
+            case .unsafeGodotArgs(let args):
+                return args.retrieveVariant(at: index)
+            }
+        }
+    }
+}
+
+/// Execute `body` and return the result of executing it taking temporary storage keeping Godot managed `Variant`s stored in `pargs`.
+func withArguments<T>(pargs: UnsafePointer<UnsafeRawPointer?>?, argc: Int64, _ body: (borrowing Arguments) -> T) -> T {
+    let arguments = Arguments(pargs: pargs, argc: argc)
+    let result = body(arguments)
+    return result
+}
+
+func withArguments<T>(from array: [Variant], _ body: (borrowing Arguments) -> T) -> T {
+    body(Arguments(from: array))
+}
+
+public extension Array where Element == Variant {
+    init(_ args: borrowing Arguments) {
+        switch args.contents {
+        case .array(let array):
+            self = array
+        case .unsafeGodotArgs(let args):
+            self = (0..<args.count).map { i in
+                args.retrieveVariant(at: i)
+            }
+        }
+    }
+}

--- a/Sources/SwiftGodot/Core/Arguments.swift
+++ b/Sources/SwiftGodot/Core/Arguments.swift
@@ -27,6 +27,7 @@ public struct Arguments: ~Copyable {
             }
         }
         /// User constructed and passed an array, reuse it
+        /// It's also cheap to use in a case with no arguments, Swift array impl will just hold a null pointer inside.
         case array([Variant])
         
         /// Godot passed internally managed buffer, retrieve values lazily

--- a/Sources/SwiftGodot/Core/Arguments.swift
+++ b/Sources/SwiftGodot/Core/Arguments.swift
@@ -23,7 +23,7 @@ public struct Arguments: ~Copyable {
                     return Variant()
                 }
                 
-                return Variant(fromContent: ptr.assumingMemoryBound(to: Variant.ContentType.self).pointee)
+                return Variant(copying: ptr.assumingMemoryBound(to: Variant.ContentType.self).pointee)
             }
         }
         /// User constructed and passed an array, reuse it

--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  ClassServices.swift
+//
 //
 //  Created by Miguel de Icaza on 4/13/23.
 //
@@ -42,7 +42,7 @@ public class ClassInfo<T:Object> {
     ///
     /// Users of your signal can then connect to the signal using the ``Object/connect(signal:callable:flags:)``
     /// method.
-    /// 
+    ///
     /// - Parameters:
     ///  - name: the name we want to use to register the signal
     ///  - arguments: an array of PropInfo structures that describe each argument that must be passed to the signal
@@ -58,7 +58,7 @@ public class ClassInfo<T:Object> {
     }
     
     // Here so we can box the function pointer
-    class FunctionInfo {
+    struct FunctionInfo {
         var function: (T) -> (borrowing Arguments) -> Variant?
         var retType: Variant.GType?
         var ttype: T.Type
@@ -133,13 +133,14 @@ public class ClassInfo<T:Object> {
         if let returnValue {
             retInfo = returnValue.makeNativeStruct()
         }
-        let functionInfo = Unmanaged.passRetained(FunctionInfo (function, retType: returnValue?.propertyType))
+        let userdata = UnsafeMutablePointer<FunctionInfo>.allocate(capacity: 1)
+        userdata.initialize(to: .init(function, retType: returnValue?.propertyType))
         
         withUnsafeMutablePointer(to: &name.content) { namePtr in
             withUnsafeMutablePointer(to: &retInfo) { retInfoPtr in
             var info = GDExtensionClassMethodInfo (
                 name: namePtr,
-                method_userdata: functionInfo.toOpaque(),
+                method_userdata: userdata,
                 call_func: bind_call,
                 ptrcall_func: nil, //ClassInfo.bind_call_ptr,
                 method_flags: UInt32 (flags.rawValue),
@@ -252,25 +253,15 @@ func bind_call (_ udata: UnsafeMutableRawPointer?,
                 r_error: UnsafeMutablePointer<GDExtensionCallError>?){
     guard let udata else { return }
     guard let classInstance else { return }
+        
+    let finfo = udata.assumingMemoryBound(to: ClassInfo.FunctionInfo.self).pointee
+    let object = Unmanaged<Object>.fromOpaque(classInstance).takeUnretainedValue()
     
-    let finfoPtr: Unmanaged<ClassInfo.FunctionInfo> = Unmanaged.fromOpaque(udata)
-    let finfo = finfoPtr.takeUnretainedValue()
-    let target : Unmanaged<Object> = Unmanaged.fromOpaque(classInstance)
-    
-    var args: [Variant] = []
-    
-    if let variantArgs {
-        for i in 0..<Int (argc) {
-            guard let va = variantArgs [i] else {
-                args.append (Variant())
-                continue
-            }
-            let ct = va.assumingMemoryBound(to: Variant.ContentType.self)
-            args.append (Variant (fromContent: ct.pointee))
-        }
+    let ret = withArguments(pargs: variantArgs, argc: argc) { arguments in
+        let bound = finfo.function(object)
+        return bound(arguments)
     }
-    let bound = finfo.function (target.takeUnretainedValue())
-    let ret = bound (Arguments(from: args))
+
     if let returnValue, let ret {
         if ret.gtype != finfo.retType {
             print ("Your declared function should return the type originally set \(String(describing: finfo.retType)) and \(ret.gtype)")

--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -59,11 +59,11 @@ public class ClassInfo<T:Object> {
     
     // Here so we can box the function pointer
     class FunctionInfo {
-        var function: (T) -> ([Variant]) -> Variant?
+        var function: (T) -> (borrowing Arguments) -> Variant?
         var retType: Variant.GType?
         var ttype: T.Type
         
-        init (_ function: @escaping (T) -> ([Variant]) -> Variant?, retType: Variant.GType?) {
+        init (_ function: @escaping (T) -> (borrowing Arguments) -> Variant?, retType: Variant.GType?) {
             self.function = function
             self.retType = retType
             self.ttype = T.self
@@ -95,7 +95,7 @@ public class ClassInfo<T:Object> {
     ///     let _ = initClass ()
     ///   }
     ///
-    ///   func checkBaddies (args: [Variant]) -> Variant? {
+    ///   func checkBaddies (args: borrowing Arguments) -> Variant? {
     ///     // We are getting one integer if called from Godot of type Int
     ///     // validate in case you called this directly from Swift
     ///     guard args.count > 0 else {
@@ -117,7 +117,7 @@ public class ClassInfo<T:Object> {
     ///  - returnValue: if nil, this method does not return a value, otherwise, the descritption of the return value as a PropInfo
     ///  - arguments: an array describing the parameters that this method takes
     ///  - function: this is a curried function that will be registered.   It will be invoked on the instance of your object
-    public func registerMethod (name: StringName, flags: MethodFlags, returnValue: PropInfo?, arguments: [PropInfo], function: @escaping (T) -> ([Variant]) -> Variant?) {
+    public func registerMethod (name: StringName, flags: MethodFlags, returnValue: PropInfo?, arguments: [PropInfo], function: @escaping (T) -> (borrowing Arguments) -> Variant?) {
         let argPtr = UnsafeMutablePointer<GDExtensionPropertyInfo>.allocate(capacity: arguments.count)
         defer { argPtr.deallocate() }
         let argMeta = UnsafeMutablePointer<GDExtensionClassMethodArgumentMetadata>.allocate(capacity: arguments.count)
@@ -270,7 +270,7 @@ func bind_call (_ udata: UnsafeMutableRawPointer?,
         }
     }
     let bound = finfo.function (target.takeUnretainedValue())
-    let ret = bound (args)
+    let ret = bound (Arguments(from: args))
     if let returnValue, let ret {
         if ret.gtype != finfo.retType {
             print ("Your declared function should return the type originally set \(String(describing: finfo.retType)) and \(ret.gtype)")

--- a/Sources/SwiftGodot/Core/GArray.swift
+++ b/Sources/SwiftGodot/Core/GArray.swift
@@ -28,7 +28,7 @@ extension GArray {
                 return Variant()
             }
             let ptr = ret.assumingMemoryBound(to: Variant.ContentType.self)
-            return Variant(fromContent: ptr.pointee)
+            return Variant(copying: ptr.pointee)
         }
         set {
             guard let ret = gi.array_operator_index (&content, Int64 (index)) else {

--- a/Sources/SwiftGodot/Core/InspectableProperty.swift
+++ b/Sources/SwiftGodot/Core/InspectableProperty.swift
@@ -8,7 +8,7 @@
 /// A structure that houses a property that can be added to a Godot inspector.
 public struct InspectableProperty<T> {
     /// A typealias for the the method type used to register a property to Godot for inspectors.
-    public typealias RegisteredPropertyFunction = (T) -> ([Variant]) -> Variant?
+    public typealias RegisteredPropertyFunction = (T) -> (borrowing Arguments) -> Variant?
 
     /// The host object the property derives from.
     public let hostObject: T.Type

--- a/Sources/SwiftGodot/Core/SignalSupport.swift
+++ b/Sources/SwiftGodot/Core/SignalSupport.swift
@@ -29,7 +29,7 @@ public class SignalProxy: Object {
     } ()
     
     /// The code invoked when Godot invokes the `proxy` method on this object.
-    public typealias Proxy = ([Variant]) -> ()
+    public typealias Proxy = (borrowing Arguments) -> ()
     public var proxy: Proxy?
     
     public required init () {
@@ -41,7 +41,7 @@ public class SignalProxy: Object {
         super.init (nativeHandle: nativeHandle)
     }
     
-    func proxyFunc (args: [Variant]) -> Variant? {
+    func proxyFunc (args: borrowing Arguments) -> Variant? {
         proxy? (args)
         return nil
     }

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -568,7 +568,16 @@ struct CallableWrapper {
         err?.pointee.error = GDEXTENSION_CALL_OK
     }
     
-    static func callableVariantContent(wrapping function: @escaping (borrowing Arguments) -> Variant?) -> Callable.ContentType {
+    @available(*, deprecated, message: "Use version taking `@escaping (borrowing Arguments) -> Variant?` instead.")    
+    static func callableVariantContent(wrapping function: @escaping ([Variant]) -> Variant?) -> Callable.ContentType {
+        callableVariantContent { (arguments: borrowing Arguments) in
+            let array = Array(arguments)
+            let result = function(array)
+            return result ?? Variant()
+        }
+    }
+    
+    static func callableVariantContent(wrapping function: @escaping (borrowing Arguments) -> Variant) -> Callable.ContentType {
         let wrapperPtr = UnsafeMutablePointer<Self>.allocate(capacity: 1)
         wrapperPtr.initialize(to: Self(function: function))
         

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -554,7 +554,7 @@ func callableProxy (userData: UnsafeMutableRawPointer?, pargs: UnsafePointer<Uns
             args.append (variant)
         }
     }
-    if let methodRet = wrapper.method (args) {
+    if let methodRet = wrapper.method (Arguments(from: args)) {
         retPtr!.storeBytes(of: methodRet.content, as: type (of: methodRet.content))
     }
     err?.pointee.error = GDEXTENSION_CALL_OK
@@ -567,12 +567,12 @@ func freeMethodWrapper (ptr: UnsafeMutableRawPointer?) {
 }
 
 class CallableWrapper {
-    var method: ([Variant])->Variant?
-    init (method: @escaping ([Variant])->Variant?) {
+    var method: (borrowing Arguments)->Variant?
+    init (method: @escaping (borrowing Arguments)->Variant?) {
         self.method = method
     }
     
-    static func makeCallable (_ method: @escaping ([Variant])->Variant?) -> Callable.ContentType {
+    static func makeCallable (_ method: @escaping (borrowing Arguments)->Variant?) -> Callable.ContentType {
         let wrapper = CallableWrapper(method: method)
         let retained = Unmanaged.passRetained(wrapper)
         

--- a/Sources/SwiftGodot/EntryPoint.swift
+++ b/Sources/SwiftGodot/EntryPoint.swift
@@ -329,7 +329,7 @@ func loadGodotInterface (_ godotGetProcAddrPtr: GDExtensionInterfaceGetProcAddre
 /// your Swift entry point, which can look like this:
 ///
 /// ```
-/// @cdecl ("swift_entry_point")
+/// @cdecl("swift_entry_point")
 /// public func swift_entry_point (i: OpaquePointer?, l: OpaquePointer?, e: OpaquePointer?) -> UInt8 {
 ///     guard let iface, let lib, let ext else {
 ///         return 0

--- a/Sources/SwiftGodot/Extensions/ClassInfo+ConvenienceProperties.swift
+++ b/Sources/SwiftGodot/Extensions/ClassInfo+ConvenienceProperties.swift
@@ -33,7 +33,7 @@ public protocol Nameable {
 
 extension ClassInfo {
     /// A type alias referencing a class info function that can be registered.
-    public typealias ClassInfoFunction = (T) -> ([Variant]) -> Variant?
+    public typealias ClassInfoFunction = (T) -> (borrowing Arguments) -> Variant?
 
     /// A type alias referencing a registerable int enum.
     public typealias RegisteredIntEnum = CaseIterable & Nameable & RawRepresentable<Int>
@@ -43,7 +43,7 @@ extension ClassInfo {
     /// This can be used inside setter method to set a property in-class with a guaranteed argument value.
     ///
     /// ```swift
-    /// func setBubbleCount(args: [Variant]) -> Variant? {
+    /// func setBubbleCount(args: borrowing Arguments) -> Variant? {
     ///     withCheckedProperty(named: "bubbles", in: args) { argument in
     ///         self.bubbles = Int(argument) ?? 0
     ///     }
@@ -54,7 +54,7 @@ extension ClassInfo {
     /// - Parameter arguments: The list of arguments that were passed from the setter.
     /// - Parameter action: A closure that accepts a valid argument.
     public static func withCheckedProperty(named name: String,
-                                           in arguments: [Variant],
+                                           in arguments: borrowing Arguments,
                                            perform action: (Variant) -> Void) -> Variant? {
         guard let arg = arguments.first else {
             GD.pushError("Expected argument for \(name), but got nil instead.")

--- a/Sources/SwiftGodot/SwiftGodot.docc/CustomTypes.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/CustomTypes.md
@@ -66,7 +66,7 @@ func setupScene (level: GDExtension.InitializationLevel) {
 
 /// This is the entry point referenced from the `.gdextension` file
 /// that you used to declare the Swift extension:
-@_cdecl ("swift_entry_point")
+@_cdecl("swift_entry_point")
 public func swift_entry_point(
     interfacePtr: OpaquePointer?,
     libraryPtr: OpaquePointer?,

--- a/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
@@ -206,7 +206,7 @@ In SwiftGodot, you can create `Callable` instances by directly passing a Swift f
 and returns an optional `Variant` result, like this:
 
 ```swift
-func myCallback(args: [Variant])-> Variant? {
+func myCallback(args: borrowing Arguments)-> Variant? {
 	print ("MyCallback invoked with \(args.count) arguments")
 	return nil
 }

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -15,7 +15,7 @@ import SwiftSyntaxMacros
 public struct GodotCallable: PeerMacro {
     static func process (funcDecl: FunctionDeclSyntax) throws -> String {
         let funcName = funcDecl.name.text
-        var genMethod = "func _mproxy_\(funcName) (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {\n"
+        var genMethod = "func _mproxy_\(funcName) (args: borrowing Arguments) -> SwiftGodot.Variant? {\n"
         var retProp: String? = nil
         var retOptional: Bool = false
 		

--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -20,7 +20,7 @@ public struct GodotExport: PeerMacro {
         if isEnum {
             return
     """
-    func \(name) (args: [Variant]) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> Variant? {
         return Variant (\(varName).rawValue)
     }
     """
@@ -29,7 +29,7 @@ public struct GodotExport: PeerMacro {
         if isOptional {
             return
     """
-    func \(name) (args: [Variant]) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> Variant? {
         guard let result = \(varName) else { return nil }
         return Variant (result)
     }
@@ -37,7 +37,7 @@ public struct GodotExport: PeerMacro {
         } else {
             return
     """
-    func \(name) (args: [Variant]) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> Variant? {
         return Variant (\(varName))
     }
     """
@@ -93,7 +93,7 @@ public struct GodotExport: PeerMacro {
     """
             }
         }
-        return "func \(name) (args: [Variant]) -> Variant? {\n\(body)\n\treturn nil\n}"
+        return "func \(name) (args: borrowing Arguments) -> Variant? {\n\(body)\n\treturn nil\n}"
     }
 
     
@@ -198,7 +198,7 @@ public struct GodotExport: PeerMacro {
 private extension GodotExport {
     private static func makeGArrayCollectionGetProxyAccessor(varName: String, elementTypeName: String) -> String {
 		"""
-		func _mproxy_get_\(varName)(args: [Variant]) -> Variant? {
+		func _mproxy_get_\(varName)(args: borrowing Arguments) -> Variant? {
 			return Variant(\(varName).array)
 		}
 		"""
@@ -206,7 +206,7 @@ private extension GodotExport {
     
     private static func makeGArrayCollectionSetProxyAccessor(varName: String, elementTypeName: String) -> String {
 		"""
-		func _mproxy_set_\(varName)(args: [Variant]) -> Variant? {
+		func _mproxy_set_\(varName)(args: borrowing Arguments) -> Variant? {
 			guard let arg = args.first,
 				  let gArray = GArray(arg),
 				  gArray.isTyped(),

--- a/Sources/SwiftGodotTestability/GodotRuntime.swift
+++ b/Sources/SwiftGodotTestability/GodotRuntime.swift
@@ -5,6 +5,7 @@
 //  Created by Mikhail Tishin on 22.10.2023.
 //
 
+import Foundation
 import libgodot
 @testable import SwiftGodot
 

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -33,7 +33,7 @@ class Car: Node {
 class Car: Node {
     var vehicle_make: String = "Mazda"
 
-    func _mproxy_set_vehicle_make (args: [Variant]) -> Variant? {
+    func _mproxy_set_vehicle_make (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -45,12 +45,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_vehicle_make (args: [Variant]) -> Variant? {
+    func _mproxy_get_vehicle_make (args: borrowing Arguments) -> Variant? {
         return Variant (vehicle_make)
     }
     var vehicle_model: String = "RX7"
 
-    func _mproxy_set_vehicle_model (args: [Variant]) -> Variant? {
+    func _mproxy_set_vehicle_model (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -62,7 +62,7 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_vehicle_model (args: [Variant]) -> Variant? {
+    func _mproxy_get_vehicle_model (args: borrowing Arguments) -> Variant? {
         return Variant (vehicle_model)
     }
 
@@ -119,7 +119,7 @@ class Car: Node {
 class Car: Node {
     var make: String = "Mazda"
 
-    func _mproxy_set_make (args: [Variant]) -> Variant? {
+    func _mproxy_set_make (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -131,12 +131,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_make (args: [Variant]) -> Variant? {
+    func _mproxy_get_make (args: borrowing Arguments) -> Variant? {
         return Variant (make)
     }
     var model: String = "RX7"
 
-    func _mproxy_set_model (args: [Variant]) -> Variant? {
+    func _mproxy_set_model (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -148,7 +148,7 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_model (args: [Variant]) -> Variant? {
+    func _mproxy_get_model (args: borrowing Arguments) -> Variant? {
         return Variant (model)
     }
 
@@ -206,7 +206,7 @@ class Car: Node {
 class Car: Node {
     var vin: String = "00000000000000000"
 
-    func _mproxy_set_vin (args: [Variant]) -> Variant? {
+    func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -218,12 +218,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_vin (args: [Variant]) -> Variant? {
+    func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
         return Variant (vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year (args: [Variant]) -> Variant? {
+    func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -235,7 +235,7 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_year (args: [Variant]) -> Variant? {
+    func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
         return Variant (year)
     }
 
@@ -292,7 +292,7 @@ class Car: Node {
 class Car: Node {
     var vin: String = "00000000000000000"
 
-    func _mproxy_set_vin (args: [Variant]) -> Variant? {
+    func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -304,12 +304,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_vin (args: [Variant]) -> Variant? {
+    func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
         return Variant (vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year (args: [Variant]) -> Variant? {
+    func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -321,7 +321,7 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_year (args: [Variant]) -> Variant? {
+    func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
         return Variant (year)
     }
 
@@ -382,7 +382,7 @@ class Car: Node {
 class Car: Node {
     var vin: String = ""
 
-    func _mproxy_set_vin (args: [Variant]) -> Variant? {
+    func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -394,12 +394,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_vin (args: [Variant]) -> Variant? {
+    func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
         return Variant (vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year (args: [Variant]) -> Variant? {
+    func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -411,12 +411,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_year (args: [Variant]) -> Variant? {
+    func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
         return Variant (year)
     }
     var make: String = "HONDA"
 
-    func _mproxy_set_make (args: [Variant]) -> Variant? {
+    func _mproxy_set_make (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -428,12 +428,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_make (args: [Variant]) -> Variant? {
+    func _mproxy_get_make (args: borrowing Arguments) -> Variant? {
         return Variant (make)
     }
     var model: String = "ACCORD"
 
-    func _mproxy_set_model (args: [Variant]) -> Variant? {
+    func _mproxy_set_model (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -445,7 +445,7 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_model (args: [Variant]) -> Variant? {
+    func _mproxy_get_model (args: borrowing Arguments) -> Variant? {
         return Variant (model)
     }
 
@@ -524,11 +524,11 @@ class Car: Node {
 class Car: Node {
     var makes: VariantCollection<String> = ["Mazda"]
 
-    func _mproxy_get_makes(args: [Variant]) -> Variant? {
+    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
     	return Variant(makes.array)
     }
 
-    func _mproxy_set_makes(args: [Variant]) -> Variant? {
+    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -540,11 +540,11 @@ class Car: Node {
     }
     var model: VariantCollection<String> = ["RX7"]
 
-    func _mproxy_get_model(args: [Variant]) -> Variant? {
+    func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
     	return Variant(model.array)
     }
 
-    func _mproxy_set_model(args: [Variant]) -> Variant? {
+    func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -609,11 +609,11 @@ class Car: Node {
 class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
     	return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -625,11 +625,11 @@ class Car: Node {
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
     	return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -693,11 +693,11 @@ class Car: Node {
 class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
     	return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -709,11 +709,11 @@ class Car: Node {
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
     	return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -781,11 +781,11 @@ class Car: Node {
 class Car: Node {
     var vins: VariantCollection<String> = [""]
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
     	return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -797,11 +797,11 @@ class Car: Node {
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
     	return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -813,11 +813,11 @@ class Car: Node {
     }
     var makes: VariantCollection<String> = ["HONDA"]
 
-    func _mproxy_get_makes(args: [Variant]) -> Variant? {
+    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
     	return Variant(makes.array)
     }
 
-    func _mproxy_set_makes(args: [Variant]) -> Variant? {
+    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -829,11 +829,11 @@ class Car: Node {
     }
     var models: VariantCollection<String> = ["ACCORD"]
 
-    func _mproxy_get_models(args: [Variant]) -> Variant? {
+    func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
     	return Variant(models.array)
     }
 
-    func _mproxy_set_models(args: [Variant]) -> Variant? {
+    func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -921,11 +921,11 @@ class Car: Node {
 class Car: Node {
     var makes: ObjectCollection<Node> = []
 
-    func _mproxy_get_makes(args: [Variant]) -> Variant? {
+    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
     	return Variant(makes.array)
     }
 
-    func _mproxy_set_makes(args: [Variant]) -> Variant? {
+    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -937,11 +937,11 @@ class Car: Node {
     }
     var model: ObjectCollection<Node> = []
 
-    func _mproxy_get_model(args: [Variant]) -> Variant? {
+    func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
     	return Variant(model.array)
     }
 
-    func _mproxy_set_model(args: [Variant]) -> Variant? {
+    func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1005,11 +1005,11 @@ class Car: Node {
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
     	return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1021,11 +1021,11 @@ class Car: Node {
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
     	return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1089,11 +1089,11 @@ class Car: Node {
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
     	return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1105,11 +1105,11 @@ class Car: Node {
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
     	return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1177,11 +1177,11 @@ class Car: Node {
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_get_vins(args: [Variant]) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
     	return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: [Variant]) -> Variant? {
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1193,11 +1193,11 @@ class Car: Node {
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_get_years(args: [Variant]) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
     	return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: [Variant]) -> Variant? {
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1209,11 +1209,11 @@ class Car: Node {
     }
     var makes: ObjectCollection<Node> = []
 
-    func _mproxy_get_makes(args: [Variant]) -> Variant? {
+    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
     	return Variant(makes.array)
     }
 
-    func _mproxy_set_makes(args: [Variant]) -> Variant? {
+    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1225,11 +1225,11 @@ class Car: Node {
     }
     var models: ObjectCollection<Node> = []
 
-    func _mproxy_get_models(args: [Variant]) -> Variant? {
+    func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
     	return Variant(models.array)
     }
 
-    func _mproxy_set_models(args: [Variant]) -> Variant? {
+    func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1323,7 +1323,7 @@ class Garage: Node {
 class Garage: Node {
     var name: String = ""
 
-    func _mproxy_set_name (args: [Variant]) -> Variant? {
+    func _mproxy_set_name (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -1335,12 +1335,12 @@ class Garage: Node {
     	return nil
     }
 
-    func _mproxy_get_name (args: [Variant]) -> Variant? {
+    func _mproxy_get_name (args: borrowing Arguments) -> Variant? {
         return Variant (name)
     }
     var rating: Float = 0.0
 
-    func _mproxy_set_rating (args: [Variant]) -> Variant? {
+    func _mproxy_set_rating (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -1352,16 +1352,16 @@ class Garage: Node {
     	return nil
     }
 
-    func _mproxy_get_rating (args: [Variant]) -> Variant? {
+    func _mproxy_get_rating (args: borrowing Arguments) -> Variant? {
         return Variant (rating)
     }
     var reviews: VariantCollection<String> = []
 
-    func _mproxy_get_reviews(args: [Variant]) -> Variant? {
+    func _mproxy_get_reviews(args: borrowing Arguments) -> Variant? {
     	return Variant(reviews.array)
     }
 
-    func _mproxy_set_reviews(args: [Variant]) -> Variant? {
+    func _mproxy_set_reviews(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1373,11 +1373,11 @@ class Garage: Node {
     }
     var checkIns: ObjectCollection<CheckIn> = []
 
-    func _mproxy_get_checkIns(args: [Variant]) -> Variant? {
+    func _mproxy_get_checkIns(args: borrowing Arguments) -> Variant? {
     	return Variant(checkIns.array)
     }
 
-    func _mproxy_set_checkIns(args: [Variant]) -> Variant? {
+    func _mproxy_set_checkIns(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1389,7 +1389,7 @@ class Garage: Node {
     }
     var address: String = ""
 
-    func _mproxy_set_address (args: [Variant]) -> Variant? {
+    func _mproxy_set_address (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -1401,16 +1401,16 @@ class Garage: Node {
     	return nil
     }
 
-    func _mproxy_get_address (args: [Variant]) -> Variant? {
+    func _mproxy_get_address (args: borrowing Arguments) -> Variant? {
         return Variant (address)
     }
     var daysOfOperation: VariantCollection<String> = []
 
-    func _mproxy_get_daysOfOperation(args: [Variant]) -> Variant? {
+    func _mproxy_get_daysOfOperation(args: borrowing Arguments) -> Variant? {
     	return Variant(daysOfOperation.array)
     }
 
-    func _mproxy_set_daysOfOperation(args: [Variant]) -> Variant? {
+    func _mproxy_set_daysOfOperation(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1422,11 +1422,11 @@ class Garage: Node {
     }
     var hours: VariantCollection<String> = []
 
-    func _mproxy_get_hours(args: [Variant]) -> Variant? {
+    func _mproxy_get_hours(args: borrowing Arguments) -> Variant? {
     	return Variant(hours.array)
     }
 
-    func _mproxy_set_hours(args: [Variant]) -> Variant? {
+    func _mproxy_set_hours(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1438,11 +1438,11 @@ class Garage: Node {
     }
     var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
 
-    func _mproxy_get_insuranceProvidersAccepted(args: [Variant]) -> Variant? {
+    func _mproxy_get_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
     	return Variant(insuranceProvidersAccepted.array)
     }
 
-    func _mproxy_set_insuranceProvidersAccepted(args: [Variant]) -> Variant? {
+    func _mproxy_set_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1567,7 +1567,7 @@ class Garage: Node {
 class Garage: Node {
     var bar: Bool = false
 
-    func _mproxy_set_bar (args: [Variant]) -> Variant? {
+    func _mproxy_set_bar (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -1579,7 +1579,7 @@ class Garage: Node {
     	return nil
     }
 
-    func _mproxy_get_bar (args: [Variant]) -> Variant? {
+    func _mproxy_get_bar (args: borrowing Arguments) -> Variant? {
         return Variant (bar)
     }
 
@@ -1626,7 +1626,7 @@ public class Issue353: Node {
 public class Issue353: Node {
     var prefix1_prefixed_bool: Bool = true
 
-    func _mproxy_set_prefix1_prefixed_bool (args: [Variant]) -> Variant? {
+    func _mproxy_set_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -1638,12 +1638,12 @@ public class Issue353: Node {
     	return nil
     }
 
-    func _mproxy_get_prefix1_prefixed_bool (args: [Variant]) -> Variant? {
+    func _mproxy_get_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant? {
         return Variant (prefix1_prefixed_bool)
     }
     var non_prefixed_bool: Bool = true
 
-    func _mproxy_set_non_prefixed_bool (args: [Variant]) -> Variant? {
+    func _mproxy_set_non_prefixed_bool (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -1655,7 +1655,7 @@ public class Issue353: Node {
     	return nil
     }
 
-    func _mproxy_get_non_prefixed_bool (args: [Variant]) -> Variant? {
+    func _mproxy_get_non_prefixed_bool (args: borrowing Arguments) -> Variant? {
         return Variant (non_prefixed_bool)
     }
 
@@ -1711,11 +1711,11 @@ class Garage: Node {
 class Garage: Node {
     var bar: VariantCollection<Bool> = [false]
 
-    func _mproxy_get_bar(args: [Variant]) -> Variant? {
+    func _mproxy_get_bar(args: borrowing Arguments) -> Variant? {
     	return Variant(bar.array)
     }
 
-    func _mproxy_set_bar(args: [Variant]) -> Variant? {
+    func _mproxy_set_bar(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1769,11 +1769,11 @@ public class Issue353: Node {
 public class Issue353: Node {
     var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
 
-    func _mproxy_get_prefix1_prefixed_bool(args: [Variant]) -> Variant? {
+    func _mproxy_get_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
     	return Variant(prefix1_prefixed_bool.array)
     }
 
-    func _mproxy_set_prefix1_prefixed_bool(args: [Variant]) -> Variant? {
+    func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),
@@ -1785,11 +1785,11 @@ public class Issue353: Node {
     }
     var non_prefixed_bool: VariantCollection<Bool> = [false]
 
-    func _mproxy_get_non_prefixed_bool(args: [Variant]) -> Variant? {
+    func _mproxy_get_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
     	return Variant(non_prefixed_bool.array)
     }
 
-    func _mproxy_set_non_prefixed_bool(args: [Variant]) -> Variant? {
+    func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first,
     		  let gArray = GArray(arg),
     		  gArray.isTyped(),

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -72,11 +72,11 @@ class SomeNode: Node {
 class SomeNode: Node {
 	var greetings: VariantCollection<String> = []
 
-	func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+	func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
 		return Variant(greetings.array)
 	}
 
-	func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+	func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
 		guard let arg = args.first,
 			  let gArray = GArray(arg),
 			  gArray.isTyped(),
@@ -123,11 +123,11 @@ class SomeNode: Node {
 
 var greetings: VariantCollection<String> = []
 
-func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
 	return Variant(greetings.array)
 }
 
-func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
 	guard let arg = args.first,
 		  let gArray = GArray(arg),
 		  gArray.isTyped(),
@@ -152,11 +152,11 @@ func _mproxy_set_greetings(args: [Variant]) -> Variant? {
 
 var greetings: VariantCollection<String> = []
 
-func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
 	return Variant(greetings.array)
 }
 
-func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
 	guard let arg = args.first,
 		  let gArray = GArray(arg),
 		  gArray.isTyped(),
@@ -181,11 +181,11 @@ func _mproxy_set_greetings(args: [Variant]) -> Variant? {
 
 let greetings: VariantCollection<String> = []
 
-func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
 	return Variant(greetings.array)
 }
 
-func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
 	guard let arg = args.first,
 		  let gArray = GArray(arg),
 		  gArray.isTyped(),
@@ -225,7 +225,7 @@ class SomeNode: Node {
 class SomeNode: Node {
     var someArray: GArray = GArray()
 
-    func _mproxy_set_someArray (args: [Variant]) -> Variant? {
+    func _mproxy_set_someArray (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -237,7 +237,7 @@ class SomeNode: Node {
     	return nil
     }
 
-    func _mproxy_get_someArray (args: [Variant]) -> Variant? {
+    func _mproxy_get_someArray (args: borrowing Arguments) -> Variant? {
         return Variant (someArray)
     }
 
@@ -281,11 +281,11 @@ class SomeNode: Node {
 class SomeNode: Node {
 	var someNumbers: VariantCollection<Int> = []
 
-	func _mproxy_get_someNumbers(args: [Variant]) -> Variant? {
+	func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
 		return Variant(someNumbers.array)
 	}
 
-	func _mproxy_set_someNumbers(args: [Variant]) -> Variant? {
+	func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
 		guard let arg = args.first,
 			  let gArray = GArray(arg),
 			  gArray.isTyped(),
@@ -337,11 +337,11 @@ class SomeNode: Node {
 class SomeNode: Node {
 	var someNumbers: VariantCollection<Int> = []
 
-	func _mproxy_get_someNumbers(args: [Variant]) -> Variant? {
+	func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
 		return Variant(someNumbers.array)
 	}
 
-	func _mproxy_set_someNumbers(args: [Variant]) -> Variant? {
+	func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
 		guard let arg = args.first,
 			  let gArray = GArray(arg),
 			  gArray.isTyped(),
@@ -353,11 +353,11 @@ class SomeNode: Node {
 	}
 	var someOtherNumbers: VariantCollection<Int> = []
 
-	func _mproxy_get_someOtherNumbers(args: [Variant]) -> Variant? {
+	func _mproxy_get_someOtherNumbers(args: borrowing Arguments) -> Variant? {
 		return Variant(someOtherNumbers.array)
 	}
 
-	func _mproxy_set_someOtherNumbers(args: [Variant]) -> Variant? {
+	func _mproxy_set_someOtherNumbers(args: borrowing Arguments) -> Variant? {
 		guard let arg = args.first,
 			  let gArray = GArray(arg),
 			  gArray.isTyped(),
@@ -421,11 +421,11 @@ import SwiftGodot
 class ArrayTest: Node {
    var firstNames: VariantCollection<String> = ["Thelonius"]
 
-   func _mproxy_get_firstNames(args: [Variant]) -> Variant? {
+   func _mproxy_get_firstNames(args: borrowing Arguments) -> Variant? {
    	return Variant(firstNames.array)
    }
 
-   func _mproxy_set_firstNames(args: [Variant]) -> Variant? {
+   func _mproxy_set_firstNames(args: borrowing Arguments) -> Variant? {
    	guard let arg = args.first,
    		  let gArray = GArray(arg),
    		  gArray.isTyped(),
@@ -437,11 +437,11 @@ class ArrayTest: Node {
    }
    var lastNames: VariantCollection<String> = ["Monk"]
 
-   func _mproxy_get_lastNames(args: [Variant]) -> Variant? {
+   func _mproxy_get_lastNames(args: borrowing Arguments) -> Variant? {
    	return Variant(lastNames.array)
    }
 
-   func _mproxy_set_lastNames(args: [Variant]) -> Variant? {
+   func _mproxy_set_lastNames(args: borrowing Arguments) -> Variant? {
    	guard let arg = args.first,
    		  let gArray = GArray(arg),
    		  gArray.isTyped(),
@@ -497,11 +497,11 @@ class ArrayTest: Node {
 """
 var greetings: ObjectCollection<Node3D> = []
 
-func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
 	return Variant(greetings.array)
 }
 
-func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
 	guard let arg = args.first,
 		  let gArray = GArray(arg),
 		  gArray.isTyped(),
@@ -530,11 +530,11 @@ class SomeNode: Node {
 class SomeNode: Node {
 	var greetings: ObjectCollection<Node3D> = []
 
-	func _mproxy_get_greetings(args: [Variant]) -> Variant? {
+	func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
 		return Variant(greetings.array)
 	}
 
-	func _mproxy_set_greetings(args: [Variant]) -> Variant? {
+	func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
 		guard let arg = args.first,
 			  let gArray = GArray(arg),
 			  gArray.isTyped(),

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
@@ -42,26 +42,26 @@ final class MacroGodotExportEnumTests: XCTestCase {
         class SomeNode: Node {
             var demo: Demo
 
-            func _mproxy_set_demo (args: [Variant]) -> Variant? {
+            func _mproxy_set_demo (args: borrowing Arguments) -> Variant? {
                 if let iv = Int (args [0]), let ev = Demo(rawValue: numericCast (iv)) {
                     self.demo = ev
                 }
             	return nil
             }
 
-            func _mproxy_get_demo (args: [Variant]) -> Variant? {
+            func _mproxy_get_demo (args: borrowing Arguments) -> Variant? {
                 return Variant (demo.rawValue)
             }
             var demo64: Demo64
 
-            func _mproxy_set_demo64 (args: [Variant]) -> Variant? {
+            func _mproxy_set_demo64 (args: borrowing Arguments) -> Variant? {
                 if let iv = Int (args [0]), let ev = Demo64(rawValue: numericCast (iv)) {
                     self.demo64 = ev
                 }
             	return nil
             }
 
-            func _mproxy_get_demo64 (args: [Variant]) -> Variant? {
+            func _mproxy_get_demo64 (args: borrowing Arguments) -> Variant? {
                 return Variant (demo64.rawValue)
             }
 

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
@@ -37,7 +37,7 @@ final class MacroGodotExportSubroupTests: XCTestCase {
 class Car: Node {
     var vin: String = ""
 
-    func _mproxy_set_vin (args: [Variant]) -> Variant? {
+    func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -49,12 +49,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_vin (args: [Variant]) -> Variant? {
+    func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
         return Variant (vin)
     }
     var ymms_year: Int = 1998
 
-    func _mproxy_set_ymms_year (args: [Variant]) -> Variant? {
+    func _mproxy_set_ymms_year (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -66,12 +66,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_ymms_year (args: [Variant]) -> Variant? {
+    func _mproxy_get_ymms_year (args: borrowing Arguments) -> Variant? {
         return Variant (ymms_year)
     }
     var ymms_make: String = "Honda"
 
-    func _mproxy_set_ymms_make (args: [Variant]) -> Variant? {
+    func _mproxy_set_ymms_make (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -83,12 +83,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_ymms_make (args: [Variant]) -> Variant? {
+    func _mproxy_get_ymms_make (args: borrowing Arguments) -> Variant? {
         return Variant (ymms_make)
     }
     var ymms_model: String = "Odyssey"
 
-    func _mproxy_set_ymms_model (args: [Variant]) -> Variant? {
+    func _mproxy_set_ymms_model (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -100,12 +100,12 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_ymms_model (args: [Variant]) -> Variant? {
+    func _mproxy_get_ymms_model (args: borrowing Arguments) -> Variant? {
         return Variant (ymms_model)
     }
     var ymms_series: String = "LX"
 
-    func _mproxy_set_ymms_series (args: [Variant]) -> Variant? {
+    func _mproxy_set_ymms_series (args: borrowing Arguments) -> Variant? {
     	guard let arg = args.first else {
     		return nil
     	}
@@ -117,7 +117,7 @@ class Car: Node {
     	return nil
     }
 
-    func _mproxy_get_ymms_series (args: [Variant]) -> Variant? {
+    func _mproxy_get_ymms_series (args: borrowing Arguments) -> Variant? {
         return Variant (ymms_series)
     }
 

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -203,31 +203,31 @@ final class MacroGodotTests: XCTestCase {
                 class Castro: Node {
                     func deleteEpisode() {}
 
-                    func _mproxy_deleteEpisode (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_deleteEpisode (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	deleteEpisode ()
                     	return nil
                     }
                     func subscribe(podcast: Podcast) {}
 
-                    func _mproxy_subscribe (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_subscribe (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	subscribe (podcast: Podcast.makeOrUnwrap (args [0])!)
                     	return nil
                     }
                     func removeSilences(from: Variant) {}
 
-                    func _mproxy_removeSilences (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_removeSilences (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	removeSilences (from: args [0])
                     	return nil
                     }
                     func getLatestEpisode(podcast: Podcast) -> Episode {}
 
-                    func _mproxy_getLatestEpisode (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_getLatestEpisode (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = getLatestEpisode (podcast: Podcast.makeOrUnwrap (args [0])!)
                     	return Variant (result)
                     }
                     func queue(_ podcast: Podcast, after preceedingPodcast: Podcast) {}
 
-                    func _mproxy_queue (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_queue (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	queue (Podcast.makeOrUnwrap (args [0])!, after: Podcast.makeOrUnwrap (args [1])!)
                     	return nil
                     }
@@ -298,7 +298,7 @@ final class MacroGodotTests: XCTestCase {
             final class MyClass: Node {
                 var data: MyData = .init()
 
-                func _mproxy_set_data (args: [Variant]) -> Variant? {
+                func _mproxy_set_data (args: borrowing Arguments) -> Variant? {
                     func dynamicCast<T, U>(_ value: T, as type: U.Type) -> U? {
                         value as? U
                     }
@@ -311,7 +311,7 @@ final class MacroGodotTests: XCTestCase {
                 	return nil
                 }
 
-                func _mproxy_get_data (args: [Variant]) -> Variant? {
+                func _mproxy_get_data (args: borrowing Arguments) -> Variant? {
                     return Variant (data)
                 }
 
@@ -361,7 +361,7 @@ final class MacroGodotTests: XCTestCase {
                         return result
                     }
 
-                    func _mproxy_getIntegerCollection (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_getIntegerCollection (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = getIntegerCollection ()
                     	return Variant (result)
                     }
@@ -403,7 +403,7 @@ final class MacroGodotTests: XCTestCase {
                         integers.map { $0 * $0 }.reduce(into: VariantCollection<Int>()) { $0.append(value: $1) }
                     }
                 
-                    func _mproxy_square (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_square (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = square (GArray(args[0])!.reduce(into: VariantCollection<Int>()) {
                     	        $0.append(Int.makeOrUnwrap($1)!)
                     	    })
@@ -452,7 +452,7 @@ final class MacroGodotTests: XCTestCase {
                         return result
                     }
 
-                    func _mproxy_getNodeCollection (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_getNodeCollection (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = getNodeCollection ()
                     	return Variant (result)
                     }
@@ -494,7 +494,7 @@ final class MacroGodotTests: XCTestCase {
                         nodes.forEach { print($0.name) }
                     }
                 
-                    func _mproxy_printNames (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_printNames (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	printNames (of: GArray(args[0])!.reduce(into: ObjectCollection<Node>()) {
                     	        $0.append(Node.makeOrUnwrap($1)!)
                     	    })
@@ -541,7 +541,7 @@ final class MacroGodotTests: XCTestCase {
                         integers.reduce(into: 1) { $0 *= $1 }
                     }
                 
-                    func _mproxy_multiply (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = multiply (GArray (args [0])!.compactMap(Int.makeOrUnwrap))
                     	return Variant (result)
                     }
@@ -592,7 +592,7 @@ final class MacroGodotTests: XCTestCase {
                         [1, 2, 3, 4]
                     }
                 
-                    func _mproxy_get_ages (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_get_ages (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = get_ages ()
                     	return Variant ( result.reduce(into: GArray(Int.self)) {
                     	        $0.append(Variant($1))
@@ -602,7 +602,7 @@ final class MacroGodotTests: XCTestCase {
                         [.init(), .init(), .init()]
                     }
                 
-                    func _mproxy_get_markers (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_get_markers (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = get_markers ()
                     	return Variant ( result.reduce(into: GArray(Marker3D.self)) {
                     	        $0.append(Variant($1))
@@ -648,7 +648,7 @@ final class MacroGodotTests: XCTestCase {
                         integers.reduce(into: 1) { $0 *= $1 }
                     }
                 
-                    func _mproxy_multiply (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = multiply (GArray (args [0])!.compactMap(Int.makeOrUnwrap))
                     	return Variant (result)
                     }
@@ -699,7 +699,7 @@ final class MacroGodotTests: XCTestCase {
                         [1, 2, 3, 4]
                     }
                 
-                    func _mproxy_get_ages (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_get_ages (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = get_ages ()
                     	return Variant ( result.reduce(into: GArray(Int.self)) {
                     	        $0.append(Variant($1))
@@ -709,7 +709,7 @@ final class MacroGodotTests: XCTestCase {
                         [.init(), .init(), .init()]
                     }
                 
-                    func _mproxy_get_markers (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_get_markers (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = get_markers ()
                     	return Variant ( result.reduce(into: GArray(Marker3D.self)) {
                     	        $0.append(Variant($1))
@@ -750,19 +750,19 @@ final class MacroGodotTests: XCTestCase {
                 class MathHelper: Node {
                     func multiply(_ a: Int, by b: Int) -> Int { a * b}
 
-                    func _mproxy_multiply (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = multiply (Int.makeOrUnwrap (args [0])!, by: Int.makeOrUnwrap (args [1])!)
                     	return Variant (result)
                     }
                     func divide(_ a: Float, by b: Float) -> Float { a / b }
 
-                    func _mproxy_divide (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_divide (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = divide (Float.makeOrUnwrap (args [0])!, by: Float.makeOrUnwrap (args [1])!)
                     	return Variant (result)
                     }
                     func areBothTrue(_ a: Bool, and b: Bool) -> Bool { a == b }
 
-                    func _mproxy_areBothTrue (args: [SwiftGodot.Variant]) -> SwiftGodot.Variant? {
+                    func _mproxy_areBothTrue (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     	let result = areBothTrue (Bool.makeOrUnwrap (args [0])!, and: Bool.makeOrUnwrap (args [1])!)
                     	return Variant (result)
                     }
@@ -819,7 +819,7 @@ final class MacroGodotTests: XCTestCase {
             class Hi: Node {
             	var goodName: String = "Supertop"
             
-            	func _mproxy_set_goodName (args: [Variant]) -> Variant? {
+            	func _mproxy_set_goodName (args: borrowing Arguments) -> Variant? {
             		guard let arg = args.first else {
             			return nil
             		}
@@ -831,7 +831,7 @@ final class MacroGodotTests: XCTestCase {
             		return nil
             	}
             
-            	func _mproxy_get_goodName (args: [Variant]) -> Variant? {
+            	func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
             	    return Variant (goodName)
             	}
             

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -64,6 +64,16 @@ final class MarshalTests: GodotTestCase {
         }
     }
     
+    func testVarargMethodsPerformance() {
+        let randomValues = (0..<10).map { _ in Variant(Float.random(in: -1.0...1.0)) }
+        
+        measure {
+            for _ in 0..<1000000 {
+                let _ = GD.max(arg1: randomValues[0], arg2: randomValues[1], randomValues[2], randomValues[3], randomValues[4], randomValues[5], randomValues[6], randomValues[7], randomValues[8], randomValues[9])
+            }
+        }
+    }
+    
     func testUnsafePointersNMemoryLayout() {
         // UnsafeRawPointersN# is keeping `UnsafeRawPointer?` inside, but Swift Compiler is smart enough to confine the optionality of `UnsafeRawPointer` as a property of its payload (being a zero address or not) instead of introducing an extra byte and consequential alignment padding.
         XCTAssertEqual(MemoryLayout<UnsafeRawPointersN9>.size, MemoryLayout<UnsafeRawPointer>.stride * 9, "UnsafeRawPointersN should have the same size as a N of UnsafeRawPointers")

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -64,6 +64,53 @@ final class MarshalTests: GodotTestCase {
         }
     }
     
+    func testUnsafePointersNMemoryLayout() {
+        // UnsafeRawPointersN# is keeping `UnsafeRawPointer?` inside, but Swift Compiler is smart enough to confine the optionality of `UnsafeRawPointer` as a property of its payload (being a zero address or not) instead of introducing an extra byte and consequential alignment padding.
+        XCTAssertEqual(MemoryLayout<UnsafeRawPointersN9>.size, MemoryLayout<UnsafeRawPointer>.stride * 9, "UnsafeRawPointersN should have the same size as a N of UnsafeRawPointers")
+    }
+    
+    func testUnsafePointersHelpers() {
+        var v0 = 0
+        var v1 = 1
+        var v2 = 2
+        var v3 = 3
+        var v4 = 4
+        var v5 = 5
+        var v6 = 6
+        var v7 = 7
+        var v8 = 8
+        var v9 = 9
+        var v10 = 10
+        var v11 = 11
+        var v12 = 12
+        var v13 = 13
+        var v14 = 14
+        
+        withUnsafePointerToUnsafePointers(storing: &v0, &v1, &v2, &v3, &v4, &v5, &v6) { ptr in
+            ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 7) { reboundPtr in
+                for i in 0..<7 {
+                    XCTAssertEqual(reboundPtr[i].pointee, i)
+                }
+            }
+        }
+        
+        withUnsafePointerToUnsafePointers(storing: &v0, &v1, &v2, &v3) { ptr in
+            ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 4) { reboundPtr in
+                for i in 0..<4 {
+                    XCTAssertEqual(reboundPtr[i].pointee, i)
+                }
+            }
+        }
+        
+        withUnsafePointerToUnsafePointers(storing: &v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14) { ptr in
+            ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 15) { reboundPtr in
+                for i in 0..<15 {
+                    XCTAssertEqual(reboundPtr[i].pointee, i)
+                }
+            }
+        }
+    }
+    
     func wrapInt <A: VariantStorable>(_ argument: A) -> Int? {
         Int (.init (argument))
     }

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -34,6 +34,36 @@ final class MarshalTests: GodotTestCase {
         XCTAssertEqual (tv.receivedString, "Joey", "Strings should have been the same")
     }
     
+    func testClassesMethodsPerformance() {
+        let tv = TestVariant()
+        let child = TestVariant()
+
+        measure {
+            for _ in 0..<10000000 {
+                tv.addChild(node: child)
+                tv.removeChild(node: child)
+            }
+        }
+    }
+    
+    func testBuiltinsTypesMethodsPerformance() {
+        let makeRandomVector = {
+            Vector3(x: .random(in: -1.0...1.0), y: .random(in: -1.0...1.0), z: .random(in: -1.0...1.0))
+        }
+        
+        let a = makeRandomVector()
+        let b = makeRandomVector()
+        let preA = makeRandomVector()
+        let preB = makeRandomVector()
+        let weight = 0.23
+        
+        measure {
+            for _ in 0..<10000000 {
+                let _ = a.cubicInterpolate(b: b, preA: preA, postB: preB, weight: weight)
+            }
+        }
+    }
+    
     func wrapInt <A: VariantStorable>(_ argument: A) -> Int? {
         Int (.init (argument))
     }

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -86,7 +86,7 @@ final class MarshalTests: GodotTestCase {
         var v13 = 13
         var v14 = 14
         
-        withUnsafePointerToUnsafePointers(&v0, &v1, &v2, &v3, &v4, &v5, &v6) { ptr in
+        withUnsafeArgumentsPointer(&v0, &v1, &v2, &v3, &v4, &v5, &v6) { ptr in
             ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 7) { reboundPtr in
                 for i in 0..<7 {
                     XCTAssertEqual(reboundPtr[i].pointee, i)
@@ -94,7 +94,7 @@ final class MarshalTests: GodotTestCase {
             }
         }
         
-        withUnsafePointerToUnsafePointers(&v0, &v1, &v2, &v3) { ptr in
+        withUnsafeArgumentsPointer(&v0, &v1, &v2, &v3) { ptr in
             ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 4) { reboundPtr in
                 for i in 0..<4 {
                     XCTAssertEqual(reboundPtr[i].pointee, i)
@@ -102,7 +102,7 @@ final class MarshalTests: GodotTestCase {
             }
         }
         
-        withUnsafePointerToUnsafePointers(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14) { ptr in
+        withUnsafeArgumentsPointer(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14) { ptr in
             ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 15) { reboundPtr in
                 for i in 0..<15 {
                     XCTAssertEqual(reboundPtr[i].pointee, i)

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -86,7 +86,7 @@ final class MarshalTests: GodotTestCase {
         var v13 = 13
         var v14 = 14
         
-        withUnsafePointerToUnsafePointers(storing: &v0, &v1, &v2, &v3, &v4, &v5, &v6) { ptr in
+        withUnsafePointerToUnsafePointers(&v0, &v1, &v2, &v3, &v4, &v5, &v6) { ptr in
             ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 7) { reboundPtr in
                 for i in 0..<7 {
                     XCTAssertEqual(reboundPtr[i].pointee, i)
@@ -94,7 +94,7 @@ final class MarshalTests: GodotTestCase {
             }
         }
         
-        withUnsafePointerToUnsafePointers(storing: &v0, &v1, &v2, &v3) { ptr in
+        withUnsafePointerToUnsafePointers(&v0, &v1, &v2, &v3) { ptr in
             ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 4) { reboundPtr in
                 for i in 0..<4 {
                     XCTAssertEqual(reboundPtr[i].pointee, i)
@@ -102,7 +102,7 @@ final class MarshalTests: GodotTestCase {
             }
         }
         
-        withUnsafePointerToUnsafePointers(storing: &v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14) { ptr in
+        withUnsafePointerToUnsafePointers(&v0, &v1, &v2, &v3, &v4, &v5, &v6, &v7, &v8, &v9, &v10, &v11, &v12, &v13, &v14) { ptr in
             ptr.withMemoryRebound(to: UnsafePointer<Int>.self, capacity: 15) { reboundPtr in
                 for i in 0..<15 {
                     XCTAssertEqual(reboundPtr[i].pointee, i)

--- a/Tests/SwiftGodotTests/VariantTests.swift
+++ b/Tests/SwiftGodotTests/VariantTests.swift
@@ -19,6 +19,62 @@ final class VariantTests: GodotTestCase {
         XCTAssertEqual (unwrapped, testString)
     }
     
+    func testVariantCall() {
+        let string = "Hello Hello Hello Hello"
+        let variant = Variant(string)
+        
+        switch variant.call(method: "count", Variant("ello"), Variant(0), Variant(11)) {
+        case .success(let value):
+            guard let value = Int(value) else {
+                XCTFail("Expected \(Variant.GType.int.debugDescription), got \(value.gtype.debugDescription) instead")
+                return
+            }
+            XCTAssertEqual(value, 2, "ello appears twice in `\(string)` from index 0 to 11, got \(value) instead")
+        case .failure(let error):
+            XCTFail("\(error)")
+            return
+        }
+        
+        switch variant.call(method: "count", Variant("ello"), Variant(0), Variant(0)) {
+        case .success(let value):
+            guard let value = Int(value) else {
+                XCTFail("Expected \(Variant.GType.int.debugDescription), got \(value.gtype.debugDescription) instead")
+                return
+            }
+            XCTAssertEqual(value, 4, "ello appears twice in `\(string)`, got \(value) instead")
+        case .failure(let error):
+            XCTFail("\(error)")
+            return
+        }
+                        
+        // Check special treatment for a single argument case
+        switch variant.call(method: "ends_with", Variant("llo")) {
+        case .success(let value):
+            guard let value = Bool(value) else {
+                XCTFail("Expected \(Variant.GType.bool.debugDescription), got \(value.gtype.debugDescription) instead")
+                return
+            }
+            XCTAssertTrue(value, "`\(string)` ends with `llo`, got `false` instead")
+        case .failure(let error):
+            XCTFail("\(error)")
+            return
+        }
+        
+        // Check special treatment for a zero arguments case
+        switch variant.call(method: "is_empty") {
+        case .success(let value):
+            guard let value = Bool(value) else {
+                XCTFail("Expected \(Variant.GType.bool.debugDescription), got \(value.gtype.debugDescription) instead")
+                return
+            }
+            XCTAssertFalse(value, "`\(string)` is not empty, got `true` instead")
+        case .failure(let error):
+            XCTFail("\(error)")
+            return
+        }
+                              
+    }
+    
     func testInitVariantStorable () {
         var variant: Variant
         


### PR DESCRIPTION
This PR contains improvements to avoid allocations, based on the observation most of those allocations are transient and data can be kept on the stack

1. For marshalled methods of built-in types and classes - keep everything on stack, avoid using `[UnsafeRawPtr?]`. Old code is still available using `LEGACY_MARSHALLING` define, which is currently commented-out. Performance difference can be tested using `testBuiltinsTypesMethodsPerformance` and  and `testClassesMethodsPerformance` in `MarshalTests` with this flag on and off.
2. For `Callable` API - change `[Variant]` to new `Arguments` type, that either contains a Swift array if a call was issued from the Swift side, or wraps a Godot managed `pargs` and lazily reconstructs `Variant`s inside when requested to avoid eager array initialisation. Guarantee of it not becoming dangling is based on the fact that `Arguments` is `~Copyable` and only visible on the user side as `borrowing`.