### PR TITLE
Fix a 541 leak

### DIFF
--- a/Sources/SwiftGodot/Core/VariantStorable.swift
+++ b/Sources/SwiftGodot/Core/VariantStorable.swift
@@ -43,7 +43,7 @@ extension VariantStorable {
 
 extension String: VariantStorable {
     public func toVariantRepresentable() -> GString {
-        var r = GString()
+        let r = GString()
         gi.string_new_with_utf8_chars (&r.content, self)
         return r
     }

--- a/Sources/SwiftGodot/Core/VariantStorable.swift
+++ b/Sources/SwiftGodot/Core/VariantStorable.swift
@@ -41,25 +41,9 @@ extension VariantStorable {
     }
 }
 
-/// Internal version of the GString, which is a structure instead of a class
-/// so it is suitable for the codepath that uses the address of the object
-/// as the address for `content` in the `private init<T: VariantRepresentable>(representable value: T)`
-/// method.   You do not need to use this type.
-public struct GStringRaw: ContentVariantRepresentable {
-    public var content: GString.ContentType
-    public static var zero: GString.ContentType = 0
-    public init () {
-        content = GString.zero
-    }
-    public init (alreadyOwnedContent content: GString.ContentType) {
-        self.content = content
-    }
-    public static var godotType: Variant.GType { .string }
-}
-
 extension String: VariantStorable {
-    public func toVariantRepresentable() -> GStringRaw {
-        var r = GStringRaw ()
+    public func toVariantRepresentable() -> GString {
+        var r = GString()
         gi.string_new_with_utf8_chars (&r.content, self)
         return r
     }

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -73,6 +73,10 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
             gi.variant_new_copy(&content, src)
         }
     }
+    
+    public init(takingOver other: Variant) {
+        content = other.content
+    }
 
     deinit {
         if experimentalDisableVariantUnref { return }

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -73,10 +73,6 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
             gi.variant_new_copy(&content, src)
         }
     }
-    
-    public init(takingOver other: Variant) {
-        content = other.content
-    }
 
     deinit {
         if experimentalDisableVariantUnref { return }
@@ -289,11 +285,10 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
     
     
     /// Gets the name of a Variant type.
-    public static func typeName (_ type: GType) -> String {
-        var res = GStringRaw()
+    public static func typeName(_ type: GType) -> String {
+        let res = GString()
         gi.variant_get_type_name (GDExtensionVariantType (GDExtensionVariantType.RawValue(type.rawValue)), &res.content)
         let ret = GString.stringFromGStringPtr(ptr: &res.content)
-        GString.destructor (&res.content)
         return ret ?? ""
     }
 }

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -64,9 +64,9 @@ final class MemoryLeakTests: GodotTestCase {
     func test_541_leak() {
         let before = Performance.getMonitor(.memoryStatic)
         
-        for i in 0...10000000 {
+        for _ in 0...10000000 {
             autoreleasepool {
-                let variant = Variant("daosdoasodasoda")
+                let _ = Variant("daosdoasodasoda")
             }
         }
         

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -1,4 +1,4 @@
-@testable import SwiftGodot
+import SwiftGodot
 import SwiftGodotTestability
 import XCTest
 
@@ -66,7 +66,7 @@ final class MemoryLeakTests: GodotTestCase {
         
         for i in 0...10000000 {
             autoreleasepool {
-                let variant = Variant("daosdoasodasoda")                
+                let variant = Variant("daosdoasodasoda")
             }
         }
         

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -1,4 +1,4 @@
-import SwiftGodot
+@testable import SwiftGodot
 import SwiftGodotTestability
 import XCTest
 
@@ -60,4 +60,19 @@ final class MemoryLeakTests: GodotTestCase {
         XCTAssertEqual(before, after, "Leaked \(Int((after - before) / Double(count))) bytes per iteration.")
     }
 
+    
+    func test_541_leak() {
+        let before = Performance.getMonitor(.memoryStatic)
+        
+        for i in 0...10000000 {
+            autoreleasepool {
+                let string = Variant("\(i)")
+                let str = Variant(takingOver: string)
+            }
+        }
+        
+        let after = Performance.getMonitor(.memoryStatic)
+        
+        XCTAssertEqual(before, after, "Leaked \(Int(after - before))")
+    }
 }

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -66,8 +66,7 @@ final class MemoryLeakTests: GodotTestCase {
         
         for i in 0...10000000 {
             autoreleasepool {
-                let string = Variant("\(i)")
-                let str = Variant(takingOver: string)
+                let variant = Variant("daosdoasodasoda")                
             }
         }
         


### PR DESCRIPTION
Fixes https://github.com/migueldeicaza/SwiftGodot/issues/541

Godot String (aka GString) is described as `"has_destructor": true`. In the case of the bug, it was created, Variant made a copy of it that it manages by itself, but it was never destructed. `GString` would manage its destruction in such a case. `GStringRaw` was removed as redundant.