### PR TITLE
Add additional reserved words to generator

### DIFF
--- a/Generator/Generator/StringOperations.swift
+++ b/Generator/Generator/StringOperations.swift
@@ -57,7 +57,8 @@ public extension String {
 func escapeSwift(_ id: String) -> String {
     switch id {
     case "protocol", "func", "static", "inout", "in", "self", "case", "repeat", "default",
-         "import", "init", "continue", "class", "operator", "where", "var", "enum", "nil", "extension", "internal", "return":
+         "import", "init", "continue", "class", "operator", "where", "var", "enum", "nil", "extension", "internal", "return",
+         "switch", "public", "private", "for":
         return "`\(id)`"
     default:
         return id


### PR DESCRIPTION
While experimenting with customized extension APIs, I came across these identifiers that were not escaped previously.

Specifically, these 4 (`switch`, `public`, `private`, `for`) are used in <https://github.com/GodotSteam/GodotSteam>.