### PR TITLE
Optimize GitHub actions configuration

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
Now it should cancel runs for the older commits if newer commits are added in the PR.