### PR TITLE
Add Macro Compatibility Check to CI workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,4 +40,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build
         run: swift build -v
+
+  check-macro-compatibility:
+    name: Check Macro Compatibility
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Swift Macro Compatibility Check
+        uses: Matejkob/swift-macro-compatibility-check@v1
+        with:
+          run-tests: false
+          major-versions-only: true
         


### PR DESCRIPTION
This pull request introduces the **Swift Macro Compatibility Check** GitHub Action into the CI workflow. This action verifies that the Swift package remains compatible with multiple versions of `swift-syntax`, which is critical for macro-based functionality.

#### Motivation for Adding This Check:
1. **swift-syntax Versioning Complexity**: As detailed by Point-Free in their article, ["Being a good citizen in the land of SwiftSyntax"](https://www.pointfree.co/blog/posts/116-being-a-good-citizen-in-the-land-of-swiftsyntax), swift-syntax employs a versioning scheme where minor versions of Swift correspond to major versions of swift-syntax (e.g., SwiftSyntax 509.0 maps to Swift 5.9). This scheme introduces complexity in maintaining compatibility across versions.
   
2. **Frequent Breaking Changes**: Minor releases of swift-syntax have introduced breaking changes, which can cause issues with existing macros and dependencies. This action helps ensure that our macros remain functional across these versions.

3. **Dependency Graph Resolution**: By testing against multiple versions, we can prevent dependency conflicts in the broader Swift ecosystem. This is essential, especially as more libraries are adopting macros and using swift-syntax, increasing the likelihood of conflicting dependencies.

4. **Proactive Development**: Catching compatibility issues early in the development cycle allows us to resolve them before they become critical, reducing the risk of blocked releases or difficult debugging sessions later.

> [!IMPORTANT]
> To ensure the library can be used alongside others in the Swift packages, it need to support all versions of swift-syntax. Without this compatibility, users may face issues where they can't use several libraries together if they depend on different versions of swift-syntax. 
