### PR TITLE
Fixed Generator issue when using class arguments not looking up subtypes

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -539,7 +539,16 @@ func generateSignalType (_ p: Printer, _ cdef: JGodotExtensionAPIClass, _ signal
             if let _ = classMap [arg.type] {
                 argUnwrap += "var ptr_\(argIdx): UnsafeMutableRawPointer?\n"
                 argUnwrap += "args [\(argIdx)].toType (Variant.GType.object, dest: &ptr_\(argIdx))\n"
-                construct = "lookupLiveObject (handleAddress: ptr_\(argIdx)!) as? \(arg.type) ?? \(arg.type) (nativeHandle: ptr_\(argIdx)!)"
+                let handleResolver: String
+                if hasSubclasses.contains(cdef.name) {
+                    // If the type we are bubbling up has subclasses, we want to create the most
+                    // derived type if possible, so we perform the longer lookup
+                    handleResolver = "lookupObject (nativeHandle: ptr_\(argIdx)!) ?? "
+                } else {
+                    handleResolver = ""
+                }
+                
+                construct = "lookupLiveObject (handleAddress: ptr_\(argIdx)!) as? \(arg.type) ?? \(handleResolver)\(arg.type) (nativeHandle: ptr_\(argIdx)!)"
             } else if arg.type == "String" {
                     construct = "\(mapTypeName(arg.type)) (args [\(argIdx)])!.description"
             } else if arg.type == "Variant" {


### PR DESCRIPTION
Fixes #535

When using the inputEvent on CollisionObject3D, for example, the callback alway returns an InputEvent instance instead of the correct subclass. In the example code the if in mouse_input_event will never pass.

Example code:
```
class SomeNode: Node3D {
 
  @SceneTree(path: "CollisionObject3D")
  var nodeArea: CollisionObject3D?

  public override func _ready() {
        nodeArea?.inputEvent.connect(mouse_input_event)
  }
  
  func mouse_input_event(camera: Node, event: InputEvent, eventPosition: Vector3, normal: Vector3, _shape_idx: Int64) {
      if event is InputEventMouse {
           print("InputEventMouse") // Will never print
      }
  }
}
```

The original output would be 

```
let arg_1 = lookupLiveObject (handleAddress: ptr_1!) as? InputEvent ?? InputEvent (nativeHandle: ptr_1!)
```

Now it will be this if the type has a subclass

```
let arg_1 = lookupLiveObject (handleAddress: ptr_1!) as? InputEvent ?? lookupObject (nativeHandle: ptr_1!) ?? InputEvent (nativeHandle: ptr_1!)
```