### PR TITLE
Fix a 544 leak

### DIFF
--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -73,6 +73,11 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
             gi.variant_new_copy(&content, src)
         }
     }
+    
+    /// Initializes using `ContentType` and assuming that this `Variant` is sole owner of this content now.
+    init(takingOver other: ContentType) {
+        self.content = other
+    }
 
     deinit {
         if experimentalDisableVariantUnref { return }
@@ -229,7 +234,7 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
             return .failure(toCallErrorType(err.error))
         }
         
-        return .success(Variant(copying: result))
+        return .success(Variant(takingOver: result))
     }
     
     /// Errors raised by the variant subscript

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -59,5 +59,22 @@ final class MemoryLeakTests: GodotTestCase {
 
         XCTAssertEqual(before, after, "Leaked \(Int((after - before) / Double(count))) bytes per iteration.")
     }
+    
+    func test_544_leak() {
+        let string = "Hello, World!"
+        let variant = Variant(string)
 
+        // https://docs.godotengine.org/en/stable/classes/class_string.html#class-string-method-left
+        let methodName = StringName("left")
+
+        let before = Performance.getMonitor(.memoryStatic)
+        
+        for _ in 0 ..< 2000 {
+            let _ = variant.call(method: methodName, Variant(2))
+        }
+        
+        let after = Performance.getMonitor(.memoryStatic)
+
+        XCTAssertEqual(before, after, "Leaked \(Int(after - before)) bytes")
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/migueldeicaza/SwiftGodot/issues/544:

`variant_call` returns a retained copy, we don't need to `copy` it, but assume control over it instead.