### PR TITLE
Eradicate optional Variant

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -510,7 +510,7 @@ func generateBuiltinMethods (_ p: Printer,
             p ("return gi.variant_get_ptr_keyed_checker (\(variantType))!")
         }
         p("""
-        public subscript(key: Variant) -> Variant? {
+        public subscript(key: Variant) -> Variant {
             get {
                 var result = Variant.zero
                 if Self.keyed_checker(&content, &key.content) != 0 {
@@ -523,13 +523,7 @@ func generateBuiltinMethods (_ p: Printer,
             }
         
             set {                
-                if let newValue {
-                    Self.keyed_setter(&content, &key.content, &newValue.content)
-                } else {                    
-                    var nilContent = Variant.zero
-                    // nil will cause a crash, needs a pointer to Nil Variant content instead
-                    Self.keyed_setter(&content, &key.content, &nilContent)
-                }                
+                Self.keyed_setter(&content, &key.content, &newValue.content)                
             }
         }
         """)        
@@ -702,7 +696,7 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                 p("""
                 @available(*, deprecated, message: "Use `init(_ callback: @escaping (borrowing Arguments) -> Variant)` instead.")
                 """)
-                p ("public init (_ callback: @escaping ([Variant])->Variant?)") {
+                p ("public init (_ callback: @escaping ([Variant]) -> Variant)") {
                     p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
                 }
             }

--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -70,7 +70,7 @@ class SwiftSprite: Sprite2D {
         GD.print("Found this value IMAGE: \(imageVariant.gtype) variant: \(imageVariant) desc: \(imageVariant.description)")
         
         let dict2: GDictionary? = GDictionary(imageVariant)
-       GD.print("dictionary2: \(String(describing: dict2)) \(dict2?["type"]?.description ?? "no type") \(dict2?["value"]?.description ?? "no value")")
+        GD.print("dictionary2: \(String(describing: dict2)) \(dict2?["type"].description ?? "no type") \(dict2?["value"].description ?? "no value")")
         
         // part b
         if let result = dict2?.get(key: Variant("type"), default: Variant(-1)) {
@@ -141,17 +141,17 @@ class SwiftSprite2: Sprite2D {
     // This callback style receives the arguments from Godot as an array of Variants, and returns a Variant
     // harder than using the macros above
     var food: String = "none"
-    func demoSetFavoriteFood (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
+    func demoSetFavoriteFood (args: borrowing Arguments) -> Variant {
+        guard args.count > 0 else {
             print ("Method registered taking one argument got none")
             return nil
         }
-        food = String (arg) ?? "The variant passed was not a string"
+        food = String (args.first) ?? "The variant passed was not a string"
         print ("The favorite food was set to: \(food)")
         return nil
     }
     
-    func demoGetFavoriteFood (args: borrowing Arguments) -> Variant? {
+    func demoGetFavoriteFood (args: borrowing Arguments) -> Variant {
         return Variant(food)
     }
 
@@ -162,7 +162,7 @@ class SwiftSprite2: Sprite2D {
         GD.print("Found this value IMAGE: \(imageVariant.gtype) variant: \(imageVariant) desc: \(imageVariant.description)")
         
         let dict2: GDictionary? = GDictionary(imageVariant)
-        GD.print("dictionary2: \(String(describing: dict2)) \(dict2?["type"]?.description ?? "no value for type") \(dict2?["value"]?.description ?? "no value for value")")
+        GD.print("dictionary2: \(String(describing: dict2)) \(dict2?["type"].description ?? "no value for type") \(dict2?["value"].description ?? "no value for value")")
         
         // part b
         if let result = dict2?.get(key: Variant("type"), default: Variant(-1)) {

--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -59,11 +59,11 @@ public class ClassInfo<T:Object> {
     
     // Here so we can box the function pointer
     struct FunctionInfo {
-        var function: (T) -> (borrowing Arguments) -> Variant?
+        var function: (T) -> (borrowing Arguments) -> Variant
         var retType: Variant.GType?
         var ttype: T.Type
         
-        init (_ function: @escaping (T) -> (borrowing Arguments) -> Variant?, retType: Variant.GType?) {
+        init (_ function: @escaping (T) -> (borrowing Arguments) -> Variant, retType: Variant.GType?) {
             self.function = function
             self.retType = retType
             self.ttype = T.self
@@ -95,7 +95,7 @@ public class ClassInfo<T:Object> {
     ///     let _ = initClass ()
     ///   }
     ///
-    ///   func checkBaddies (args: borrowing Arguments) -> Variant? {
+    ///   func checkBaddies (args: borrowing Arguments) -> Variant {
     ///     // We are getting one integer if called from Godot of type Int
     ///     // validate in case you called this directly from Swift
     ///     guard args.count > 0 else {
@@ -117,7 +117,7 @@ public class ClassInfo<T:Object> {
     ///  - returnValue: if nil, this method does not return a value, otherwise, the descritption of the return value as a PropInfo
     ///  - arguments: an array describing the parameters that this method takes
     ///  - function: this is a curried function that will be registered.   It will be invoked on the instance of your object
-    public func registerMethod (name: StringName, flags: MethodFlags, returnValue: PropInfo?, arguments: [PropInfo], function: @escaping (T) -> (borrowing Arguments) -> Variant?) {
+    public func registerMethod (name: StringName, flags: MethodFlags, returnValue: PropInfo?, arguments: [PropInfo], function: @escaping (T) -> (borrowing Arguments) -> Variant) {
         let argPtr = UnsafeMutablePointer<GDExtensionPropertyInfo>.allocate(capacity: arguments.count)
         defer { argPtr.deallocate() }
         let argMeta = UnsafeMutablePointer<GDExtensionClassMethodArgumentMetadata>.allocate(capacity: arguments.count)
@@ -262,7 +262,7 @@ func bind_call (_ udata: UnsafeMutableRawPointer?,
         return bound(arguments)
     }
 
-    if let returnValue, let ret {
+    if let returnValue {
         if ret.gtype != finfo.retType {
             print ("Your declared function should return the type originally set \(String(describing: finfo.retType)) and \(ret.gtype)")
             if let rError = r_error {

--- a/Sources/SwiftGodot/Core/GArray.swift
+++ b/Sources/SwiftGodot/Core/GArray.swift
@@ -13,14 +13,14 @@ public enum ArrayError {
 extension GArray {
     /// Initializes an empty, but typed `GArray`. For example: `GArray(Node.self)`
     /// - Parameter type: `T` the type of the elements in the GArray, must conform to `VariantStorable`.
-	public convenience init<T: VariantStorable>(_ type: T.Type = T.self) {
-		self.init(
-			base: GArray(),
-			type: Int32(T.Representable.godotType.rawValue),
-			className: T.Representable.godotType == .object ? StringName("\(T.self)") : StringName(),
-			script: Variant()
-		)
-	}
+    public convenience init<T: VariantStorable>(_ type: T.Type = T.self) {
+        self.init(
+            base: GArray(),
+            type: Int32(T.Representable.godotType.rawValue),
+            className: T.Representable.godotType == .object ? StringName("\(T.self)") : StringName(),
+            script: Variant()
+        )
+    }
     
     public subscript (index: Int) -> Variant {
         get {

--- a/Sources/SwiftGodot/Core/GArrayCollection.swift
+++ b/Sources/SwiftGodot/Core/GArrayCollection.swift
@@ -9,5 +9,5 @@
 
 // If our exported Collections conform to this protocol, then we can use the same Macro code while exporting them
 protocol GArrayCollection: Collection where Element: VariantStorable {
-	var array: GArray { set get }
+    var array: GArray { set get }
 }

--- a/Sources/SwiftGodot/Core/InspectableProperty.swift
+++ b/Sources/SwiftGodot/Core/InspectableProperty.swift
@@ -8,7 +8,7 @@
 /// A structure that houses a property that can be added to a Godot inspector.
 public struct InspectableProperty<T> {
     /// A typealias for the the method type used to register a property to Godot for inspectors.
-    public typealias RegisteredPropertyFunction = (T) -> (borrowing Arguments) -> Variant?
+    public typealias RegisteredPropertyFunction = (T) -> (borrowing Arguments) -> Variant
 
     /// The host object the property derives from.
     public let hostObject: T.Type

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -16,8 +16,8 @@ extension ObjectCollection: VariantStorable {
 
 /// This represents a typed array of one of the built-in types from Godot
 public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLiteral, GArrayCollection {
-	public typealias ArrayLiteralElement = Element
-	
+    public typealias ArrayLiteralElement = Element
+    
     /// The underlying GArray, passed to the Godot client, and reassigned by the Godot client via the proxy accessors
     /// In general you should not be modifying this property directly
     public var array: GArray
@@ -34,13 +34,13 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
         // Array took a reference, we do not need to take it.
         GArray.destructor (&copy)
     }
-	
+    
     /// Initializes the collection using an array literal, for example: `let objectCollection: ObjectCollection<Node> = [Node()]`
-	public required init(arrayLiteral elements: ArrayLiteralElement...) {
-		array = elements.reduce(into: .init(Element.self)) {
+    public required init(arrayLiteral elements: ArrayLiteralElement...) {
+        array = elements.reduce(into: .init(Element.self)) {
             $0.append(Variant($1))
-		}
-	}
+        }
+    }
     
     /// Initializes the collection using an array
     public init(_ elements: [Element]) {

--- a/Sources/SwiftGodot/Core/SignalSupport.swift
+++ b/Sources/SwiftGodot/Core/SignalSupport.swift
@@ -29,7 +29,7 @@ public class SignalProxy: Object {
     } ()
     
     /// The code invoked when Godot invokes the `proxy` method on this object.
-    public typealias Proxy = (borrowing Arguments) -> ()
+    public typealias Proxy = (borrowing Arguments) -> Void
     public var proxy: Proxy?
     
     public required init () {
@@ -41,7 +41,7 @@ public class SignalProxy: Object {
         super.init (nativeHandle: nativeHandle)
     }
     
-    func proxyFunc (args: borrowing Arguments) -> Variant? {
+    func proxyFunc (args: borrowing Arguments) -> Variant {
         proxy? (args)
         return nil
     }

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -24,9 +24,9 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
 
     /// Initializes the collection using an array literal, for example: `let variantCollection: VariantCollection<Int> = [0]`
     public required init(arrayLiteral elements: ArrayLiteralElement...) {
-		array = elements.reduce(into: .init(Element.self)) {
+        array = elements.reduce(into: .init(Element.self)) {
             $0.append(Variant($1))
-		}
+        }
     }
     
     init (content: Int64) {

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -559,21 +559,20 @@ func freeCallableWrapper(wrapperPtr: UnsafeMutableRawPointer?) {
 }
 
 struct CallableWrapper {
-    let function: (borrowing Arguments) -> Variant?
+    let function: (borrowing Arguments) -> Variant
         
     func invoke(arguments: borrowing Arguments, retPtr: UnsafeMutableRawPointer?, err: UnsafeMutablePointer<GDExtensionCallError>?) {
-        if let methodRet = function(arguments) {
-            retPtr!.storeBytes(of: methodRet.content, as: type (of: methodRet.content))
-        }
+        let methodRet = function(arguments)
+        retPtr!.storeBytes(of: methodRet.content, as: type (of: methodRet.content))
         err?.pointee.error = GDEXTENSION_CALL_OK
     }
     
-    @available(*, deprecated, message: "Use version taking `@escaping (borrowing Arguments) -> Variant?` instead.")    
-    static func callableVariantContent(wrapping function: @escaping ([Variant]) -> Variant?) -> Callable.ContentType {
+    @available(*, deprecated, message: "Use version taking `@escaping (borrowing Arguments) -> Variant` instead.")
+    static func callableVariantContent(wrapping function: @escaping ([Variant]) -> Variant) -> Callable.ContentType {
         callableVariantContent { (arguments: borrowing Arguments) in
             let array = Array(arguments)
             let result = function(array)
-            return result ?? Variant()
+            return result
         }
     }
     

--- a/Sources/SwiftGodot/Extensions/ClassInfo+ConvenienceProperties.swift
+++ b/Sources/SwiftGodot/Extensions/ClassInfo+ConvenienceProperties.swift
@@ -33,7 +33,7 @@ public protocol Nameable {
 
 extension ClassInfo {
     /// A type alias referencing a class info function that can be registered.
-    public typealias ClassInfoFunction = (T) -> (borrowing Arguments) -> Variant?
+    public typealias ClassInfoFunction = (T) -> (borrowing Arguments) -> Variant
 
     /// A type alias referencing a registerable int enum.
     public typealias RegisteredIntEnum = CaseIterable & Nameable & RawRepresentable<Int>
@@ -43,7 +43,7 @@ extension ClassInfo {
     /// This can be used inside setter method to set a property in-class with a guaranteed argument value.
     ///
     /// ```swift
-    /// func setBubbleCount(args: borrowing Arguments) -> Variant? {
+    /// func setBubbleCount(args: borrowing Arguments) -> Variant {
     ///     withCheckedProperty(named: "bubbles", in: args) { argument in
     ///         self.bubbles = Int(argument) ?? 0
     ///     }
@@ -55,11 +55,12 @@ extension ClassInfo {
     /// - Parameter action: A closure that accepts a valid argument.
     public static func withCheckedProperty(named name: String,
                                            in arguments: borrowing Arguments,
-                                           perform action: (Variant) -> Void) -> Variant? {
-        guard let arg = arguments.first else {
+                                           perform action: (Variant) -> Void) -> Variant {
+        let arg = arguments.first
+        guard !arg.isNil else {
             GD.pushError("Expected argument for \(name), but got nil instead.")
             return nil
-        }
+        }        
         action(arg)
         return nil
     }

--- a/Sources/SwiftGodot/Extensions/GDictionary.swift
+++ b/Sources/SwiftGodot/Extensions/GDictionary.swift
@@ -8,7 +8,7 @@
 extension GDictionary: CustomDebugStringConvertible, CustomStringConvertible {
     /// Convenience subscript that uses a String as the key to access the
     /// elements in the dictionary.   Merely wraps this on a Variant.
-    public subscript (key: String) -> Variant? {
+    public subscript (key: String) -> Variant {
         get {
             return self [Variant (key)]
         }
@@ -19,7 +19,7 @@ extension GDictionary: CustomDebugStringConvertible, CustomStringConvertible {
     
     /// Convenience subscript that uses a StringName as the key to access the
     /// elements in the dictionary.   Merely wraps this on a Variant.
-    public subscript (key: StringName) -> Variant? {
+    public subscript (key: StringName) -> Variant {
         get {
             return self [Variant (key)]
         }

--- a/Sources/SwiftGodot/Extensions/NodeExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/NodeExtensions.swift
@@ -33,15 +33,15 @@ public struct BindNode<Value: Node> {
     ) -> Value {
         get {
             if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *) {
-				if let node = instance[keyPath: storageKeyPath].cachedNode {
-					return node as! Value
-				}
+                if let node = instance[keyPath: storageKeyPath].cachedNode {
+                    return node as! Value
+                }
 
-				if !instance[keyPath: storageKeyPath].path.isEmpty {
-					let nodePath = NodePath(from: instance[keyPath: storageKeyPath].path)
-					instance[keyPath: storageKeyPath].cachedNode = instance.getNode(path: nodePath)
-					return instance[keyPath: storageKeyPath].cachedNode as! Value
-				}
+                if !instance[keyPath: storageKeyPath].path.isEmpty {
+                    let nodePath = NodePath(from: instance[keyPath: storageKeyPath].path)
+                    instance[keyPath: storageKeyPath].cachedNode = instance.getNode(path: nodePath)
+                    return instance[keyPath: storageKeyPath].cachedNode as! Value
+                }
 
                 let name: String
                 let fullName = wrappedKeyPath.debugDescription
@@ -52,7 +52,7 @@ public struct BindNode<Value: Node> {
                 }
                 let nodePath = NodePath(from: name)
                 
-				instance[keyPath: storageKeyPath].cachedNode = instance.getNode(path: nodePath)
+                instance[keyPath: storageKeyPath].cachedNode = instance.getNode(path: nodePath)
                 return instance[keyPath: storageKeyPath].cachedNode as! Value
             } else {
                 fatalError ("BindNode is not supported with current swift, or older Mac")
@@ -74,7 +74,7 @@ public struct BindNode<Value: Node> {
             fatalError()
         }
     }
-	private var cachedNode: Node?
-	private var path: String
+    private var cachedNode: Node?
+    private var path: String
 }
 

--- a/Sources/SwiftGodot/Extensions/PhysicsDirectSpaceState2D+IntersectRayResult.swift
+++ b/Sources/SwiftGodot/Extensions/PhysicsDirectSpaceState2D+IntersectRayResult.swift
@@ -5,9 +5,11 @@
 //  Created by Estevan Hernandez on 06/24/24.
 //
 
-private extension GDictionary {
+extension GDictionary {
     func makeOrUnwrap<T: VariantStorable>(key: String) -> T? {
-        guard let variant = self[key] else {
+        let variant = self[key]
+        
+        guard !variant.isNil else {
             GD.pushWarning("There was no Variant for key: \(key)")
             return nil
         }
@@ -36,14 +38,13 @@ extension PhysicsDirectSpaceState2D {
         /// The shape index of the colliding shape.
         public let shape: Int
         /// The metadata value from the dictionary.
-        public let metadata: Variant?
+        public let metadata: Variant
 
         init?(_ dictionary: GDictionary) {
             guard dictionary.isEmpty() == false,
                   let position: Vector2 = dictionary.makeOrUnwrap(key: "position"),
-                  let normal: Vector2 = dictionary.makeOrUnwrap(key: "normal"),
-                  let colliderVariant = dictionary["collider"],
-                  let collider = T.makeOrUnwrap(colliderVariant),
+                  let normal: Vector2 = dictionary.makeOrUnwrap(key: "normal"),                  
+                  let collider = T.makeOrUnwrap(dictionary["collider"]),
                   let colliderId: Int = dictionary.makeOrUnwrap(key: "collider_id"),
                   let rid: RID = dictionary.makeOrUnwrap(key: "rid"),
                   let shape: Int = dictionary.makeOrUnwrap(key: "shape") else {

--- a/Sources/SwiftGodot/Extensions/PhysicsDirectSpaceState3D+IntersectRayResult.swift
+++ b/Sources/SwiftGodot/Extensions/PhysicsDirectSpaceState3D+IntersectRayResult.swift
@@ -5,21 +5,6 @@
 //  Created by Estevan Hernandez on 12/24/23.
 //
 
-private extension GDictionary {
-    func makeOrUnwrap<T: VariantStorable>(key: String) -> T? {
-        guard let variant = self[key] else {
-            GD.pushWarning("There was no Variant for key: \(key)")
-            return nil
-        }
-        guard let result = T.makeOrUnwrap(variant) else {
-            GD.pushWarning("\(T.self).makeOrUnwrap(\(variant)) was nil")
-            return nil
-        }
-
-        return result
-    }
-}
-
 extension PhysicsDirectSpaceState3D {
     /// Result from intersecting a ray
     public struct IntersectRayResult<T: Object> {
@@ -36,16 +21,17 @@ extension PhysicsDirectSpaceState3D {
         /// The shape index of the colliding shape.
         public let shape: Int
         /// The metadata value from the dictionary.
-        public let metadata: Variant?
+        public let metadata: Variant
         /// The face index at the intersection point.
         public let faceIndex: Int
 
         init?(_ dictionary: GDictionary) {
+            let collider = T.makeOrUnwrap(dictionary["collider"])
+            
             guard dictionary.isEmpty() == false,
                   let position: Vector3 = dictionary.makeOrUnwrap(key: "position"),
-                  let normal: Vector3 = dictionary.makeOrUnwrap(key: "normal"),
-                  let colliderVariant = dictionary["collider"],
-                  let collider = T.makeOrUnwrap(colliderVariant),
+                  let normal: Vector3 = dictionary.makeOrUnwrap(key: "normal"),                  
+                  let collider,
                   let colliderId: Int = dictionary.makeOrUnwrap(key: "collider_id"),
                   let rid: RID = dictionary.makeOrUnwrap(key: "rid"),
                   let shape: Int = dictionary.makeOrUnwrap(key: "shape"),

--- a/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
@@ -206,7 +206,7 @@ In SwiftGodot, you can create `Callable` instances by directly passing a Swift f
 and returns an optional `Variant` result, like this:
 
 ```swift
-func myCallback(args: borrowing Arguments)-> Variant? {
+func myCallback(args: borrowing Arguments) -> Variant {
 	print ("MyCallback invoked with \(args.count) arguments")
 	return nil
 }

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -157,6 +157,11 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible, Express
         return asObject(Object.self) == nil
     }
     
+    /// Returns true if the `Variant` contains Godot `Nil`
+    public var isNil: Bool {
+        content == Variant.zero
+    }
+    
     ///
     /// Attempts to cast the Variant into a SwiftGodot.Object, if the variant contains a value of type `.object`, then
     // this will return the object.  If the variant contains the nil value, or the content of the variant is not

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -15,7 +15,7 @@ import SwiftSyntaxMacros
 public struct GodotCallable: PeerMacro {
     static func process (funcDecl: FunctionDeclSyntax) throws -> String {
         let funcName = funcDecl.name.text
-        var genMethod = "func _mproxy_\(funcName) (args: borrowing Arguments) -> SwiftGodot.Variant? {\n"
+        var genMethod = "func _mproxy_\(funcName) (args: borrowing Arguments) -> SwiftGodot.Variant {\n"
         var retProp: String? = nil
         var retOptional: Bool = false
         

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -18,7 +18,7 @@ public struct GodotCallable: PeerMacro {
         var genMethod = "func _mproxy_\(funcName) (args: borrowing Arguments) -> SwiftGodot.Variant? {\n"
         var retProp: String? = nil
         var retOptional: Bool = false
-		
+        
         if let effects = funcDecl.signature.effectSpecifiers,
            effects.asyncSpecifier?.presence == .present ||
             effects.throwsSpecifier?.presence == .present {
@@ -27,10 +27,10 @@ public struct GodotCallable: PeerMacro {
         
         if let (retType, _, ro) = getIdentifier (funcDecl.signature.returnClause?.type) {
             retProp = godotTypeToProp (typeName: retType)
-            genMethod.append ("\tlet result = \(funcName) (")
+            genMethod.append ("    let result = \(funcName) (")
             retOptional = ro
         } else {
-            genMethod.append ("\t\(funcName) (")
+            genMethod.append ("    \(funcName) (")
         }
         //     let result = computeGodot (String (args [0]), Int (args [1]))
         
@@ -69,15 +69,15 @@ public struct GodotCallable: PeerMacro {
         genMethod.append (")\n")
         if retProp != nil {
             if retOptional {
-                genMethod.append ("\tguard let result else { return nil }\n")
+                genMethod.append ("    guard let result else { return nil }\n")
             }
             if funcDecl.returnTypeIsArray, let elementTypeName = funcDecl.arrayElementType {
-                genMethod.append ("\treturn Variant ( result.reduce(into: GArray(\(elementTypeName).self)) { $0.append(Variant($1)) })\n")
+                genMethod.append ("    return Variant ( result.reduce(into: GArray(\(elementTypeName).self)) { $0.append(Variant($1)) })\n")
             } else {
-                genMethod.append ("\treturn Variant (result)\n")
+                genMethod.append ("    return Variant (result)\n")
             }
         } else {
-            genMethod.append ("\treturn nil\n")
+            genMethod.append ("    return nil\n")
         }
         if genMethod != "" {
             genMethod.append("}\n")

--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -20,7 +20,7 @@ public struct GodotExport: PeerMacro {
         if isEnum {
             return
     """
-    func \(name) (args: borrowing Arguments) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> Variant {
         return Variant (\(varName).rawValue)
     }
     """
@@ -29,7 +29,7 @@ public struct GodotExport: PeerMacro {
         if isOptional {
             return
     """
-    func \(name) (args: borrowing Arguments) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> Variant {
         guard let result = \(varName) else { return nil }
         return Variant (result)
     }
@@ -37,7 +37,7 @@ public struct GodotExport: PeerMacro {
         } else {
             return
     """
-    func \(name) (args: borrowing Arguments) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> Variant {
         return Variant (\(varName))
     }
     """
@@ -82,9 +82,7 @@ public struct GodotExport: PeerMacro {
             } else {
                 body =
     """
-        guard let arg = args.first else {
-            return nil
-        }
+        let arg = args.first
         if let value = \(typeName) (arg) {
             self.\(varName) = value
         } else {
@@ -93,7 +91,7 @@ public struct GodotExport: PeerMacro {
     """
             }
         }
-        return "func \(name) (args: borrowing Arguments) -> Variant? {\n\(body)\n    return nil\n}"
+        return "func \(name) (args: borrowing Arguments) -> Variant {\n\(body)\n    return nil\n}"
     }
 
     
@@ -198,7 +196,7 @@ public struct GodotExport: PeerMacro {
 private extension GodotExport {
     private static func makeGArrayCollectionGetProxyAccessor(varName: String, elementTypeName: String) -> String {
         """
-        func _mproxy_get_\(varName)(args: borrowing Arguments) -> Variant? {
+        func _mproxy_get_\(varName)(args: borrowing Arguments) -> Variant {
             return Variant(\(varName).array)
         }
         """
@@ -206,9 +204,9 @@ private extension GodotExport {
     
     private static func makeGArrayCollectionSetProxyAccessor(varName: String, elementTypeName: String) -> String {
         """
-        func _mproxy_set_\(varName)(args: borrowing Arguments) -> Variant? {
-            guard let arg = args.first,
-                  let gArray = GArray(arg),
+        func _mproxy_set_\(varName)(args: borrowing Arguments) -> Variant {
+            let arg = args.first
+            guard let gArray = GArray(arg),
                   gArray.isTyped(),
                   gArray.isSameTyped(array: GArray(\(elementTypeName).self)) else {
                 return nil

--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -56,8 +56,8 @@ public struct GodotExport: PeerMacro {
         }
     """
         } else if typeName == "Variant" {
-			body = "\(varName) = args [0]"
-		} else if godotVariants [typeName] == nil {
+            body = "\(varName) = args [0]"
+        } else if godotVariants [typeName] == nil {
             let optBody = isOptional ? " else { \(varName) = nil }" : ""
             
             // The use of the local function dynamicCast here is such that the compiler
@@ -77,23 +77,23 @@ public struct GodotExport: PeerMacro {
             if isOptional {
                 body =
     """
-    	\(varName) = \(typeName) (args [0])
+        \(varName) = \(typeName) (args [0])
     """
             } else {
                 body =
     """
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = \(typeName) (arg) {
-    		self.\(varName) = value
-    	} else {
-    		GD.printErr ("Unable to set `\(varName)` value: ", arg)
-    	}
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = \(typeName) (arg) {
+            self.\(varName) = value
+        } else {
+            GD.printErr ("Unable to set `\(varName)` value: ", arg)
+        }
     """
             }
         }
-        return "func \(name) (args: borrowing Arguments) -> Variant? {\n\(body)\n\treturn nil\n}"
+        return "func \(name) (args: borrowing Arguments) -> Variant? {\n\(body)\n    return nil\n}"
     }
 
     
@@ -197,25 +197,25 @@ public struct GodotExport: PeerMacro {
 
 private extension GodotExport {
     private static func makeGArrayCollectionGetProxyAccessor(varName: String, elementTypeName: String) -> String {
-		"""
-		func _mproxy_get_\(varName)(args: borrowing Arguments) -> Variant? {
-			return Variant(\(varName).array)
-		}
-		"""
+        """
+        func _mproxy_get_\(varName)(args: borrowing Arguments) -> Variant? {
+            return Variant(\(varName).array)
+        }
+        """
     }
     
     private static func makeGArrayCollectionSetProxyAccessor(varName: String, elementTypeName: String) -> String {
-		"""
-		func _mproxy_set_\(varName)(args: borrowing Arguments) -> Variant? {
-			guard let arg = args.first,
-				  let gArray = GArray(arg),
-				  gArray.isTyped(),
-				  gArray.isSameTyped(array: GArray(\(elementTypeName).self)) else {
-				return nil
-			}
-			\(varName).array = gArray
-			return nil
-		}
-		"""
+        """
+        func _mproxy_set_\(varName)(args: borrowing Arguments) -> Variant? {
+            guard let arg = args.first,
+                  let gArray = GArray(arg),
+                  gArray.isTyped(),
+                  gArray.isSameTyped(array: GArray(\(elementTypeName).self)) else {
+                return nil
+            }
+            \(varName).array = gArray
+            return nil
+        }
+        """
     }
 }

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -80,7 +80,7 @@ class GodotMacroProcessor {
         
         // TODO: perhaps for these prop infos that are parameters to functions, we should not bother making them unique
         // and instead share all the Ints, all the Floats and so on.
-        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\(parameterName)\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: .default)\n")
+        ctor.append ("    let \(name) = PropInfo (propertyType: \(propType), propertyName: \"\(parameterName)\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: .default)\n")
         propertyDeclarations [key] = name
         return name
     }
@@ -125,7 +125,7 @@ class GodotMacroProcessor {
         let hint = propType == ".array" ? ".arrayType" : ".none"
         // TODO: perhaps for these prop infos that are parameters to functions, we should not bother making them unique
         // and instead share all the Ints, all the Floats and so on.
-        ctor.append ("\tlet \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: .default)\n")
+        ctor.append ("    let \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: .default)\n")
         propertyDeclarations [key] = name
         return name
     }
@@ -193,15 +193,15 @@ class GodotMacroProcessor {
                 parameterName: pname
             )
             if funcArgs == "" {
-                funcArgs = "\tlet \(funcName)Args = [\n"
+                funcArgs = "    let \(funcName)Args = [\n"
             }
-            funcArgs.append ("\t\t\(propInfo),\n")
+            funcArgs.append ("        \(propInfo),\n")
         }
         if funcArgs != "" {
-            funcArgs.append ("\t]\n")
+            funcArgs.append ("    ]\n")
         }
         ctor.append (funcArgs)
-        ctor.append ("\tclassInfo.registerMethod(name: StringName(\"\(funcName)\"), flags: .default, returnValue: \(retProp ?? "nil"), arguments: \(funcArgs == "" ? "[]" : "\(funcName)Args"), function: \(className)._mproxy_\(funcName))\n")
+        ctor.append ("    classInfo.registerMethod(name: StringName(\"\(funcName)\"), flags: .default, returnValue: \(retProp ?? "nil"), arguments: \(funcArgs == "" ? "[]" : "\(funcName)Args"), function: \(className)._mproxy_\(funcName))\n")
     }
     
     // Returns true if it used "tryCase"
@@ -306,9 +306,9 @@ class GodotMacroProcessor {
     
     """)
             
-            ctor.append("\tclassInfo.registerMethod (name: \"\(getterName)\", flags: .default, returnValue: \(pinfo), arguments: [], function: \(className).\(proxyGetterName))\n")
-            ctor.append("\tclassInfo.registerMethod (name: \"\(setterName)\", flags: .default, returnValue: nil, arguments: [\(pinfo)], function: \(className).\(proxySetterName))\n")
-            ctor.append("\tclassInfo.registerProperty (\(pinfo), getter: \"\(getterName)\", setter: \"\(setterName)\")\n")
+            ctor.append("    classInfo.registerMethod (name: \"\(getterName)\", flags: .default, returnValue: \(pinfo), arguments: [], function: \(className).\(proxyGetterName))\n")
+            ctor.append("    classInfo.registerMethod (name: \"\(setterName)\", flags: .default, returnValue: nil, arguments: [\(pinfo)], function: \(className).\(proxySetterName))\n")
+            ctor.append("    classInfo.registerProperty (\(pinfo), getter: \"\(getterName)\", setter: \"\(setterName)\")\n")
         }
         if usedTryCase {
             return true
@@ -404,9 +404,9 @@ class GodotMacroProcessor {
         usage: .default)\n
     """)
             
-            ctor.append("\tclassInfo.registerMethod (name: \"\(getterName)\", flags: .default, returnValue: \(pinfo), arguments: [], function: \(className).\(proxyGetterName))\n")
-            ctor.append("\tclassInfo.registerMethod (name: \"\(setterName)\", flags: .default, returnValue: nil, arguments: [\(pinfo)], function: \(className).\(proxySetterName))\n")
-            ctor.append("\tclassInfo.registerProperty (\(pinfo), getter: \"\(getterName)\", setter: \"\(setterName)\")\n")
+            ctor.append("    classInfo.registerMethod (name: \"\(getterName)\", flags: .default, returnValue: \(pinfo), arguments: [], function: \(className).\(proxyGetterName))\n")
+            ctor.append("    classInfo.registerMethod (name: \"\(setterName)\", flags: .default, returnValue: nil, arguments: [\(pinfo)], function: \(className).\(proxySetterName))\n")
+            ctor.append("    classInfo.registerProperty (\(pinfo), getter: \"\(getterName)\", setter: \"\(setterName)\")\n")
         }
     }
     
@@ -436,15 +436,15 @@ class GodotMacroProcessor {
                 previousSubgroupPrefix = macroExpansion.exportSubgroupPrefix ?? ""
                 processExportSubgroup(name: name, prefix: previousSubgroupPrefix ?? "")
             } else if let funcDecl = FunctionDeclSyntax(decl) {
-				try processFunction (funcDecl)
-			} else if let varDecl = VariableDeclSyntax(decl) {
-				if varDecl.isGArrayCollection {
+                try processFunction (funcDecl)
+            } else if let varDecl = VariableDeclSyntax(decl) {
+                if varDecl.isGArrayCollection {
                     try processGArrayCollectionVariable(varDecl, prefix: previousSubgroupPrefix ?? previousGroupPrefix)
-				} else {
+                } else {
                     if try processVariable(varDecl, prefix: previousSubgroupPrefix ?? previousGroupPrefix) {
                         needTrycase = true
                     }
-				}
+                }
             } else if let macroDecl = MacroExpansionDeclSyntax(decl) {
                 try classInitSignals(macroDecl)
             }
@@ -589,7 +589,7 @@ public struct GodotMacro: MemberMacro {
                 }
                 implementedOverridesDecl += "return super.implementedOverrides () + [\n"
                 for name in stringNames {
-                    implementedOverridesDecl.append("\t\(name),\n")
+                    implementedOverridesDecl.append("    \(name),\n")
                 }
                 implementedOverridesDecl.append("]\n}")
                 decls.append (DeclSyntax(extendedGraphemeClusterLiteral: implementedOverridesDecl))

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -80,7 +80,7 @@ enum GodotMacroError: Error, DiagnosticMessage {
             "@Callable does not support asynchronous or throwing functions"
         case .noSupportForOptionalEnums:
             "@Export(.enum) does not support optional values for the enumeration"
-		}
+        }
     }
     
     var diagnosticID: MessageID {

--- a/Tests/SwiftGodotEngineTests/Math/Geometry2DTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/Geometry2DTests.swift
@@ -214,7 +214,7 @@ final class Geometry2DTests: GodotTestCase {
         result = Geometry2D.makeAtlas (sizes: r)
         XCTAssertEqual (result.size (), 2)
         XCTAssertEqual (result ["size"], Variant (Vector2i (x: 2, y: 2)))
-        XCTAssertEqual (result ["points"]?.description, "[(0, 0)]")
+        XCTAssertEqual (result ["points"].description, "[(0, 0)]")
         
         r.clear ()
         result.clear ()
@@ -224,7 +224,7 @@ final class Geometry2DTests: GodotTestCase {
         r.pushBack (value: Vector2 (x: 7, y: 8))
         result = Geometry2D.makeAtlas (sizes: r)
         XCTAssertEqual (result.size (), 2)
-        XCTAssertEqual (PackedVector2Array (result ["points"] ?? Variant ())?.size (), r.size ())
+        XCTAssertEqual (PackedVector2Array (result ["points"])?.size (), r.size ())
     }
     
     func testPolygonIntersection () throws {

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -11,11 +11,11 @@ import SwiftGodot
 
 @Godot
 class Demo: Object {
-	@Export var demo: GArray = GArray()
+    @Export var demo: GArray = GArray()
 }
 
 @Godot
 class Demo2: Object {
-	@Export var demo: Variant = Variant()
+    @Export var demo: Variant = Variant()
 }
 

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -33,10 +33,8 @@ class Car: Node {
 class Car: Node {
     var vehicle_make: String = "Mazda"
 
-    func _mproxy_set_vehicle_make (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_vehicle_make (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.vehicle_make = value
         } else {
@@ -45,15 +43,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_vehicle_make (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vehicle_make (args: borrowing Arguments) -> Variant {
         return Variant (vehicle_make)
     }
     var vehicle_model: String = "RX7"
 
-    func _mproxy_set_vehicle_model (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_vehicle_model (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.vehicle_model = value
         } else {
@@ -62,7 +58,7 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_vehicle_model (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vehicle_model (args: borrowing Arguments) -> Variant {
         return Variant (vehicle_model)
     }
 
@@ -119,10 +115,8 @@ class Car: Node {
 class Car: Node {
     var make: String = "Mazda"
 
-    func _mproxy_set_make (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_make (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.make = value
         } else {
@@ -131,15 +125,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_make (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_make (args: borrowing Arguments) -> Variant {
         return Variant (make)
     }
     var model: String = "RX7"
 
-    func _mproxy_set_model (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_model (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.model = value
         } else {
@@ -148,7 +140,7 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_model (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_model (args: borrowing Arguments) -> Variant {
         return Variant (model)
     }
 
@@ -206,10 +198,8 @@ class Car: Node {
 class Car: Node {
     var vin: String = "00000000000000000"
 
-    func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_vin (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.vin = value
         } else {
@@ -218,15 +208,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vin (args: borrowing Arguments) -> Variant {
         return Variant (vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_year (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = Int (arg) {
             self.year = value
         } else {
@@ -235,7 +223,7 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_year (args: borrowing Arguments) -> Variant {
         return Variant (year)
     }
 
@@ -292,10 +280,8 @@ class Car: Node {
 class Car: Node {
     var vin: String = "00000000000000000"
 
-    func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_vin (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.vin = value
         } else {
@@ -304,15 +290,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vin (args: borrowing Arguments) -> Variant {
         return Variant (vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_year (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = Int (arg) {
             self.year = value
         } else {
@@ -321,7 +305,7 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_year (args: borrowing Arguments) -> Variant {
         return Variant (year)
     }
 
@@ -382,10 +366,8 @@ class Car: Node {
 class Car: Node {
     var vin: String = ""
 
-    func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_vin (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.vin = value
         } else {
@@ -394,15 +376,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vin (args: borrowing Arguments) -> Variant {
         return Variant (vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_year (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = Int (arg) {
             self.year = value
         } else {
@@ -411,15 +391,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_year (args: borrowing Arguments) -> Variant {
         return Variant (year)
     }
     var make: String = "HONDA"
 
-    func _mproxy_set_make (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_make (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.make = value
         } else {
@@ -428,15 +406,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_make (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_make (args: borrowing Arguments) -> Variant {
         return Variant (make)
     }
     var model: String = "ACCORD"
 
-    func _mproxy_set_model (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_model (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.model = value
         } else {
@@ -445,7 +421,7 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_model (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_model (args: borrowing Arguments) -> Variant {
         return Variant (model)
     }
 
@@ -524,13 +500,13 @@ class Car: Node {
 class Car: Node {
     var makes: VariantCollection<String> = ["Mazda"]
 
-    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_makes(args: borrowing Arguments) -> Variant {
         return Variant(makes.array)
     }
 
-    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_makes(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -540,13 +516,13 @@ class Car: Node {
     }
     var model: VariantCollection<String> = ["RX7"]
 
-    func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_model(args: borrowing Arguments) -> Variant {
         return Variant(model.array)
     }
 
-    func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_model(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -609,13 +585,13 @@ class Car: Node {
 class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant {
         return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -625,13 +601,13 @@ class Car: Node {
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant {
         return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Int.self)) else {
             return nil
@@ -693,13 +669,13 @@ class Car: Node {
 class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant {
         return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -709,13 +685,13 @@ class Car: Node {
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant {
         return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Int.self)) else {
             return nil
@@ -781,13 +757,13 @@ class Car: Node {
 class Car: Node {
     var vins: VariantCollection<String> = [""]
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant {
         return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -797,13 +773,13 @@ class Car: Node {
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant {
         return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Int.self)) else {
             return nil
@@ -813,13 +789,13 @@ class Car: Node {
     }
     var makes: VariantCollection<String> = ["HONDA"]
 
-    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_makes(args: borrowing Arguments) -> Variant {
         return Variant(makes.array)
     }
 
-    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_makes(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -829,13 +805,13 @@ class Car: Node {
     }
     var models: VariantCollection<String> = ["ACCORD"]
 
-    func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_models(args: borrowing Arguments) -> Variant {
         return Variant(models.array)
     }
 
-    func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_models(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -921,13 +897,13 @@ class Car: Node {
 class Car: Node {
     var makes: ObjectCollection<Node> = []
 
-    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_makes(args: borrowing Arguments) -> Variant {
         return Variant(makes.array)
     }
 
-    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_makes(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -937,13 +913,13 @@ class Car: Node {
     }
     var model: ObjectCollection<Node> = []
 
-    func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_model(args: borrowing Arguments) -> Variant {
         return Variant(model.array)
     }
 
-    func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_model(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1005,13 +981,13 @@ class Car: Node {
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant {
         return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1021,13 +997,13 @@ class Car: Node {
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant {
         return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1089,13 +1065,13 @@ class Car: Node {
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant {
         return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1105,13 +1081,13 @@ class Car: Node {
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant {
         return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1177,13 +1153,13 @@ class Car: Node {
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vins(args: borrowing Arguments) -> Variant {
         return Variant(vins.array)
     }
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_vins(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1193,13 +1169,13 @@ class Car: Node {
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_years(args: borrowing Arguments) -> Variant {
         return Variant(years.array)
     }
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_years(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1209,13 +1185,13 @@ class Car: Node {
     }
     var makes: ObjectCollection<Node> = []
 
-    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_makes(args: borrowing Arguments) -> Variant {
         return Variant(makes.array)
     }
 
-    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_makes(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1225,13 +1201,13 @@ class Car: Node {
     }
     var models: ObjectCollection<Node> = []
 
-    func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_models(args: borrowing Arguments) -> Variant {
         return Variant(models.array)
     }
 
-    func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_models(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node.self)) else {
             return nil
@@ -1323,10 +1299,8 @@ class Garage: Node {
 class Garage: Node {
     var name: String = ""
 
-    func _mproxy_set_name (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_name (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.name = value
         } else {
@@ -1335,15 +1309,13 @@ class Garage: Node {
         return nil
     }
 
-    func _mproxy_get_name (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_name (args: borrowing Arguments) -> Variant {
         return Variant (name)
     }
     var rating: Float = 0.0
 
-    func _mproxy_set_rating (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_rating (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = Float (arg) {
             self.rating = value
         } else {
@@ -1352,18 +1324,18 @@ class Garage: Node {
         return nil
     }
 
-    func _mproxy_get_rating (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_rating (args: borrowing Arguments) -> Variant {
         return Variant (rating)
     }
     var reviews: VariantCollection<String> = []
 
-    func _mproxy_get_reviews(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_reviews(args: borrowing Arguments) -> Variant {
         return Variant(reviews.array)
     }
 
-    func _mproxy_set_reviews(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_reviews(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -1373,13 +1345,13 @@ class Garage: Node {
     }
     var checkIns: ObjectCollection<CheckIn> = []
 
-    func _mproxy_get_checkIns(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_checkIns(args: borrowing Arguments) -> Variant {
         return Variant(checkIns.array)
     }
 
-    func _mproxy_set_checkIns(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_checkIns(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(CheckIn.self)) else {
             return nil
@@ -1389,10 +1361,8 @@ class Garage: Node {
     }
     var address: String = ""
 
-    func _mproxy_set_address (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_address (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.address = value
         } else {
@@ -1401,18 +1371,18 @@ class Garage: Node {
         return nil
     }
 
-    func _mproxy_get_address (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_address (args: borrowing Arguments) -> Variant {
         return Variant (address)
     }
     var daysOfOperation: VariantCollection<String> = []
 
-    func _mproxy_get_daysOfOperation(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_daysOfOperation(args: borrowing Arguments) -> Variant {
         return Variant(daysOfOperation.array)
     }
 
-    func _mproxy_set_daysOfOperation(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_daysOfOperation(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -1422,13 +1392,13 @@ class Garage: Node {
     }
     var hours: VariantCollection<String> = []
 
-    func _mproxy_get_hours(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_hours(args: borrowing Arguments) -> Variant {
         return Variant(hours.array)
     }
 
-    func _mproxy_set_hours(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_hours(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -1438,13 +1408,13 @@ class Garage: Node {
     }
     var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
 
-    func _mproxy_get_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant {
         return Variant(insuranceProvidersAccepted.array)
     }
 
-    func _mproxy_set_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(InsuranceProvider.self)) else {
             return nil
@@ -1567,10 +1537,8 @@ class Garage: Node {
 class Garage: Node {
     var bar: Bool = false
 
-    func _mproxy_set_bar (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_bar (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = Bool (arg) {
             self.bar = value
         } else {
@@ -1579,7 +1547,7 @@ class Garage: Node {
         return nil
     }
 
-    func _mproxy_get_bar (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_bar (args: borrowing Arguments) -> Variant {
         return Variant (bar)
     }
 
@@ -1626,10 +1594,8 @@ public class Issue353: Node {
 public class Issue353: Node {
     var prefix1_prefixed_bool: Bool = true
 
-    func _mproxy_set_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = Bool (arg) {
             self.prefix1_prefixed_bool = value
         } else {
@@ -1638,15 +1604,13 @@ public class Issue353: Node {
         return nil
     }
 
-    func _mproxy_get_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant {
         return Variant (prefix1_prefixed_bool)
     }
     var non_prefixed_bool: Bool = true
 
-    func _mproxy_set_non_prefixed_bool (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_non_prefixed_bool (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = Bool (arg) {
             self.non_prefixed_bool = value
         } else {
@@ -1655,7 +1619,7 @@ public class Issue353: Node {
         return nil
     }
 
-    func _mproxy_get_non_prefixed_bool (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_non_prefixed_bool (args: borrowing Arguments) -> Variant {
         return Variant (non_prefixed_bool)
     }
 
@@ -1711,13 +1675,13 @@ class Garage: Node {
 class Garage: Node {
     var bar: VariantCollection<Bool> = [false]
 
-    func _mproxy_get_bar(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_bar(args: borrowing Arguments) -> Variant {
         return Variant(bar.array)
     }
 
-    func _mproxy_set_bar(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_bar(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Bool.self)) else {
             return nil
@@ -1769,13 +1733,13 @@ public class Issue353: Node {
 public class Issue353: Node {
     var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
 
-    func _mproxy_get_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant {
         return Variant(prefix1_prefixed_bool.array)
     }
 
-    func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Bool.self)) else {
             return nil
@@ -1785,13 +1749,13 @@ public class Issue353: Node {
     }
     var non_prefixed_bool: VariantCollection<Bool> = [false]
 
-    func _mproxy_get_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_non_prefixed_bool(args: borrowing Arguments) -> Variant {
         return Variant(non_prefixed_bool.array)
     }
 
-    func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Bool.self)) else {
             return nil

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -34,15 +34,15 @@ class Car: Node {
     var vehicle_make: String = "Mazda"
 
     func _mproxy_set_vehicle_make (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vehicle_make = value
-    	} else {
-    		GD.printErr ("Unable to set `vehicle_make` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.vehicle_make = value
+        } else {
+            GD.printErr ("Unable to set `vehicle_make` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_vehicle_make (args: borrowing Arguments) -> Variant? {
@@ -51,15 +51,15 @@ class Car: Node {
     var vehicle_model: String = "RX7"
 
     func _mproxy_set_vehicle_model (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vehicle_model = value
-    	} else {
-    		GD.printErr ("Unable to set `vehicle_model` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.vehicle_model = value
+        } else {
+            GD.printErr ("Unable to set `vehicle_model` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_vehicle_model (args: borrowing Arguments) -> Variant? {
@@ -83,9 +83,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pvehicle_make, arguments: [], function: Car._mproxy_get_vehicle_make)
-    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pvehicle_make], function: Car._mproxy_set_vehicle_make)
-    	classInfo.registerProperty (_pvehicle_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+        classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pvehicle_make, arguments: [], function: Car._mproxy_get_vehicle_make)
+        classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pvehicle_make], function: Car._mproxy_set_vehicle_make)
+        classInfo.registerProperty (_pvehicle_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
         let _pvehicle_model = PropInfo (
             propertyType: .string,
             propertyName: "vehicle_model",
@@ -93,9 +93,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pvehicle_model, arguments: [], function: Car._mproxy_get_vehicle_model)
-    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pvehicle_model], function: Car._mproxy_set_vehicle_model)
-    	classInfo.registerProperty (_pvehicle_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+        classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pvehicle_model, arguments: [], function: Car._mproxy_get_vehicle_model)
+        classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pvehicle_model], function: Car._mproxy_set_vehicle_model)
+        classInfo.registerProperty (_pvehicle_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
     } ()
 }
 """,
@@ -120,15 +120,15 @@ class Car: Node {
     var make: String = "Mazda"
 
     func _mproxy_set_make (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.make = value
-    	} else {
-    		GD.printErr ("Unable to set `make` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.make = value
+        } else {
+            GD.printErr ("Unable to set `make` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_make (args: borrowing Arguments) -> Variant? {
@@ -137,15 +137,15 @@ class Car: Node {
     var model: String = "RX7"
 
     func _mproxy_set_model (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.model = value
-    	} else {
-    		GD.printErr ("Unable to set `model` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.model = value
+        } else {
+            GD.printErr ("Unable to set `model` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_model (args: borrowing Arguments) -> Variant? {
@@ -169,9 +169,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
-    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
-    	classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+        classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
+        classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
+        classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
         let _pmodel = PropInfo (
             propertyType: .string,
             propertyName: "model",
@@ -179,9 +179,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-    	classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+        classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+        classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+        classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
     } ()
 }
 """,
@@ -207,15 +207,15 @@ class Car: Node {
     var vin: String = "00000000000000000"
 
     func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vin = value
-    	} else {
-    		GD.printErr ("Unable to set `vin` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.vin = value
+        } else {
+            GD.printErr ("Unable to set `vin` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
@@ -224,15 +224,15 @@ class Car: Node {
     var year: Int = 1997
 
     func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Int (arg) {
-    		self.year = value
-    	} else {
-    		GD.printErr ("Unable to set `year` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = Int (arg) {
+            self.year = value
+        } else {
+            GD.printErr ("Unable to set `year` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
@@ -255,9 +255,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+        classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+        classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+        classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
         classInfo.addPropertyGroup(name: "YMMS", prefix: "")
         let _pyear = PropInfo (
             propertyType: .int,
@@ -266,9 +266,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-    	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+        classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+        classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+        classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
     } ()
 }
 """,
@@ -293,15 +293,15 @@ class Car: Node {
     var vin: String = "00000000000000000"
 
     func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vin = value
-    	} else {
-    		GD.printErr ("Unable to set `vin` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.vin = value
+        } else {
+            GD.printErr ("Unable to set `vin` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
@@ -310,15 +310,15 @@ class Car: Node {
     var year: Int = 1997
 
     func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Int (arg) {
-    		self.year = value
-    	} else {
-    		GD.printErr ("Unable to set `year` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = Int (arg) {
+            self.year = value
+        } else {
+            GD.printErr ("Unable to set `year` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
@@ -341,9 +341,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+        classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+        classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+        classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
         let _pyear = PropInfo (
             propertyType: .int,
             propertyName: "year",
@@ -351,9 +351,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-    	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+        classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+        classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+        classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
         classInfo.addPropertyGroup(name: "Pointless", prefix: "")
     } ()
 }
@@ -383,15 +383,15 @@ class Car: Node {
     var vin: String = ""
 
     func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vin = value
-    	} else {
-    		GD.printErr ("Unable to set `vin` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.vin = value
+        } else {
+            GD.printErr ("Unable to set `vin` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
@@ -400,15 +400,15 @@ class Car: Node {
     var year: Int = 1997
 
     func _mproxy_set_year (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Int (arg) {
-    		self.year = value
-    	} else {
-    		GD.printErr ("Unable to set `year` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = Int (arg) {
+            self.year = value
+        } else {
+            GD.printErr ("Unable to set `year` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
@@ -417,15 +417,15 @@ class Car: Node {
     var make: String = "HONDA"
 
     func _mproxy_set_make (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.make = value
-    	} else {
-    		GD.printErr ("Unable to set `make` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.make = value
+        } else {
+            GD.printErr ("Unable to set `make` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_make (args: borrowing Arguments) -> Variant? {
@@ -434,15 +434,15 @@ class Car: Node {
     var model: String = "ACCORD"
 
     func _mproxy_set_model (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.model = value
-    	} else {
-    		GD.printErr ("Unable to set `model` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.model = value
+        } else {
+            GD.printErr ("Unable to set `model` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_model (args: borrowing Arguments) -> Variant? {
@@ -466,9 +466,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+        classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+        classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+        classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
         classInfo.addPropertyGroup(name: "YMM", prefix: "")
         let _pyear = PropInfo (
             propertyType: .int,
@@ -477,9 +477,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-    	classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+        classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+        classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+        classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
         let _pmake = PropInfo (
             propertyType: .string,
             propertyName: "make",
@@ -487,9 +487,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
-    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
-    	classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+        classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
+        classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
+        classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
         let _pmodel = PropInfo (
             propertyType: .string,
             propertyName: "model",
@@ -497,9 +497,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-    	classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+        classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+        classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+        classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
     } ()
     
 }
@@ -525,34 +525,34 @@ class Car: Node {
     var makes: VariantCollection<String> = ["Mazda"]
 
     func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
-    	return Variant(makes.array)
+        return Variant(makes.array)
     }
 
     func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	makes.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        makes.array = gArray
+        return nil
     }
     var model: VariantCollection<String> = ["RX7"]
 
     func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
-    	return Variant(model.array)
+        return Variant(model.array)
     }
 
     func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	model.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        model.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -572,9 +572,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
-    	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
-    	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
+        classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
+        classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
+        classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
         let _pmodel = PropInfo (
             propertyType: .array,
             propertyName: "model",
@@ -582,9 +582,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-    	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-    	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
+        classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+        classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+        classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
     } ()
 }
 """,
@@ -610,34 +610,34 @@ class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
     func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-    	return Variant(vins.array)
+        return Variant(vins.array)
     }
 
     func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        vins.array = gArray
+        return nil
     }
     var years: VariantCollection<Int> = [1997]
 
     func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-    	return Variant(years.array)
+        return Variant(years.array)
     }
 
     func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Int.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Int.self)) else {
+            return nil
+        }
+        years.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -656,9 +656,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+        classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+        classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+        classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMMS", prefix: "")
         let _pyears = PropInfo (
             propertyType: .array,
@@ -667,9 +667,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "int",
             usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+        classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+        classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+        classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
     } ()
 }
 """,
@@ -694,34 +694,34 @@ class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
     func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-    	return Variant(vins.array)
+        return Variant(vins.array)
     }
 
     func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        vins.array = gArray
+        return nil
     }
     var years: VariantCollection<Int> = [1997]
 
     func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-    	return Variant(years.array)
+        return Variant(years.array)
     }
 
     func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Int.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Int.self)) else {
+            return nil
+        }
+        years.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -740,9 +740,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+        classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+        classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+        classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         let _pyears = PropInfo (
             propertyType: .array,
             propertyName: "years",
@@ -750,9 +750,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "int",
             usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+        classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+        classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+        classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
         classInfo.addPropertyGroup(name: "Pointless", prefix: "")
     } ()
 }
@@ -782,66 +782,66 @@ class Car: Node {
     var vins: VariantCollection<String> = [""]
 
     func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-    	return Variant(vins.array)
+        return Variant(vins.array)
     }
 
     func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        vins.array = gArray
+        return nil
     }
     var years: VariantCollection<Int> = [1997]
 
     func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-    	return Variant(years.array)
+        return Variant(years.array)
     }
 
     func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Int.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Int.self)) else {
+            return nil
+        }
+        years.array = gArray
+        return nil
     }
     var makes: VariantCollection<String> = ["HONDA"]
 
     func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
-    	return Variant(makes.array)
+        return Variant(makes.array)
     }
 
     func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	makes.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        makes.array = gArray
+        return nil
     }
     var models: VariantCollection<String> = ["ACCORD"]
 
     func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
-    	return Variant(models.array)
+        return Variant(models.array)
     }
 
     func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	models.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        models.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -861,9 +861,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+        classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+        classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+        classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMM", prefix: "")
         let _pyears = PropInfo (
             propertyType: .array,
@@ -872,9 +872,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "int",
             usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+        classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+        classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+        classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
         let _pmakes = PropInfo (
             propertyType: .array,
             propertyName: "makes",
@@ -882,9 +882,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
-    	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
-    	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
+        classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
+        classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
+        classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
         let _pmodels = PropInfo (
             propertyType: .array,
             propertyName: "models",
@@ -892,9 +892,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
-    	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
-    	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
+        classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
+        classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
+        classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
     } ()
     
 }
@@ -922,34 +922,34 @@ class Car: Node {
     var makes: ObjectCollection<Node> = []
 
     func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
-    	return Variant(makes.array)
+        return Variant(makes.array)
     }
 
     func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	makes.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        makes.array = gArray
+        return nil
     }
     var model: ObjectCollection<Node> = []
 
     func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
-    	return Variant(model.array)
+        return Variant(model.array)
     }
 
     func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	model.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        model.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -969,9 +969,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
-    	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
-    	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
+        classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
+        classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
+        classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
         let _pmodel = PropInfo (
             propertyType: .array,
             propertyName: "model",
@@ -979,9 +979,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-    	classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-    	classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
+        classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+        classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+        classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
     } ()
 }
 """,
@@ -1006,34 +1006,34 @@ class Car: Node {
     var vins: ObjectCollection<Node> = []
 
     func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-    	return Variant(vins.array)
+        return Variant(vins.array)
     }
 
     func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        vins.array = gArray
+        return nil
     }
     var years: ObjectCollection<Node> = []
 
     func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-    	return Variant(years.array)
+        return Variant(years.array)
     }
 
     func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        years.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -1052,9 +1052,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+        classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+        classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+        classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMMS", prefix: "")
         let _pyears = PropInfo (
             propertyType: .array,
@@ -1063,9 +1063,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+        classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+        classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+        classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
     } ()
 }
 """,
@@ -1090,34 +1090,34 @@ class Car: Node {
     var vins: ObjectCollection<Node> = []
 
     func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-    	return Variant(vins.array)
+        return Variant(vins.array)
     }
 
     func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        vins.array = gArray
+        return nil
     }
     var years: ObjectCollection<Node> = []
 
     func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-    	return Variant(years.array)
+        return Variant(years.array)
     }
 
     func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        years.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -1136,9 +1136,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+        classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+        classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+        classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         let _pyears = PropInfo (
             propertyType: .array,
             propertyName: "years",
@@ -1146,9 +1146,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+        classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+        classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+        classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
         classInfo.addPropertyGroup(name: "Pointless", prefix: "")
     } ()
 }
@@ -1178,66 +1178,66 @@ class Car: Node {
     var vins: ObjectCollection<Node> = []
 
     func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-    	return Variant(vins.array)
+        return Variant(vins.array)
     }
 
     func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	vins.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        vins.array = gArray
+        return nil
     }
     var years: ObjectCollection<Node> = []
 
     func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-    	return Variant(years.array)
+        return Variant(years.array)
     }
 
     func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	years.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        years.array = gArray
+        return nil
     }
     var makes: ObjectCollection<Node> = []
 
     func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
-    	return Variant(makes.array)
+        return Variant(makes.array)
     }
 
     func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	makes.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        makes.array = gArray
+        return nil
     }
     var models: ObjectCollection<Node> = []
 
     func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
-    	return Variant(models.array)
+        return Variant(models.array)
     }
 
     func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Node.self)) else {
-    		return nil
-    	}
-    	models.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node.self)) else {
+            return nil
+        }
+        models.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -1257,9 +1257,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
-    	classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
-    	classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
+        classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
+        classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
+        classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMM", prefix: "")
         let _pyears = PropInfo (
             propertyType: .array,
@@ -1268,9 +1268,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
-    	classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
-    	classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
+        classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
+        classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
+        classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
         let _pmakes = PropInfo (
             propertyType: .array,
             propertyName: "makes",
@@ -1278,9 +1278,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
-    	classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
-    	classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
+        classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
+        classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
+        classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
         let _pmodels = PropInfo (
             propertyType: .array,
             propertyName: "models",
@@ -1288,9 +1288,9 @@ class Car: Node {
             hint: .arrayType,
             hintStr: "Node",
             usage: .default)
-    	classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
-    	classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
-    	classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
+        classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
+        classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
+        classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")
     } ()
     
 }
@@ -1324,15 +1324,15 @@ class Garage: Node {
     var name: String = ""
 
     func _mproxy_set_name (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.name = value
-    	} else {
-    		GD.printErr ("Unable to set `name` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.name = value
+        } else {
+            GD.printErr ("Unable to set `name` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_name (args: borrowing Arguments) -> Variant? {
@@ -1341,15 +1341,15 @@ class Garage: Node {
     var rating: Float = 0.0
 
     func _mproxy_set_rating (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Float (arg) {
-    		self.rating = value
-    	} else {
-    		GD.printErr ("Unable to set `rating` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = Float (arg) {
+            self.rating = value
+        } else {
+            GD.printErr ("Unable to set `rating` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_rating (args: borrowing Arguments) -> Variant? {
@@ -1358,47 +1358,47 @@ class Garage: Node {
     var reviews: VariantCollection<String> = []
 
     func _mproxy_get_reviews(args: borrowing Arguments) -> Variant? {
-    	return Variant(reviews.array)
+        return Variant(reviews.array)
     }
 
     func _mproxy_set_reviews(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	reviews.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        reviews.array = gArray
+        return nil
     }
     var checkIns: ObjectCollection<CheckIn> = []
 
     func _mproxy_get_checkIns(args: borrowing Arguments) -> Variant? {
-    	return Variant(checkIns.array)
+        return Variant(checkIns.array)
     }
 
     func _mproxy_set_checkIns(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(CheckIn.self)) else {
-    		return nil
-    	}
-    	checkIns.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(CheckIn.self)) else {
+            return nil
+        }
+        checkIns.array = gArray
+        return nil
     }
     var address: String = ""
 
     func _mproxy_set_address (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.address = value
-    	} else {
-    		GD.printErr ("Unable to set `address` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.address = value
+        } else {
+            GD.printErr ("Unable to set `address` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_address (args: borrowing Arguments) -> Variant? {
@@ -1407,50 +1407,50 @@ class Garage: Node {
     var daysOfOperation: VariantCollection<String> = []
 
     func _mproxy_get_daysOfOperation(args: borrowing Arguments) -> Variant? {
-    	return Variant(daysOfOperation.array)
+        return Variant(daysOfOperation.array)
     }
 
     func _mproxy_set_daysOfOperation(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	daysOfOperation.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        daysOfOperation.array = gArray
+        return nil
     }
     var hours: VariantCollection<String> = []
 
     func _mproxy_get_hours(args: borrowing Arguments) -> Variant? {
-    	return Variant(hours.array)
+        return Variant(hours.array)
     }
 
     func _mproxy_set_hours(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(String.self)) else {
-    		return nil
-    	}
-    	hours.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        hours.array = gArray
+        return nil
     }
     var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
 
     func _mproxy_get_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
-    	return Variant(insuranceProvidersAccepted.array)
+        return Variant(insuranceProvidersAccepted.array)
     }
 
     func _mproxy_set_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(InsuranceProvider.self)) else {
-    		return nil
-    	}
-    	insuranceProvidersAccepted.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(InsuranceProvider.self)) else {
+            return nil
+        }
+        insuranceProvidersAccepted.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -1470,9 +1470,9 @@ class Garage: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_name", flags: .default, returnValue: _pname, arguments: [], function: Garage._mproxy_get_name)
-    	classInfo.registerMethod (name: "_mproxy_set_name", flags: .default, returnValue: nil, arguments: [_pname], function: Garage._mproxy_set_name)
-    	classInfo.registerProperty (_pname, getter: "_mproxy_get_name", setter: "_mproxy_set_name")
+        classInfo.registerMethod (name: "_mproxy_get_name", flags: .default, returnValue: _pname, arguments: [], function: Garage._mproxy_get_name)
+        classInfo.registerMethod (name: "_mproxy_set_name", flags: .default, returnValue: nil, arguments: [_pname], function: Garage._mproxy_set_name)
+        classInfo.registerProperty (_pname, getter: "_mproxy_get_name", setter: "_mproxy_set_name")
         let _prating = PropInfo (
             propertyType: .float,
             propertyName: "rating",
@@ -1480,9 +1480,9 @@ class Garage: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_rating", flags: .default, returnValue: _prating, arguments: [], function: Garage._mproxy_get_rating)
-    	classInfo.registerMethod (name: "_mproxy_set_rating", flags: .default, returnValue: nil, arguments: [_prating], function: Garage._mproxy_set_rating)
-    	classInfo.registerProperty (_prating, getter: "_mproxy_get_rating", setter: "_mproxy_set_rating")
+        classInfo.registerMethod (name: "_mproxy_get_rating", flags: .default, returnValue: _prating, arguments: [], function: Garage._mproxy_get_rating)
+        classInfo.registerMethod (name: "_mproxy_set_rating", flags: .default, returnValue: nil, arguments: [_prating], function: Garage._mproxy_set_rating)
+        classInfo.registerProperty (_prating, getter: "_mproxy_get_rating", setter: "_mproxy_set_rating")
         classInfo.addPropertyGroup(name: "More Details", prefix: "")
         let _previews = PropInfo (
             propertyType: .array,
@@ -1491,9 +1491,9 @@ class Garage: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_reviews", flags: .default, returnValue: _previews, arguments: [], function: Garage._mproxy_get_reviews)
-    	classInfo.registerMethod (name: "set_reviews", flags: .default, returnValue: nil, arguments: [_previews], function: Garage._mproxy_set_reviews)
-    	classInfo.registerProperty (_previews, getter: "get_reviews", setter: "set_reviews")
+        classInfo.registerMethod (name: "get_reviews", flags: .default, returnValue: _previews, arguments: [], function: Garage._mproxy_get_reviews)
+        classInfo.registerMethod (name: "set_reviews", flags: .default, returnValue: nil, arguments: [_previews], function: Garage._mproxy_set_reviews)
+        classInfo.registerProperty (_previews, getter: "get_reviews", setter: "set_reviews")
         let _pcheckIns = PropInfo (
             propertyType: .array,
             propertyName: "check_ins",
@@ -1501,9 +1501,9 @@ class Garage: Node {
             hint: .arrayType,
             hintStr: "CheckIn",
             usage: .default)
-    	classInfo.registerMethod (name: "get_check_ins", flags: .default, returnValue: _pcheckIns, arguments: [], function: Garage._mproxy_get_checkIns)
-    	classInfo.registerMethod (name: "set_check_ins", flags: .default, returnValue: nil, arguments: [_pcheckIns], function: Garage._mproxy_set_checkIns)
-    	classInfo.registerProperty (_pcheckIns, getter: "get_check_ins", setter: "set_check_ins")
+        classInfo.registerMethod (name: "get_check_ins", flags: .default, returnValue: _pcheckIns, arguments: [], function: Garage._mproxy_get_checkIns)
+        classInfo.registerMethod (name: "set_check_ins", flags: .default, returnValue: nil, arguments: [_pcheckIns], function: Garage._mproxy_set_checkIns)
+        classInfo.registerProperty (_pcheckIns, getter: "get_check_ins", setter: "set_check_ins")
         let _paddress = PropInfo (
             propertyType: .string,
             propertyName: "address",
@@ -1511,9 +1511,9 @@ class Garage: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_address", flags: .default, returnValue: _paddress, arguments: [], function: Garage._mproxy_get_address)
-    	classInfo.registerMethod (name: "_mproxy_set_address", flags: .default, returnValue: nil, arguments: [_paddress], function: Garage._mproxy_set_address)
-    	classInfo.registerProperty (_paddress, getter: "_mproxy_get_address", setter: "_mproxy_set_address")
+        classInfo.registerMethod (name: "_mproxy_get_address", flags: .default, returnValue: _paddress, arguments: [], function: Garage._mproxy_get_address)
+        classInfo.registerMethod (name: "_mproxy_set_address", flags: .default, returnValue: nil, arguments: [_paddress], function: Garage._mproxy_set_address)
+        classInfo.registerProperty (_paddress, getter: "_mproxy_get_address", setter: "_mproxy_set_address")
         classInfo.addPropertyGroup(name: "Hours and Insurance", prefix: "")
         let _pdaysOfOperation = PropInfo (
             propertyType: .array,
@@ -1522,9 +1522,9 @@ class Garage: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_days_of_operation", flags: .default, returnValue: _pdaysOfOperation, arguments: [], function: Garage._mproxy_get_daysOfOperation)
-    	classInfo.registerMethod (name: "set_days_of_operation", flags: .default, returnValue: nil, arguments: [_pdaysOfOperation], function: Garage._mproxy_set_daysOfOperation)
-    	classInfo.registerProperty (_pdaysOfOperation, getter: "get_days_of_operation", setter: "set_days_of_operation")
+        classInfo.registerMethod (name: "get_days_of_operation", flags: .default, returnValue: _pdaysOfOperation, arguments: [], function: Garage._mproxy_get_daysOfOperation)
+        classInfo.registerMethod (name: "set_days_of_operation", flags: .default, returnValue: nil, arguments: [_pdaysOfOperation], function: Garage._mproxy_set_daysOfOperation)
+        classInfo.registerProperty (_pdaysOfOperation, getter: "get_days_of_operation", setter: "set_days_of_operation")
         let _phours = PropInfo (
             propertyType: .array,
             propertyName: "hours",
@@ -1532,9 +1532,9 @@ class Garage: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_hours", flags: .default, returnValue: _phours, arguments: [], function: Garage._mproxy_get_hours)
-    	classInfo.registerMethod (name: "set_hours", flags: .default, returnValue: nil, arguments: [_phours], function: Garage._mproxy_set_hours)
-    	classInfo.registerProperty (_phours, getter: "get_hours", setter: "set_hours")
+        classInfo.registerMethod (name: "get_hours", flags: .default, returnValue: _phours, arguments: [], function: Garage._mproxy_get_hours)
+        classInfo.registerMethod (name: "set_hours", flags: .default, returnValue: nil, arguments: [_phours], function: Garage._mproxy_set_hours)
+        classInfo.registerProperty (_phours, getter: "get_hours", setter: "set_hours")
         let _pinsuranceProvidersAccepted = PropInfo (
             propertyType: .array,
             propertyName: "insurance_providers_accepted",
@@ -1542,9 +1542,9 @@ class Garage: Node {
             hint: .arrayType,
             hintStr: "InsuranceProvider",
             usage: .default)
-    	classInfo.registerMethod (name: "get_insurance_providers_accepted", flags: .default, returnValue: _pinsuranceProvidersAccepted, arguments: [], function: Garage._mproxy_get_insuranceProvidersAccepted)
-    	classInfo.registerMethod (name: "set_insurance_providers_accepted", flags: .default, returnValue: nil, arguments: [_pinsuranceProvidersAccepted], function: Garage._mproxy_set_insuranceProvidersAccepted)
-    	classInfo.registerProperty (_pinsuranceProvidersAccepted, getter: "get_insurance_providers_accepted", setter: "set_insurance_providers_accepted")
+        classInfo.registerMethod (name: "get_insurance_providers_accepted", flags: .default, returnValue: _pinsuranceProvidersAccepted, arguments: [], function: Garage._mproxy_get_insuranceProvidersAccepted)
+        classInfo.registerMethod (name: "set_insurance_providers_accepted", flags: .default, returnValue: nil, arguments: [_pinsuranceProvidersAccepted], function: Garage._mproxy_set_insuranceProvidersAccepted)
+        classInfo.registerProperty (_pinsuranceProvidersAccepted, getter: "get_insurance_providers_accepted", setter: "set_insurance_providers_accepted")
     } ()
 }
 """,
@@ -1568,15 +1568,15 @@ class Garage: Node {
     var bar: Bool = false
 
     func _mproxy_set_bar (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Bool (arg) {
-    		self.bar = value
-    	} else {
-    		GD.printErr ("Unable to set `bar` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = Bool (arg) {
+            self.bar = value
+        } else {
+            GD.printErr ("Unable to set `bar` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_bar (args: borrowing Arguments) -> Variant? {
@@ -1600,9 +1600,9 @@ class Garage: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
-    	classInfo.registerMethod (name: "_mproxy_set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
-    	classInfo.registerProperty (_pbar, getter: "_mproxy_get_bar", setter: "_mproxy_set_bar")
+        classInfo.registerMethod (name: "_mproxy_get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
+        classInfo.registerMethod (name: "_mproxy_set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
+        classInfo.registerProperty (_pbar, getter: "_mproxy_get_bar", setter: "_mproxy_set_bar")
     } ()
 }
 """,
@@ -1627,15 +1627,15 @@ public class Issue353: Node {
     var prefix1_prefixed_bool: Bool = true
 
     func _mproxy_set_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Bool (arg) {
-    		self.prefix1_prefixed_bool = value
-    	} else {
-    		GD.printErr ("Unable to set `prefix1_prefixed_bool` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = Bool (arg) {
+            self.prefix1_prefixed_bool = value
+        } else {
+            GD.printErr ("Unable to set `prefix1_prefixed_bool` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant? {
@@ -1644,15 +1644,15 @@ public class Issue353: Node {
     var non_prefixed_bool: Bool = true
 
     func _mproxy_set_non_prefixed_bool (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Bool (arg) {
-    		self.non_prefixed_bool = value
-    	} else {
-    		GD.printErr ("Unable to set `non_prefixed_bool` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = Bool (arg) {
+            self.non_prefixed_bool = value
+        } else {
+            GD.printErr ("Unable to set `non_prefixed_bool` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_non_prefixed_bool (args: borrowing Arguments) -> Variant? {
@@ -1676,9 +1676,9 @@ public class Issue353: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
-    	classInfo.registerMethod (name: "_mproxy_set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
-    	classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "_mproxy_get__prefixed_bool", setter: "_mproxy_set__prefixed_bool")
+        classInfo.registerMethod (name: "_mproxy_get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
+        classInfo.registerMethod (name: "_mproxy_set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
+        classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "_mproxy_get__prefixed_bool", setter: "_mproxy_set__prefixed_bool")
         let _pnon_prefixed_bool = PropInfo (
             propertyType: .bool,
             propertyName: "non_prefixed_bool",
@@ -1686,9 +1686,9 @@ public class Issue353: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
-    	classInfo.registerMethod (name: "_mproxy_set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
-    	classInfo.registerProperty (_pnon_prefixed_bool, getter: "_mproxy_get_non_prefixed_bool", setter: "_mproxy_set_non_prefixed_bool")
+        classInfo.registerMethod (name: "_mproxy_get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
+        classInfo.registerMethod (name: "_mproxy_set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
+        classInfo.registerProperty (_pnon_prefixed_bool, getter: "_mproxy_get_non_prefixed_bool", setter: "_mproxy_set_non_prefixed_bool")
     } ()
 }
 """,
@@ -1712,18 +1712,18 @@ class Garage: Node {
     var bar: VariantCollection<Bool> = [false]
 
     func _mproxy_get_bar(args: borrowing Arguments) -> Variant? {
-    	return Variant(bar.array)
+        return Variant(bar.array)
     }
 
     func _mproxy_set_bar(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Bool.self)) else {
-    		return nil
-    	}
-    	bar.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Bool.self)) else {
+            return nil
+        }
+        bar.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -1743,9 +1743,9 @@ class Garage: Node {
             hint: .arrayType,
             hintStr: "bool",
             usage: .default)
-    	classInfo.registerMethod (name: "get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
-    	classInfo.registerMethod (name: "set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
-    	classInfo.registerProperty (_pbar, getter: "get_bar", setter: "set_bar")
+        classInfo.registerMethod (name: "get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
+        classInfo.registerMethod (name: "set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
+        classInfo.registerProperty (_pbar, getter: "get_bar", setter: "set_bar")
     } ()
 }
 """,
@@ -1770,34 +1770,34 @@ public class Issue353: Node {
     var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
 
     func _mproxy_get_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
-    	return Variant(prefix1_prefixed_bool.array)
+        return Variant(prefix1_prefixed_bool.array)
     }
 
     func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Bool.self)) else {
-    		return nil
-    	}
-    	prefix1_prefixed_bool.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Bool.self)) else {
+            return nil
+        }
+        prefix1_prefixed_bool.array = gArray
+        return nil
     }
     var non_prefixed_bool: VariantCollection<Bool> = [false]
 
     func _mproxy_get_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
-    	return Variant(non_prefixed_bool.array)
+        return Variant(non_prefixed_bool.array)
     }
 
     func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first,
-    		  let gArray = GArray(arg),
-    		  gArray.isTyped(),
-    		  gArray.isSameTyped(array: GArray(Bool.self)) else {
-    		return nil
-    	}
-    	non_prefixed_bool.array = gArray
-    	return nil
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Bool.self)) else {
+            return nil
+        }
+        non_prefixed_bool.array = gArray
+        return nil
     }
 
     override open class var classInitializer: Void {
@@ -1817,9 +1817,9 @@ public class Issue353: Node {
             hint: .arrayType,
             hintStr: "bool",
             usage: .default)
-    	classInfo.registerMethod (name: "get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
-    	classInfo.registerMethod (name: "set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
-    	classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "get__prefixed_bool", setter: "set__prefixed_bool")
+        classInfo.registerMethod (name: "get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
+        classInfo.registerMethod (name: "set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
+        classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "get__prefixed_bool", setter: "set__prefixed_bool")
         let _pnon_prefixed_bool = PropInfo (
             propertyType: .array,
             propertyName: "non_prefixed_bool",
@@ -1827,9 +1827,9 @@ public class Issue353: Node {
             hint: .arrayType,
             hintStr: "bool",
             usage: .default)
-    	classInfo.registerMethod (name: "get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
-    	classInfo.registerMethod (name: "set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
-    	classInfo.registerProperty (_pnon_prefixed_bool, getter: "get_non_prefixed_bool", setter: "set_non_prefixed_bool")
+        classInfo.registerMethod (name: "get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
+        classInfo.registerMethod (name: "set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
+        classInfo.registerProperty (_pnon_prefixed_bool, getter: "get_non_prefixed_bool", setter: "set_non_prefixed_bool")
     } ()
 }
 """,

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -11,81 +11,81 @@ import XCTest
 import SwiftGodotMacroLibrary
 
 final class MacroGodotExportCollectionTests: XCTestCase {
-	let testMacros: [String: Macro.Type] = [
-		"Godot": GodotMacro.self,
-		"Export": GodotExport.self,
-	]
-	
-	func testExportArrayStringGodotMacroFails() {
-		assertMacroExpansion(
-			"""
-			@Godot
-			class SomeNode: Node {
-				@Export var greetings: [String]
-			}
-			""",
-		expandedSource:
-			"""
+    let testMacros: [String: Macro.Type] = [
+        "Godot": GodotMacro.self,
+        "Export": GodotExport.self,
+    ]
+    
+    func testExportArrayStringGodotMacroFails() {
+        assertMacroExpansion(
+            """
+            @Godot
+            class SomeNode: Node {
+                @Export var greetings: [String]
+            }
+            """,
+        expandedSource:
+            """
 
-			class SomeNode: Node {
-				var greetings: [String]
-			}
-			""",
-			diagnostics: [
-				.init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 3, column: 2),
-				.init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 1, column: 1)
-			],
-			macros: testMacros
-		)
-	}
-	
-	func testExportArrayStringMacroFails() {
-		assertMacroExpansion(
-			"""
-			@Export
-			var greetings: [String]
-			""",
-		expandedSource:
-			"""
+            class SomeNode: Node {
+                var greetings: [String]
+            }
+            """,
+            diagnostics: [
+                .init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 3, column: 5),
+                .init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    }
+    
+    func testExportArrayStringMacroFails() {
+        assertMacroExpansion(
+            """
+            @Export
+            var greetings: [String]
+            """,
+        expandedSource:
+            """
 
-			var greetings: [String]
-			""",
-			diagnostics: [
-				.init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 1, column: 1)
-			],
-			macros: testMacros
-		)
-	}
+            var greetings: [String]
+            """,
+            diagnostics: [
+                .init(message: "@Export attribute can not be applied to Array types, use a VariantCollection, or an ObjectCollection instead", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    }
 
-	func testExportGenericArrayStringGodotMacro() {
-		assertMacroExpansion(
+    func testExportGenericArrayStringGodotMacro() {
+        assertMacroExpansion(
 """
 @Godot
 class SomeNode: Node {
-	@Export
-	var greetings: VariantCollection<String> = []
+    @Export
+    var greetings: VariantCollection<String> = []
 }
 """,
-			expandedSource:
+            expandedSource:
 """
 
 class SomeNode: Node {
-	var greetings: VariantCollection<String> = []
+    var greetings: VariantCollection<String> = []
 
-	func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-		return Variant(greetings.array)
-	}
+    func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+        return Variant(greetings.array)
+    }
 
-	func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(String.self)) else {
-			return nil
-		}
-		greetings.array = gArray
-		return nil
-	}
+    func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(String.self)) else {
+            return nil
+        }
+        greetings.array = gArray
+        return nil
+    }
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
@@ -103,114 +103,114 @@ class SomeNode: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
-    	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
-    	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
+        classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
+        classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
+        classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
     } ()
 }
 """,
-			macros: testMacros
-		)
-	}
-	
-	func testExportArrayStringMacro() {
-		assertMacroExpansion(
+            macros: testMacros
+        )
+    }
+    
+    func testExportArrayStringMacro() {
+        assertMacroExpansion(
 """
 @Export var greetings: VariantCollection<String> = []
 """,
-			expandedSource:
+            expandedSource:
 """
 
 var greetings: VariantCollection<String> = []
 
 func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-	return Variant(greetings.array)
+    return Variant(greetings.array)
 }
 
 func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-	guard let arg = args.first,
-		  let gArray = GArray(arg),
-		  gArray.isTyped(),
-		  gArray.isSameTyped(array: GArray(String.self)) else {
-		return nil
-	}
-	greetings.array = gArray
-	return nil
+    guard let arg = args.first,
+          let gArray = GArray(arg),
+          gArray.isTyped(),
+          gArray.isSameTyped(array: GArray(String.self)) else {
+        return nil
+    }
+    greetings.array = gArray
+    return nil
 }
 """,
-			macros: testMacros
-		)
-	}
-	
-	func testExportGenericArrayStringMacro() {
-		assertMacroExpansion(
+            macros: testMacros
+        )
+    }
+    
+    func testExportGenericArrayStringMacro() {
+        assertMacroExpansion(
 """
 @Export var greetings: VariantCollection<String> = []
 """,
-			expandedSource:
+            expandedSource:
 """
 
 var greetings: VariantCollection<String> = []
 
 func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-	return Variant(greetings.array)
+    return Variant(greetings.array)
 }
 
 func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-	guard let arg = args.first,
-		  let gArray = GArray(arg),
-		  gArray.isTyped(),
-		  gArray.isSameTyped(array: GArray(String.self)) else {
-		return nil
-	}
-	greetings.array = gArray
-	return nil
+    guard let arg = args.first,
+          let gArray = GArray(arg),
+          gArray.isTyped(),
+          gArray.isSameTyped(array: GArray(String.self)) else {
+        return nil
+    }
+    greetings.array = gArray
+    return nil
 }
 """,
-			macros: testMacros
-		)
-	}
-	
-	func testExportConstantGenericArrayStringMacro() {
-		assertMacroExpansion(
+            macros: testMacros
+        )
+    }
+    
+    func testExportConstantGenericArrayStringMacro() {
+        assertMacroExpansion(
 """
 @Export let greetings: VariantCollection<String> = []
 """,
-			expandedSource:
+            expandedSource:
 """
 
 let greetings: VariantCollection<String> = []
 
 func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-	return Variant(greetings.array)
+    return Variant(greetings.array)
 }
 
 func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-	guard let arg = args.first,
-		  let gArray = GArray(arg),
-		  gArray.isTyped(),
-		  gArray.isSameTyped(array: GArray(String.self)) else {
-		return nil
-	}
-	greetings.array = gArray
-	return nil
+    guard let arg = args.first,
+          let gArray = GArray(arg),
+          gArray.isTyped(),
+          gArray.isSameTyped(array: GArray(String.self)) else {
+        return nil
+    }
+    greetings.array = gArray
+    return nil
 }
 """,
-			macros: testMacros
-		)
-	}
-	
-	func testExportOptionalGenericArrayStringMacro() {
-		assertMacroExpansion(
-			"@Export var greetings: VariantCollection<String>? = []",
-			expandedSource: "var greetings: VariantCollection<String>? = []",
-			diagnostics: [
-				.init(message: "@Export optional Collections are not supported", line: 1, column: 1)
-			],
-			macros: testMacros
-		)
-	}
-	
+            macros: testMacros
+        )
+    }
+    
+    func testExportOptionalGenericArrayStringMacro() {
+        assertMacroExpansion(
+            "@Export var greetings: VariantCollection<String>? = []",
+            expandedSource: "var greetings: VariantCollection<String>? = []",
+            diagnostics: [
+                .init(message: "@Export optional Collections are not supported", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    }
+    
     func testExportGArray() {
         assertMacroExpansion(
 """
@@ -226,15 +226,15 @@ class SomeNode: Node {
     var someArray: GArray = GArray()
 
     func _mproxy_set_someArray (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = GArray (arg) {
-    		self.someArray = value
-    	} else {
-    		GD.printErr ("Unable to set `someArray` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = GArray (arg) {
+            self.someArray = value
+        } else {
+            GD.printErr ("Unable to set `someArray` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_someArray (args: borrowing Arguments) -> Variant? {
@@ -257,9 +257,9 @@ class SomeNode: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_someArray", flags: .default, returnValue: _psomeArray, arguments: [], function: SomeNode._mproxy_get_someArray)
-    	classInfo.registerMethod (name: "_mproxy_set_someArray", flags: .default, returnValue: nil, arguments: [_psomeArray], function: SomeNode._mproxy_set_someArray)
-    	classInfo.registerProperty (_psomeArray, getter: "_mproxy_get_someArray", setter: "_mproxy_set_someArray")
+        classInfo.registerMethod (name: "_mproxy_get_someArray", flags: .default, returnValue: _psomeArray, arguments: [], function: SomeNode._mproxy_get_someArray)
+        classInfo.registerMethod (name: "_mproxy_set_someArray", flags: .default, returnValue: nil, arguments: [_psomeArray], function: SomeNode._mproxy_set_someArray)
+        classInfo.registerProperty (_psomeArray, getter: "_mproxy_get_someArray", setter: "_mproxy_set_someArray")
     } ()
 }
 """,
@@ -267,34 +267,34 @@ class SomeNode: Node {
         )
     }
     
-	func testExportArrayIntGodotMacro() {
-		assertMacroExpansion(
+    func testExportArrayIntGodotMacro() {
+        assertMacroExpansion(
 """
 @Godot
 class SomeNode: Node {
-	@Export var someNumbers: VariantCollection<Int> = []
+    @Export var someNumbers: VariantCollection<Int> = []
 }
 """,
-			expandedSource:
+            expandedSource:
 """
 
 class SomeNode: Node {
-	var someNumbers: VariantCollection<Int> = []
+    var someNumbers: VariantCollection<Int> = []
 
-	func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
-		return Variant(someNumbers.array)
-	}
+    func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
+        return Variant(someNumbers.array)
+    }
 
-	func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(Int.self)) else {
-			return nil
-		}
-		someNumbers.array = gArray
-		return nil
-	}
+    func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Int.self)) else {
+            return nil
+        }
+        someNumbers.array = gArray
+        return nil
+    }
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
@@ -312,61 +312,61 @@ class SomeNode: Node {
             hint: .arrayType,
             hintStr: "int",
             usage: .default)
-    	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
-    	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
-    	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
+        classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
+        classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
+        classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
     } ()
 }
 """,
-			macros: testMacros
-		)
-	}
+            macros: testMacros
+        )
+    }
 
-	func testExportArraysIntGodotMacro() throws {
-		assertMacroExpansion(
+    func testExportArraysIntGodotMacro() throws {
+        assertMacroExpansion(
 """
 @Godot
 class SomeNode: Node {
-	@Export var someNumbers: VariantCollection<Int> = []
-	@Export var someOtherNumbers: VariantCollection<Int> = []
+    @Export var someNumbers: VariantCollection<Int> = []
+    @Export var someOtherNumbers: VariantCollection<Int> = []
 }
 """,
-			expandedSource:
+            expandedSource:
 """
 
 class SomeNode: Node {
-	var someNumbers: VariantCollection<Int> = []
+    var someNumbers: VariantCollection<Int> = []
 
-	func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
-		return Variant(someNumbers.array)
-	}
+    func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
+        return Variant(someNumbers.array)
+    }
 
-	func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(Int.self)) else {
-			return nil
-		}
-		someNumbers.array = gArray
-		return nil
-	}
-	var someOtherNumbers: VariantCollection<Int> = []
+    func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Int.self)) else {
+            return nil
+        }
+        someNumbers.array = gArray
+        return nil
+    }
+    var someOtherNumbers: VariantCollection<Int> = []
 
-	func _mproxy_get_someOtherNumbers(args: borrowing Arguments) -> Variant? {
-		return Variant(someOtherNumbers.array)
-	}
+    func _mproxy_get_someOtherNumbers(args: borrowing Arguments) -> Variant? {
+        return Variant(someOtherNumbers.array)
+    }
 
-	func _mproxy_set_someOtherNumbers(args: borrowing Arguments) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(Int.self)) else {
-			return nil
-		}
-		someOtherNumbers.array = gArray
-		return nil
-	}
+    func _mproxy_set_someOtherNumbers(args: borrowing Arguments) -> Variant? {
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Int.self)) else {
+            return nil
+        }
+        someOtherNumbers.array = gArray
+        return nil
+    }
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
@@ -384,9 +384,9 @@ class SomeNode: Node {
             hint: .arrayType,
             hintStr: "int",
             usage: .default)
-    	classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
-    	classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
-    	classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
+        classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
+        classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
+        classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
         let _psomeOtherNumbers = PropInfo (
             propertyType: .array,
             propertyName: "some_other_numbers",
@@ -394,18 +394,18 @@ class SomeNode: Node {
             hint: .arrayType,
             hintStr: "int",
             usage: .default)
-    	classInfo.registerMethod (name: "get_some_other_numbers", flags: .default, returnValue: _psomeOtherNumbers, arguments: [], function: SomeNode._mproxy_get_someOtherNumbers)
-    	classInfo.registerMethod (name: "set_some_other_numbers", flags: .default, returnValue: nil, arguments: [_psomeOtherNumbers], function: SomeNode._mproxy_set_someOtherNumbers)
-    	classInfo.registerProperty (_psomeOtherNumbers, getter: "get_some_other_numbers", setter: "set_some_other_numbers")
+        classInfo.registerMethod (name: "get_some_other_numbers", flags: .default, returnValue: _psomeOtherNumbers, arguments: [], function: SomeNode._mproxy_get_someOtherNumbers)
+        classInfo.registerMethod (name: "set_some_other_numbers", flags: .default, returnValue: nil, arguments: [_psomeOtherNumbers], function: SomeNode._mproxy_set_someOtherNumbers)
+        classInfo.registerProperty (_psomeOtherNumbers, getter: "get_some_other_numbers", setter: "set_some_other_numbers")
     } ()
 }
 """,
-			macros: testMacros
-		)
-	}
-	
-	func testGodotExportTwoStringArrays() throws {
-		assertMacroExpansion(
+            macros: testMacros
+        )
+    }
+    
+    func testGodotExportTwoStringArrays() throws {
+        assertMacroExpansion(
 """
 import SwiftGodot
 
@@ -415,41 +415,41 @@ class ArrayTest: Node {
    @Export var lastNames: VariantCollection<String> = ["Monk"]
 }
 """
-		, expandedSource:
+        , expandedSource:
 """
 import SwiftGodot
 class ArrayTest: Node {
    var firstNames: VariantCollection<String> = ["Thelonius"]
 
    func _mproxy_get_firstNames(args: borrowing Arguments) -> Variant? {
-   	return Variant(firstNames.array)
+       return Variant(firstNames.array)
    }
 
    func _mproxy_set_firstNames(args: borrowing Arguments) -> Variant? {
-   	guard let arg = args.first,
-   		  let gArray = GArray(arg),
-   		  gArray.isTyped(),
-   		  gArray.isSameTyped(array: GArray(String.self)) else {
-   		return nil
-   	}
-   	firstNames.array = gArray
-   	return nil
+       guard let arg = args.first,
+             let gArray = GArray(arg),
+             gArray.isTyped(),
+             gArray.isSameTyped(array: GArray(String.self)) else {
+           return nil
+       }
+       firstNames.array = gArray
+       return nil
    }
    var lastNames: VariantCollection<String> = ["Monk"]
 
    func _mproxy_get_lastNames(args: borrowing Arguments) -> Variant? {
-   	return Variant(lastNames.array)
+       return Variant(lastNames.array)
    }
 
    func _mproxy_set_lastNames(args: borrowing Arguments) -> Variant? {
-   	guard let arg = args.first,
-   		  let gArray = GArray(arg),
-   		  gArray.isTyped(),
-   		  gArray.isSameTyped(array: GArray(String.self)) else {
-   		return nil
-   	}
-   	lastNames.array = gArray
-   	return nil
+       guard let arg = args.first,
+             let gArray = GArray(arg),
+             gArray.isTyped(),
+             gArray.isSameTyped(array: GArray(String.self)) else {
+           return nil
+       }
+       lastNames.array = gArray
+       return nil
    }
 
     override open class var classInitializer: Void {
@@ -468,9 +468,9 @@ class ArrayTest: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_first_names", flags: .default, returnValue: _pfirstNames, arguments: [], function: ArrayTest._mproxy_get_firstNames)
-    	classInfo.registerMethod (name: "set_first_names", flags: .default, returnValue: nil, arguments: [_pfirstNames], function: ArrayTest._mproxy_set_firstNames)
-    	classInfo.registerProperty (_pfirstNames, getter: "get_first_names", setter: "set_first_names")
+        classInfo.registerMethod (name: "get_first_names", flags: .default, returnValue: _pfirstNames, arguments: [], function: ArrayTest._mproxy_get_firstNames)
+        classInfo.registerMethod (name: "set_first_names", flags: .default, returnValue: nil, arguments: [_pfirstNames], function: ArrayTest._mproxy_set_firstNames)
+        classInfo.registerProperty (_pfirstNames, getter: "get_first_names", setter: "set_first_names")
         let _plastNames = PropInfo (
             propertyType: .array,
             propertyName: "last_names",
@@ -478,72 +478,72 @@ class ArrayTest: Node {
             hint: .arrayType,
             hintStr: "String",
             usage: .default)
-    	classInfo.registerMethod (name: "get_last_names", flags: .default, returnValue: _plastNames, arguments: [], function: ArrayTest._mproxy_get_lastNames)
-    	classInfo.registerMethod (name: "set_last_names", flags: .default, returnValue: nil, arguments: [_plastNames], function: ArrayTest._mproxy_set_lastNames)
-    	classInfo.registerProperty (_plastNames, getter: "get_last_names", setter: "set_last_names")
+        classInfo.registerMethod (name: "get_last_names", flags: .default, returnValue: _plastNames, arguments: [], function: ArrayTest._mproxy_get_lastNames)
+        classInfo.registerMethod (name: "set_last_names", flags: .default, returnValue: nil, arguments: [_plastNames], function: ArrayTest._mproxy_set_lastNames)
+        classInfo.registerProperty (_plastNames, getter: "get_last_names", setter: "set_last_names")
     } ()
 }
 """
-		, macros: testMacros
-		)
-	}
-	
-	func testExportObjectCollection() throws {
-		assertMacroExpansion(
+        , macros: testMacros
+        )
+    }
+    
+    func testExportObjectCollection() throws {
+        assertMacroExpansion(
 """
 @Export var greetings: ObjectCollection<Node3D> = []
 """,
-			expandedSource:
+            expandedSource:
 """
 var greetings: ObjectCollection<Node3D> = []
 
 func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-	return Variant(greetings.array)
+    return Variant(greetings.array)
 }
 
 func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-	guard let arg = args.first,
-		  let gArray = GArray(arg),
-		  gArray.isTyped(),
-		  gArray.isSameTyped(array: GArray(Node3D.self)) else {
-		return nil
-	}
-	greetings.array = gArray
-	return nil
+    guard let arg = args.first,
+          let gArray = GArray(arg),
+          gArray.isTyped(),
+          gArray.isSameTyped(array: GArray(Node3D.self)) else {
+        return nil
+    }
+    greetings.array = gArray
+    return nil
 }
 """,
-			macros: testMacros
-		)
-	}
-	
-	func testGodotExportObjectCollection() throws {
-		assertMacroExpansion(
+            macros: testMacros
+        )
+    }
+    
+    func testGodotExportObjectCollection() throws {
+        assertMacroExpansion(
 """
 @Godot
 class SomeNode: Node {
-	@Export var greetings: ObjectCollection<Node3D> = []
+    @Export var greetings: ObjectCollection<Node3D> = []
 }
 """,
-			expandedSource:
+            expandedSource:
 """
 
 class SomeNode: Node {
-	var greetings: ObjectCollection<Node3D> = []
+    var greetings: ObjectCollection<Node3D> = []
 
-	func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-		return Variant(greetings.array)
-	}
+    func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+        return Variant(greetings.array)
+    }
 
-	func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-		guard let arg = args.first,
-			  let gArray = GArray(arg),
-			  gArray.isTyped(),
-			  gArray.isSameTyped(array: GArray(Node3D.self)) else {
-			return nil
-		}
-		greetings.array = gArray
-		return nil
-	}
+    func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
+        guard let arg = args.first,
+              let gArray = GArray(arg),
+              gArray.isTyped(),
+              gArray.isSameTyped(array: GArray(Node3D.self)) else {
+            return nil
+        }
+        greetings.array = gArray
+        return nil
+    }
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
@@ -561,13 +561,13 @@ class SomeNode: Node {
             hint: .arrayType,
             hintStr: "Node3D",
             usage: .default)
-    	classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
-    	classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
-    	classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
+        classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
+        classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
+        classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
     } ()
 }
 """,
-			macros: testMacros
-		)
-	}
+            macros: testMacros
+        )
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -72,13 +72,13 @@ class SomeNode: Node {
 class SomeNode: Node {
     var greetings: VariantCollection<String> = []
 
-    func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_greetings(args: borrowing Arguments) -> Variant {
         return Variant(greetings.array)
     }
 
-    func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_greetings(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(String.self)) else {
             return nil
@@ -123,13 +123,13 @@ class SomeNode: Node {
 
 var greetings: VariantCollection<String> = []
 
-func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+func _mproxy_get_greetings(args: borrowing Arguments) -> Variant {
     return Variant(greetings.array)
 }
 
-func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-    guard let arg = args.first,
-          let gArray = GArray(arg),
+func _mproxy_set_greetings(args: borrowing Arguments) -> Variant {
+    let arg = args.first
+    guard let gArray = GArray(arg),
           gArray.isTyped(),
           gArray.isSameTyped(array: GArray(String.self)) else {
         return nil
@@ -152,13 +152,13 @@ func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
 
 var greetings: VariantCollection<String> = []
 
-func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+func _mproxy_get_greetings(args: borrowing Arguments) -> Variant {
     return Variant(greetings.array)
 }
 
-func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-    guard let arg = args.first,
-          let gArray = GArray(arg),
+func _mproxy_set_greetings(args: borrowing Arguments) -> Variant {
+    let arg = args.first
+    guard let gArray = GArray(arg),
           gArray.isTyped(),
           gArray.isSameTyped(array: GArray(String.self)) else {
         return nil
@@ -181,13 +181,13 @@ func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
 
 let greetings: VariantCollection<String> = []
 
-func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+func _mproxy_get_greetings(args: borrowing Arguments) -> Variant {
     return Variant(greetings.array)
 }
 
-func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-    guard let arg = args.first,
-          let gArray = GArray(arg),
+func _mproxy_set_greetings(args: borrowing Arguments) -> Variant {
+    let arg = args.first
+    guard let gArray = GArray(arg),
           gArray.isTyped(),
           gArray.isSameTyped(array: GArray(String.self)) else {
         return nil
@@ -225,10 +225,8 @@ class SomeNode: Node {
 class SomeNode: Node {
     var someArray: GArray = GArray()
 
-    func _mproxy_set_someArray (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_someArray (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = GArray (arg) {
             self.someArray = value
         } else {
@@ -237,7 +235,7 @@ class SomeNode: Node {
         return nil
     }
 
-    func _mproxy_get_someArray (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_someArray (args: borrowing Arguments) -> Variant {
         return Variant (someArray)
     }
 
@@ -281,13 +279,13 @@ class SomeNode: Node {
 class SomeNode: Node {
     var someNumbers: VariantCollection<Int> = []
 
-    func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant {
         return Variant(someNumbers.array)
     }
 
-    func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Int.self)) else {
             return nil
@@ -337,13 +335,13 @@ class SomeNode: Node {
 class SomeNode: Node {
     var someNumbers: VariantCollection<Int> = []
 
-    func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant {
         return Variant(someNumbers.array)
     }
 
-    func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Int.self)) else {
             return nil
@@ -353,13 +351,13 @@ class SomeNode: Node {
     }
     var someOtherNumbers: VariantCollection<Int> = []
 
-    func _mproxy_get_someOtherNumbers(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_someOtherNumbers(args: borrowing Arguments) -> Variant {
         return Variant(someOtherNumbers.array)
     }
 
-    func _mproxy_set_someOtherNumbers(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_someOtherNumbers(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Int.self)) else {
             return nil
@@ -421,13 +419,13 @@ import SwiftGodot
 class ArrayTest: Node {
    var firstNames: VariantCollection<String> = ["Thelonius"]
 
-   func _mproxy_get_firstNames(args: borrowing Arguments) -> Variant? {
+   func _mproxy_get_firstNames(args: borrowing Arguments) -> Variant {
        return Variant(firstNames.array)
    }
 
-   func _mproxy_set_firstNames(args: borrowing Arguments) -> Variant? {
-       guard let arg = args.first,
-             let gArray = GArray(arg),
+   func _mproxy_set_firstNames(args: borrowing Arguments) -> Variant {
+       let arg = args.first
+       guard let gArray = GArray(arg),
              gArray.isTyped(),
              gArray.isSameTyped(array: GArray(String.self)) else {
            return nil
@@ -437,13 +435,13 @@ class ArrayTest: Node {
    }
    var lastNames: VariantCollection<String> = ["Monk"]
 
-   func _mproxy_get_lastNames(args: borrowing Arguments) -> Variant? {
+   func _mproxy_get_lastNames(args: borrowing Arguments) -> Variant {
        return Variant(lastNames.array)
    }
 
-   func _mproxy_set_lastNames(args: borrowing Arguments) -> Variant? {
-       guard let arg = args.first,
-             let gArray = GArray(arg),
+   func _mproxy_set_lastNames(args: borrowing Arguments) -> Variant {
+       let arg = args.first
+       guard let gArray = GArray(arg),
              gArray.isTyped(),
              gArray.isSameTyped(array: GArray(String.self)) else {
            return nil
@@ -497,13 +495,13 @@ class ArrayTest: Node {
 """
 var greetings: ObjectCollection<Node3D> = []
 
-func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+func _mproxy_get_greetings(args: borrowing Arguments) -> Variant {
     return Variant(greetings.array)
 }
 
-func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-    guard let arg = args.first,
-          let gArray = GArray(arg),
+func _mproxy_set_greetings(args: borrowing Arguments) -> Variant {
+    let arg = args.first
+    guard let gArray = GArray(arg),
           gArray.isTyped(),
           gArray.isSameTyped(array: GArray(Node3D.self)) else {
         return nil
@@ -530,13 +528,13 @@ class SomeNode: Node {
 class SomeNode: Node {
     var greetings: ObjectCollection<Node3D> = []
 
-    func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_greetings(args: borrowing Arguments) -> Variant {
         return Variant(greetings.array)
     }
 
-    func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first,
-              let gArray = GArray(arg),
+    func _mproxy_set_greetings(args: borrowing Arguments) -> Variant {
+        let arg = args.first
+        guard let gArray = GArray(arg),
               gArray.isTyped(),
               gArray.isSameTyped(array: GArray(Node3D.self)) else {
             return nil

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
@@ -46,7 +46,7 @@ final class MacroGodotExportEnumTests: XCTestCase {
                 if let iv = Int (args [0]), let ev = Demo(rawValue: numericCast (iv)) {
                     self.demo = ev
                 }
-            	return nil
+                return nil
             }
 
             func _mproxy_get_demo (args: borrowing Arguments) -> Variant? {
@@ -58,7 +58,7 @@ final class MacroGodotExportEnumTests: XCTestCase {
                 if let iv = Int (args [0]), let ev = Demo64(rawValue: numericCast (iv)) {
                     self.demo64 = ev
                 }
-            	return nil
+                return nil
             }
 
             func _mproxy_get_demo64 (args: borrowing Arguments) -> Variant? {
@@ -81,9 +81,9 @@ final class MacroGodotExportEnumTests: XCTestCase {
                     hint: .enum,
                     hintStr: tryCase (Demo.self),
                     usage: .default)
-            	classInfo.registerMethod (name: "_mproxy_get_demo", flags: .default, returnValue: _pdemo, arguments: [], function: SomeNode._mproxy_get_demo)
-            	classInfo.registerMethod (name: "_mproxy_set_demo", flags: .default, returnValue: nil, arguments: [_pdemo], function: SomeNode._mproxy_set_demo)
-            	classInfo.registerProperty (_pdemo, getter: "_mproxy_get_demo", setter: "_mproxy_set_demo")
+                classInfo.registerMethod (name: "_mproxy_get_demo", flags: .default, returnValue: _pdemo, arguments: [], function: SomeNode._mproxy_get_demo)
+                classInfo.registerMethod (name: "_mproxy_set_demo", flags: .default, returnValue: nil, arguments: [_pdemo], function: SomeNode._mproxy_set_demo)
+                classInfo.registerProperty (_pdemo, getter: "_mproxy_get_demo", setter: "_mproxy_set_demo")
                 let _pdemo64 = PropInfo (
                     propertyType: .int,
                     propertyName: "demo64",
@@ -91,9 +91,9 @@ final class MacroGodotExportEnumTests: XCTestCase {
                     hint: .enum,
                     hintStr: tryCase (Demo64.self),
                     usage: .default)
-            	classInfo.registerMethod (name: "_mproxy_get_demo64", flags: .default, returnValue: _pdemo64, arguments: [], function: SomeNode._mproxy_get_demo64)
-            	classInfo.registerMethod (name: "_mproxy_set_demo64", flags: .default, returnValue: nil, arguments: [_pdemo64], function: SomeNode._mproxy_set_demo64)
-            	classInfo.registerProperty (_pdemo64, getter: "_mproxy_get_demo64", setter: "_mproxy_set_demo64")
+                classInfo.registerMethod (name: "_mproxy_get_demo64", flags: .default, returnValue: _pdemo64, arguments: [], function: SomeNode._mproxy_get_demo64)
+                classInfo.registerMethod (name: "_mproxy_set_demo64", flags: .default, returnValue: nil, arguments: [_pdemo64], function: SomeNode._mproxy_set_demo64)
+                classInfo.registerProperty (_pdemo64, getter: "_mproxy_get_demo64", setter: "_mproxy_set_demo64")
                 func tryCase <T : RawRepresentable & CaseIterable> (_ type: T.Type) -> GString {
                     GString (type.allCases.map { v in
                         "\\(v):\\(v.rawValue)"

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
@@ -42,26 +42,26 @@ final class MacroGodotExportEnumTests: XCTestCase {
         class SomeNode: Node {
             var demo: Demo
 
-            func _mproxy_set_demo (args: borrowing Arguments) -> Variant? {
+            func _mproxy_set_demo (args: borrowing Arguments) -> Variant {
                 if let iv = Int (args [0]), let ev = Demo(rawValue: numericCast (iv)) {
                     self.demo = ev
                 }
                 return nil
             }
 
-            func _mproxy_get_demo (args: borrowing Arguments) -> Variant? {
+            func _mproxy_get_demo (args: borrowing Arguments) -> Variant {
                 return Variant (demo.rawValue)
             }
             var demo64: Demo64
 
-            func _mproxy_set_demo64 (args: borrowing Arguments) -> Variant? {
+            func _mproxy_set_demo64 (args: borrowing Arguments) -> Variant {
                 if let iv = Int (args [0]), let ev = Demo64(rawValue: numericCast (iv)) {
                     self.demo64 = ev
                 }
                 return nil
             }
 
-            func _mproxy_get_demo64 (args: borrowing Arguments) -> Variant? {
+            func _mproxy_get_demo64 (args: borrowing Arguments) -> Variant {
                 return Variant (demo64.rawValue)
             }
 

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
@@ -38,15 +38,15 @@ class Car: Node {
     var vin: String = ""
 
     func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.vin = value
-    	} else {
-    		GD.printErr ("Unable to set `vin` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.vin = value
+        } else {
+            GD.printErr ("Unable to set `vin` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
@@ -55,15 +55,15 @@ class Car: Node {
     var ymms_year: Int = 1998
 
     func _mproxy_set_ymms_year (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = Int (arg) {
-    		self.ymms_year = value
-    	} else {
-    		GD.printErr ("Unable to set `ymms_year` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = Int (arg) {
+            self.ymms_year = value
+        } else {
+            GD.printErr ("Unable to set `ymms_year` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_ymms_year (args: borrowing Arguments) -> Variant? {
@@ -72,15 +72,15 @@ class Car: Node {
     var ymms_make: String = "Honda"
 
     func _mproxy_set_ymms_make (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.ymms_make = value
-    	} else {
-    		GD.printErr ("Unable to set `ymms_make` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.ymms_make = value
+        } else {
+            GD.printErr ("Unable to set `ymms_make` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_ymms_make (args: borrowing Arguments) -> Variant? {
@@ -89,15 +89,15 @@ class Car: Node {
     var ymms_model: String = "Odyssey"
 
     func _mproxy_set_ymms_model (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.ymms_model = value
-    	} else {
-    		GD.printErr ("Unable to set `ymms_model` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.ymms_model = value
+        } else {
+            GD.printErr ("Unable to set `ymms_model` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_ymms_model (args: borrowing Arguments) -> Variant? {
@@ -106,15 +106,15 @@ class Car: Node {
     var ymms_series: String = "LX"
 
     func _mproxy_set_ymms_series (args: borrowing Arguments) -> Variant? {
-    	guard let arg = args.first else {
-    		return nil
-    	}
-    	if let value = String (arg) {
-    		self.ymms_series = value
-    	} else {
-    		GD.printErr ("Unable to set `ymms_series` value: ", arg)
-    	}
-    	return nil
+        guard let arg = args.first else {
+            return nil
+        }
+        if let value = String (arg) {
+            self.ymms_series = value
+        } else {
+            GD.printErr ("Unable to set `ymms_series` value: ", arg)
+        }
+        return nil
     }
 
     func _mproxy_get_ymms_series (args: borrowing Arguments) -> Variant? {
@@ -139,9 +139,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-    	classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-    	classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+        classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+        classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+        classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
         classInfo.addPropertySubgroup(name: "YMMS", prefix: "ymms_")
         let _pymms_year = PropInfo (
             propertyType: .int,
@@ -150,9 +150,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pymms_year, arguments: [], function: Car._mproxy_get_ymms_year)
-    	classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pymms_year], function: Car._mproxy_set_ymms_year)
-    	classInfo.registerProperty (_pymms_year, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+        classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pymms_year, arguments: [], function: Car._mproxy_get_ymms_year)
+        classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pymms_year], function: Car._mproxy_set_ymms_year)
+        classInfo.registerProperty (_pymms_year, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
         let _pymms_make = PropInfo (
             propertyType: .string,
             propertyName: "ymms_make",
@@ -160,9 +160,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pymms_make, arguments: [], function: Car._mproxy_get_ymms_make)
-    	classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pymms_make], function: Car._mproxy_set_ymms_make)
-    	classInfo.registerProperty (_pymms_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
+        classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pymms_make, arguments: [], function: Car._mproxy_get_ymms_make)
+        classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pymms_make], function: Car._mproxy_set_ymms_make)
+        classInfo.registerProperty (_pymms_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
         let _pymms_model = PropInfo (
             propertyType: .string,
             propertyName: "ymms_model",
@@ -170,9 +170,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pymms_model, arguments: [], function: Car._mproxy_get_ymms_model)
-    	classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pymms_model], function: Car._mproxy_set_ymms_model)
-    	classInfo.registerProperty (_pymms_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+        classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pymms_model, arguments: [], function: Car._mproxy_get_ymms_model)
+        classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pymms_model], function: Car._mproxy_set_ymms_model)
+        classInfo.registerProperty (_pymms_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
         let _pymms_series = PropInfo (
             propertyType: .string,
             propertyName: "ymms_series",
@@ -180,9 +180,9 @@ class Car: Node {
             hint: .none,
             hintStr: "",
             usage: .default)
-    	classInfo.registerMethod (name: "_mproxy_get_series", flags: .default, returnValue: _pymms_series, arguments: [], function: Car._mproxy_get_ymms_series)
-    	classInfo.registerMethod (name: "_mproxy_set_series", flags: .default, returnValue: nil, arguments: [_pymms_series], function: Car._mproxy_set_ymms_series)
-    	classInfo.registerProperty (_pymms_series, getter: "_mproxy_get_series", setter: "_mproxy_set_series")
+        classInfo.registerMethod (name: "_mproxy_get_series", flags: .default, returnValue: _pymms_series, arguments: [], function: Car._mproxy_get_ymms_series)
+        classInfo.registerMethod (name: "_mproxy_set_series", flags: .default, returnValue: nil, arguments: [_pymms_series], function: Car._mproxy_set_ymms_series)
+        classInfo.registerProperty (_pymms_series, getter: "_mproxy_get_series", setter: "_mproxy_set_series")
     } ()
 }
 """,

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
@@ -37,10 +37,8 @@ final class MacroGodotExportSubroupTests: XCTestCase {
 class Car: Node {
     var vin: String = ""
 
-    func _mproxy_set_vin (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_vin (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.vin = value
         } else {
@@ -49,15 +47,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_vin (args: borrowing Arguments) -> Variant {
         return Variant (vin)
     }
     var ymms_year: Int = 1998
 
-    func _mproxy_set_ymms_year (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_ymms_year (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = Int (arg) {
             self.ymms_year = value
         } else {
@@ -66,15 +62,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_ymms_year (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_ymms_year (args: borrowing Arguments) -> Variant {
         return Variant (ymms_year)
     }
     var ymms_make: String = "Honda"
 
-    func _mproxy_set_ymms_make (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_ymms_make (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.ymms_make = value
         } else {
@@ -83,15 +77,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_ymms_make (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_ymms_make (args: borrowing Arguments) -> Variant {
         return Variant (ymms_make)
     }
     var ymms_model: String = "Odyssey"
 
-    func _mproxy_set_ymms_model (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_ymms_model (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.ymms_model = value
         } else {
@@ -100,15 +92,13 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_ymms_model (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_ymms_model (args: borrowing Arguments) -> Variant {
         return Variant (ymms_model)
     }
     var ymms_series: String = "LX"
 
-    func _mproxy_set_ymms_series (args: borrowing Arguments) -> Variant? {
-        guard let arg = args.first else {
-            return nil
-        }
+    func _mproxy_set_ymms_series (args: borrowing Arguments) -> Variant {
+        let arg = args.first
         if let value = String (arg) {
             self.ymms_series = value
         } else {
@@ -117,7 +107,7 @@ class Car: Node {
         return nil
     }
 
-    func _mproxy_get_ymms_series (args: borrowing Arguments) -> Variant? {
+    func _mproxy_get_ymms_series (args: borrowing Arguments) -> Variant {
         return Variant (ymms_series)
     }
 

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -204,31 +204,31 @@ final class MacroGodotTests: XCTestCase {
                 class Castro: Node {
                     func deleteEpisode() {}
 
-                    func _mproxy_deleteEpisode (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_deleteEpisode (args: borrowing Arguments) -> SwiftGodot.Variant {
                         deleteEpisode ()
                         return nil
                     }
                     func subscribe(podcast: Podcast) {}
 
-                    func _mproxy_subscribe (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_subscribe (args: borrowing Arguments) -> SwiftGodot.Variant {
                         subscribe (podcast: Podcast.makeOrUnwrap (args [0])!)
                         return nil
                     }
                     func removeSilences(from: Variant) {}
 
-                    func _mproxy_removeSilences (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_removeSilences (args: borrowing Arguments) -> SwiftGodot.Variant {
                         removeSilences (from: args [0])
                         return nil
                     }
                     func getLatestEpisode(podcast: Podcast) -> Episode {}
 
-                    func _mproxy_getLatestEpisode (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_getLatestEpisode (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = getLatestEpisode (podcast: Podcast.makeOrUnwrap (args [0])!)
                         return Variant (result)
                     }
                     func queue(_ podcast: Podcast, after preceedingPodcast: Podcast) {}
 
-                    func _mproxy_queue (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_queue (args: borrowing Arguments) -> SwiftGodot.Variant {
                         queue (Podcast.makeOrUnwrap (args [0])!, after: Podcast.makeOrUnwrap (args [1])!)
                         return nil
                     }
@@ -299,7 +299,7 @@ final class MacroGodotTests: XCTestCase {
             final class MyClass: Node {
                 var data: MyData = .init()
 
-                func _mproxy_set_data (args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_data (args: borrowing Arguments) -> Variant {
                     func dynamicCast<T, U>(_ value: T, as type: U.Type) -> U? {
                         value as? U
                     }
@@ -312,7 +312,7 @@ final class MacroGodotTests: XCTestCase {
                     return nil
                 }
 
-                func _mproxy_get_data (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_data (args: borrowing Arguments) -> Variant {
                     return Variant (data)
                 }
 
@@ -362,7 +362,7 @@ final class MacroGodotTests: XCTestCase {
                         return result
                     }
 
-                    func _mproxy_getIntegerCollection (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_getIntegerCollection (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = getIntegerCollection ()
                         return Variant (result)
                     }
@@ -404,7 +404,7 @@ final class MacroGodotTests: XCTestCase {
                         integers.map { $0 * $0 }.reduce(into: VariantCollection<Int>()) { $0.append(value: $1) }
                     }
                 
-                    func _mproxy_square (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_square (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = square (GArray(args[0])!.reduce(into: VariantCollection<Int>()) {
                                 $0.append(Int.makeOrUnwrap($1)!)
                             })
@@ -453,7 +453,7 @@ final class MacroGodotTests: XCTestCase {
                         return result
                     }
 
-                    func _mproxy_getNodeCollection (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_getNodeCollection (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = getNodeCollection ()
                         return Variant (result)
                     }
@@ -495,7 +495,7 @@ final class MacroGodotTests: XCTestCase {
                         nodes.forEach { print($0.name) }
                     }
                 
-                    func _mproxy_printNames (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_printNames (args: borrowing Arguments) -> SwiftGodot.Variant {
                         printNames (of: GArray(args[0])!.reduce(into: ObjectCollection<Node>()) {
                                 $0.append(Node.makeOrUnwrap($1)!)
                             })
@@ -542,7 +542,7 @@ final class MacroGodotTests: XCTestCase {
                         integers.reduce(into: 1) { $0 *= $1 }
                     }
                 
-                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = multiply (GArray (args [0])!.compactMap(Int.makeOrUnwrap))
                         return Variant (result)
                     }
@@ -593,7 +593,7 @@ final class MacroGodotTests: XCTestCase {
                         [1, 2, 3, 4]
                     }
                 
-                    func _mproxy_get_ages (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_get_ages (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = get_ages ()
                         return Variant ( result.reduce(into: GArray(Int.self)) {
                                 $0.append(Variant($1))
@@ -603,7 +603,7 @@ final class MacroGodotTests: XCTestCase {
                         [.init(), .init(), .init()]
                     }
                 
-                    func _mproxy_get_markers (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_get_markers (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = get_markers ()
                         return Variant ( result.reduce(into: GArray(Marker3D.self)) {
                                 $0.append(Variant($1))
@@ -649,7 +649,7 @@ final class MacroGodotTests: XCTestCase {
                         integers.reduce(into: 1) { $0 *= $1 }
                     }
                 
-                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = multiply (GArray (args [0])!.compactMap(Int.makeOrUnwrap))
                         return Variant (result)
                     }
@@ -700,7 +700,7 @@ final class MacroGodotTests: XCTestCase {
                         [1, 2, 3, 4]
                     }
                 
-                    func _mproxy_get_ages (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_get_ages (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = get_ages ()
                         return Variant ( result.reduce(into: GArray(Int.self)) {
                                 $0.append(Variant($1))
@@ -710,7 +710,7 @@ final class MacroGodotTests: XCTestCase {
                         [.init(), .init(), .init()]
                     }
                 
-                    func _mproxy_get_markers (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_get_markers (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = get_markers ()
                         return Variant ( result.reduce(into: GArray(Marker3D.self)) {
                                 $0.append(Variant($1))
@@ -751,19 +751,19 @@ final class MacroGodotTests: XCTestCase {
                 class MathHelper: Node {
                     func multiply(_ a: Int, by b: Int) -> Int { a * b}
 
-                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = multiply (Int.makeOrUnwrap (args [0])!, by: Int.makeOrUnwrap (args [1])!)
                         return Variant (result)
                     }
                     func divide(_ a: Float, by b: Float) -> Float { a / b }
 
-                    func _mproxy_divide (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_divide (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = divide (Float.makeOrUnwrap (args [0])!, by: Float.makeOrUnwrap (args [1])!)
                         return Variant (result)
                     }
                     func areBothTrue(_ a: Bool, and b: Bool) -> Bool { a == b }
 
-                    func _mproxy_areBothTrue (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    func _mproxy_areBothTrue (args: borrowing Arguments) -> SwiftGodot.Variant {
                         let result = areBothTrue (Bool.makeOrUnwrap (args [0])!, and: Bool.makeOrUnwrap (args [1])!)
                         return Variant (result)
                     }
@@ -820,10 +820,8 @@ final class MacroGodotTests: XCTestCase {
             class Hi: Node {
                 var goodName: String = "Supertop"
             
-                func _mproxy_set_goodName (args: borrowing Arguments) -> Variant? {
-                    guard let arg = args.first else {
-                        return nil
-                    }
+                func _mproxy_set_goodName (args: borrowing Arguments) -> Variant {
+                    let arg = args.first
                     if let value = String (arg) {
                         self.goodName = value
                     } else {
@@ -832,7 +830,7 @@ final class MacroGodotTests: XCTestCase {
                     return nil
                 }
             
-                func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_goodName (args: borrowing Arguments) -> Variant {
                     return Variant (goodName)
                 }
             

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -10,15 +10,16 @@ import SwiftSyntaxMacrosTestSupport
 import XCTest
 import SwiftGodotMacroLibrary
 
-// Note when editing: Xcode loves to change all indentation to be consistent as either tabs or spaces, but the macro expansion produces a mix.
-// I had to set Settings->Text Editing->Tab Key to "Inserts a Tab Character" in order to resolve this.
-// "Paste and Preserve Formatting" was also helpful.
+// Note when editing: use spaces for indentation, check that Xcode has following settings, if some tests fail without an obvious actual and expected output difference
+// Text Editing / Indentation
+// Prefer Indent Using = Spaces
+// Tab Key = Indents in leading whitespace
 
 final class MacroGodotTests: XCTestCase {
     let testMacros: [String: Macro.Type] = [
         "Godot": GodotMacro.self,
-		"Callable": GodotCallable.self,
-		"Export": GodotExport.self,
+        "Callable": GodotCallable.self,
+        "Export": GodotExport.self,
         "signal": SignalMacro.self
     ]
     
@@ -74,7 +75,7 @@ final class MacroGodotTests: XCTestCase {
                         return []
                     }
                     return super.implementedOverrides () + [
-                    	StringName("_has_point"),
+                        StringName("_has_point"),
                     ]
                 }
             }
@@ -107,7 +108,7 @@ final class MacroGodotTests: XCTestCase {
             
                 override open class func implementedOverrides () -> [StringName] {
                     return super.implementedOverrides () + [
-                    	StringName("_has_point"),
+                        StringName("_has_point"),
                     ]
                 }
             }
@@ -115,21 +116,21 @@ final class MacroGodotTests: XCTestCase {
             macros: testMacros
         )
     }
-	
-	func testGodotMacroWithNonCallableFunc() {
-		// Note when editing: Xcode loves to change all indentation to be consistent as either tabs or spaces, but the macro expansion produces a mix.
-		// I had to set Settings->Text Editing->Tab Key to "Inserts a Tab Character" in order to resolve this.
-		assertMacroExpansion(
-			"""
-			@Godot class Hi: Node {
-				func hi() {
-				}
-			}
-			""",
+    
+    func testGodotMacroWithNonCallableFunc() {
+        // Note when editing: Xcode loves to change all indentation to be consistent as either tabs or spaces, but the macro expansion produces a mix.
+        // I had to set Settings->Text Editing->Tab Key to "Inserts a Tab Character" in order to resolve this.
+        assertMacroExpansion(
+            """
+            @Godot class Hi: Node {
+                func hi() {
+                }
+            }
+            """,
             expandedSource: """
             class Hi: Node {
-            	func hi() {
-            	}
+                func hi() {
+                }
             
                 override open class var classInitializer: Void {
                     let _ = super.classInitializer
@@ -143,9 +144,9 @@ final class MacroGodotTests: XCTestCase {
                 } ()
             }
             """,
-			macros: testMacros
-		)
-	}
+            macros: testMacros
+        )
+    }
     func testGodotMacroStaticSignal() {
         // Note when editing: Xcode loves to change all indentation to be consistent as either tabs or spaces, but the macro expansion produces a mix.
         // I had to set Settings->Text Editing->Tab Key to "Inserts a Tab Character" in order to resolve this.
@@ -184,11 +185,11 @@ final class MacroGodotTests: XCTestCase {
             macros: testMacros
         )
     }
-	
-	func testGodotMacroWithCallableFuncWithObjectParams() {
-		// Note when editing: Xcode loves to change all indentation to be consistent as either tabs or spaces, but the macro expansion produces a mix.
-		// I had to set Settings->Text Editing->Tab Key to "Inserts a Tab Character" in order to resolve this.
-		assertMacroExpansion(
+    
+    func testGodotMacroWithCallableFuncWithObjectParams() {
+        // Note when editing: Xcode loves to change all indentation to be consistent as either tabs or spaces, but the macro expansion produces a mix.
+        // I had to set Settings->Text Editing->Tab Key to "Inserts a Tab Character" in order to resolve this.
+        assertMacroExpansion(
             """
             @Godot class Castro: Node {
                 @Callable func deleteEpisode() {}
@@ -204,32 +205,32 @@ final class MacroGodotTests: XCTestCase {
                     func deleteEpisode() {}
 
                     func _mproxy_deleteEpisode (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	deleteEpisode ()
-                    	return nil
+                        deleteEpisode ()
+                        return nil
                     }
                     func subscribe(podcast: Podcast) {}
 
                     func _mproxy_subscribe (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	subscribe (podcast: Podcast.makeOrUnwrap (args [0])!)
-                    	return nil
+                        subscribe (podcast: Podcast.makeOrUnwrap (args [0])!)
+                        return nil
                     }
                     func removeSilences(from: Variant) {}
 
                     func _mproxy_removeSilences (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	removeSilences (from: args [0])
-                    	return nil
+                        removeSilences (from: args [0])
+                        return nil
                     }
                     func getLatestEpisode(podcast: Podcast) -> Episode {}
 
                     func _mproxy_getLatestEpisode (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = getLatestEpisode (podcast: Podcast.makeOrUnwrap (args [0])!)
-                    	return Variant (result)
+                        let result = getLatestEpisode (podcast: Podcast.makeOrUnwrap (args [0])!)
+                        return Variant (result)
                     }
                     func queue(_ podcast: Podcast, after preceedingPodcast: Podcast) {}
 
                     func _mproxy_queue (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	queue (Podcast.makeOrUnwrap (args [0])!, after: Podcast.makeOrUnwrap (args [1])!)
-                    	return nil
+                        queue (Podcast.makeOrUnwrap (args [0])!, after: Podcast.makeOrUnwrap (args [1])!)
+                        return nil
                     }
 
                     override open class var classInitializer: Void {
@@ -241,34 +242,34 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("Castro")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<Castro> (name: className)
-                    	classInfo.registerMethod(name: StringName("deleteEpisode"), flags: .default, returnValue: nil, arguments: [], function: Castro._mproxy_deleteEpisode)
-                    	let prop_0 = PropInfo (propertyType: .object, propertyName: "podcast", className: StringName("Podcast"), hint: .none, hintStr: "", usage: .default)
-                    	let subscribeArgs = [
-                    		prop_0,
-                    	]
-                    	classInfo.registerMethod(name: StringName("subscribe"), flags: .default, returnValue: nil, arguments: subscribeArgs, function: Castro._mproxy_subscribe)
-                    	let prop_1 = PropInfo (propertyType: .object, propertyName: "from", className: StringName("Variant"), hint: .none, hintStr: "", usage: .default)
-                    	let removeSilencesArgs = [
-                    		prop_1,
-                    	]
-                    	classInfo.registerMethod(name: StringName("removeSilences"), flags: .default, returnValue: nil, arguments: removeSilencesArgs, function: Castro._mproxy_removeSilences)
-                    	let prop_2 = PropInfo (propertyType: .object, propertyName: "", className: StringName("Episode"), hint: .none, hintStr: "", usage: .default)
-                    	let getLatestEpisodeArgs = [
-                    		prop_0,
-                    	]
-                    	classInfo.registerMethod(name: StringName("getLatestEpisode"), flags: .default, returnValue: prop_2, arguments: getLatestEpisodeArgs, function: Castro._mproxy_getLatestEpisode)
-                    	let prop_3 = PropInfo (propertyType: .object, propertyName: "preceedingPodcast", className: StringName("Podcast"), hint: .none, hintStr: "", usage: .default)
-                    	let queueArgs = [
-                    		prop_0,
-                    		prop_3,
-                    	]
-                    	classInfo.registerMethod(name: StringName("queue"), flags: .default, returnValue: nil, arguments: queueArgs, function: Castro._mproxy_queue)
+                        classInfo.registerMethod(name: StringName("deleteEpisode"), flags: .default, returnValue: nil, arguments: [], function: Castro._mproxy_deleteEpisode)
+                        let prop_0 = PropInfo (propertyType: .object, propertyName: "podcast", className: StringName("Podcast"), hint: .none, hintStr: "", usage: .default)
+                        let subscribeArgs = [
+                            prop_0,
+                        ]
+                        classInfo.registerMethod(name: StringName("subscribe"), flags: .default, returnValue: nil, arguments: subscribeArgs, function: Castro._mproxy_subscribe)
+                        let prop_1 = PropInfo (propertyType: .object, propertyName: "from", className: StringName("Variant"), hint: .none, hintStr: "", usage: .default)
+                        let removeSilencesArgs = [
+                            prop_1,
+                        ]
+                        classInfo.registerMethod(name: StringName("removeSilences"), flags: .default, returnValue: nil, arguments: removeSilencesArgs, function: Castro._mproxy_removeSilences)
+                        let prop_2 = PropInfo (propertyType: .object, propertyName: "", className: StringName("Episode"), hint: .none, hintStr: "", usage: .default)
+                        let getLatestEpisodeArgs = [
+                            prop_0,
+                        ]
+                        classInfo.registerMethod(name: StringName("getLatestEpisode"), flags: .default, returnValue: prop_2, arguments: getLatestEpisodeArgs, function: Castro._mproxy_getLatestEpisode)
+                        let prop_3 = PropInfo (propertyType: .object, propertyName: "preceedingPodcast", className: StringName("Podcast"), hint: .none, hintStr: "", usage: .default)
+                        let queueArgs = [
+                            prop_0,
+                            prop_3,
+                        ]
+                        classInfo.registerMethod(name: StringName("queue"), flags: .default, returnValue: nil, arguments: queueArgs, function: Castro._mproxy_queue)
                     } ()
                 }
                 """,
-			macros: testMacros
-		)
-	}
+            macros: testMacros
+        )
+    }
     
     func testWarningAvoidance() {
         assertMacroExpansion(
@@ -308,7 +309,7 @@ final class MacroGodotTests: XCTestCase {
                         self.data = res
                     }
                     oldRef?.unreference()
-                	return nil
+                    return nil
                 }
 
                 func _mproxy_get_data (args: borrowing Arguments) -> Variant? {
@@ -331,9 +332,9 @@ final class MacroGodotTests: XCTestCase {
                         hint: .none,
                         hintStr: "",
                         usage: .default)
-                	classInfo.registerMethod (name: "_mproxy_get_data", flags: .default, returnValue: _pdata, arguments: [], function: MyClass._mproxy_get_data)
-                	classInfo.registerMethod (name: "_mproxy_set_data", flags: .default, returnValue: nil, arguments: [_pdata], function: MyClass._mproxy_set_data)
-                	classInfo.registerProperty (_pdata, getter: "_mproxy_get_data", setter: "_mproxy_set_data")
+                    classInfo.registerMethod (name: "_mproxy_get_data", flags: .default, returnValue: _pdata, arguments: [], function: MyClass._mproxy_get_data)
+                    classInfo.registerMethod (name: "_mproxy_set_data", flags: .default, returnValue: nil, arguments: [_pdata], function: MyClass._mproxy_set_data)
+                    classInfo.registerProperty (_pdata, getter: "_mproxy_get_data", setter: "_mproxy_set_data")
                 } ()
             }
             """,
@@ -362,8 +363,8 @@ final class MacroGodotTests: XCTestCase {
                     }
 
                     func _mproxy_getIntegerCollection (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = getIntegerCollection ()
-                    	return Variant (result)
+                        let result = getIntegerCollection ()
+                        return Variant (result)
                     }
 
                     override open class var classInitializer: Void {
@@ -375,8 +376,8 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
-                    	classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getIntegerCollection)
+                        let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                        classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getIntegerCollection)
                     } ()
                 }
                 """,
@@ -404,10 +405,10 @@ final class MacroGodotTests: XCTestCase {
                     }
                 
                     func _mproxy_square (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = square (GArray(args[0])!.reduce(into: VariantCollection<Int>()) {
-                    	        $0.append(Int.makeOrUnwrap($1)!)
-                    	    })
-                    	return Variant (result)
+                        let result = square (GArray(args[0])!.reduce(into: VariantCollection<Int>()) {
+                                $0.append(Int.makeOrUnwrap($1)!)
+                            })
+                        return Variant (result)
                     }
                 
                     override open class var classInitializer: Void {
@@ -419,12 +420,12 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
-                    	let squareArgs = [
-                    		prop_1,
-                    	]
-                    	classInfo.registerMethod(name: StringName("square"), flags: .default, returnValue: prop_0, arguments: squareArgs, function: SomeNode._mproxy_square)
+                        let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                        let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                        let squareArgs = [
+                            prop_1,
+                        ]
+                        classInfo.registerMethod(name: StringName("square"), flags: .default, returnValue: prop_0, arguments: squareArgs, function: SomeNode._mproxy_square)
                     } ()
                 }
                 """,
@@ -453,8 +454,8 @@ final class MacroGodotTests: XCTestCase {
                     }
 
                     func _mproxy_getNodeCollection (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = getNodeCollection ()
-                    	return Variant (result)
+                        let result = getNodeCollection ()
+                        return Variant (result)
                     }
 
                     override open class var classInitializer: Void {
@@ -466,8 +467,8 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .default)
-                    	classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getNodeCollection)
+                        let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .default)
+                        classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getNodeCollection)
                     } ()
                 }
                 """,
@@ -495,10 +496,10 @@ final class MacroGodotTests: XCTestCase {
                     }
                 
                     func _mproxy_printNames (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	printNames (of: GArray(args[0])!.reduce(into: ObjectCollection<Node>()) {
-                    	        $0.append(Node.makeOrUnwrap($1)!)
-                    	    })
-                    	return nil
+                        printNames (of: GArray(args[0])!.reduce(into: ObjectCollection<Node>()) {
+                                $0.append(Node.makeOrUnwrap($1)!)
+                            })
+                        return nil
                     }
                 
                     override open class var classInitializer: Void {
@@ -510,11 +511,11 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("SomeNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<SomeNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "nodes", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .default)
-                    	let printNamesArgs = [
-                    		prop_0,
-                    	]
-                    	classInfo.registerMethod(name: StringName("printNames"), flags: .default, returnValue: nil, arguments: printNamesArgs, function: SomeNode._mproxy_printNames)
+                        let prop_0 = PropInfo (propertyType: .array, propertyName: "nodes", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .default)
+                        let printNamesArgs = [
+                            prop_0,
+                        ]
+                        classInfo.registerMethod(name: StringName("printNames"), flags: .default, returnValue: nil, arguments: printNamesArgs, function: SomeNode._mproxy_printNames)
                     } ()
                 }
                 """,
@@ -542,8 +543,8 @@ final class MacroGodotTests: XCTestCase {
                     }
                 
                     func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = multiply (GArray (args [0])!.compactMap(Int.makeOrUnwrap))
-                    	return Variant (result)
+                        let result = multiply (GArray (args [0])!.compactMap(Int.makeOrUnwrap))
+                        return Variant (result)
                     }
                 
                     override open class var classInitializer: Void {
@@ -555,12 +556,12 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("MultiplierNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<MultiplierNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
-                    	let multiplyArgs = [
-                    		prop_1,
-                    	]
-                    	classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MultiplierNode._mproxy_multiply)
+                        let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                        let multiplyArgs = [
+                            prop_1,
+                        ]
+                        classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MultiplierNode._mproxy_multiply)
                     } ()
                 }
                 """,
@@ -593,20 +594,20 @@ final class MacroGodotTests: XCTestCase {
                     }
                 
                     func _mproxy_get_ages (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = get_ages ()
-                    	return Variant ( result.reduce(into: GArray(Int.self)) {
-                    	        $0.append(Variant($1))
-                    	    })
+                        let result = get_ages ()
+                        return Variant ( result.reduce(into: GArray(Int.self)) {
+                                $0.append(Variant($1))
+                            })
                     }
                     func get_markers() -> [Marker3D] {
                         [.init(), .init(), .init()]
                     }
                 
                     func _mproxy_get_markers (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = get_markers ()
-                    	return Variant ( result.reduce(into: GArray(Marker3D.self)) {
-                    	        $0.append(Variant($1))
-                    	    })
+                        let result = get_markers ()
+                        return Variant ( result.reduce(into: GArray(Marker3D.self)) {
+                                $0.append(Variant($1))
+                            })
                     }
                 
                     override open class var classInitializer: Void {
@@ -618,10 +619,10 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("CallableCollectionsNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
-                    	classInfo.registerMethod(name: StringName("get_ages"), flags: .default, returnValue: prop_0, arguments: [], function: CallableCollectionsNode._mproxy_get_ages)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .default)
-                    	classInfo.registerMethod(name: StringName("get_markers"), flags: .default, returnValue: prop_1, arguments: [], function: CallableCollectionsNode._mproxy_get_markers)
+                        let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                        classInfo.registerMethod(name: StringName("get_ages"), flags: .default, returnValue: prop_0, arguments: [], function: CallableCollectionsNode._mproxy_get_ages)
+                        let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .default)
+                        classInfo.registerMethod(name: StringName("get_markers"), flags: .default, returnValue: prop_1, arguments: [], function: CallableCollectionsNode._mproxy_get_markers)
                     } ()
                 }
                 """,
@@ -649,8 +650,8 @@ final class MacroGodotTests: XCTestCase {
                     }
                 
                     func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = multiply (GArray (args [0])!.compactMap(Int.makeOrUnwrap))
-                    	return Variant (result)
+                        let result = multiply (GArray (args [0])!.compactMap(Int.makeOrUnwrap))
+                        return Variant (result)
                     }
                 
                     override open class var classInitializer: Void {
@@ -662,12 +663,12 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("MultiplierNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<MultiplierNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
-                    	let multiplyArgs = [
-                    		prop_1,
-                    	]
-                    	classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MultiplierNode._mproxy_multiply)
+                        let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                        let multiplyArgs = [
+                            prop_1,
+                        ]
+                        classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MultiplierNode._mproxy_multiply)
                     } ()
                 }
                 """,
@@ -700,20 +701,20 @@ final class MacroGodotTests: XCTestCase {
                     }
                 
                     func _mproxy_get_ages (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = get_ages ()
-                    	return Variant ( result.reduce(into: GArray(Int.self)) {
-                    	        $0.append(Variant($1))
-                    	    })
+                        let result = get_ages ()
+                        return Variant ( result.reduce(into: GArray(Int.self)) {
+                                $0.append(Variant($1))
+                            })
                     }
                     func get_markers() -> Array<Marker3D> {
                         [.init(), .init(), .init()]
                     }
                 
                     func _mproxy_get_markers (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = get_markers ()
-                    	return Variant ( result.reduce(into: GArray(Marker3D.self)) {
-                    	        $0.append(Variant($1))
-                    	    })
+                        let result = get_markers ()
+                        return Variant ( result.reduce(into: GArray(Marker3D.self)) {
+                                $0.append(Variant($1))
+                            })
                     }
                 
                     override open class var classInitializer: Void {
@@ -725,10 +726,10 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("CallableCollectionsNode")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
-                    	classInfo.registerMethod(name: StringName("get_ages"), flags: .default, returnValue: prop_0, arguments: [], function: CallableCollectionsNode._mproxy_get_ages)
-                    	let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .default)
-                    	classInfo.registerMethod(name: StringName("get_markers"), flags: .default, returnValue: prop_1, arguments: [], function: CallableCollectionsNode._mproxy_get_markers)
+                        let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                        classInfo.registerMethod(name: StringName("get_ages"), flags: .default, returnValue: prop_0, arguments: [], function: CallableCollectionsNode._mproxy_get_ages)
+                        let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .default)
+                        classInfo.registerMethod(name: StringName("get_markers"), flags: .default, returnValue: prop_1, arguments: [], function: CallableCollectionsNode._mproxy_get_markers)
                     } ()
                 }
                 """,
@@ -751,20 +752,20 @@ final class MacroGodotTests: XCTestCase {
                     func multiply(_ a: Int, by b: Int) -> Int { a * b}
 
                     func _mproxy_multiply (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = multiply (Int.makeOrUnwrap (args [0])!, by: Int.makeOrUnwrap (args [1])!)
-                    	return Variant (result)
+                        let result = multiply (Int.makeOrUnwrap (args [0])!, by: Int.makeOrUnwrap (args [1])!)
+                        return Variant (result)
                     }
                     func divide(_ a: Float, by b: Float) -> Float { a / b }
 
                     func _mproxy_divide (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = divide (Float.makeOrUnwrap (args [0])!, by: Float.makeOrUnwrap (args [1])!)
-                    	return Variant (result)
+                        let result = divide (Float.makeOrUnwrap (args [0])!, by: Float.makeOrUnwrap (args [1])!)
+                        return Variant (result)
                     }
                     func areBothTrue(_ a: Bool, and b: Bool) -> Bool { a == b }
 
                     func _mproxy_areBothTrue (args: borrowing Arguments) -> SwiftGodot.Variant? {
-                    	let result = areBothTrue (Bool.makeOrUnwrap (args [0])!, and: Bool.makeOrUnwrap (args [1])!)
-                    	return Variant (result)
+                        let result = areBothTrue (Bool.makeOrUnwrap (args [0])!, and: Bool.makeOrUnwrap (args [1])!)
+                        return Variant (result)
                     }
 
                     override open class var classInitializer: Void {
@@ -776,64 +777,64 @@ final class MacroGodotTests: XCTestCase {
                         let className = StringName("MathHelper")
                         assert(ClassDB.classExists(class: className))
                         let classInfo = ClassInfo<MathHelper> (name: className)
-                    	let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_1 = PropInfo (propertyType: .int, propertyName: "a", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_2 = PropInfo (propertyType: .int, propertyName: "b", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let multiplyArgs = [
-                    		prop_1,
-                    		prop_2,
-                    	]
-                    	classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MathHelper._mproxy_multiply)
-                    	let prop_3 = PropInfo (propertyType: .float, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_4 = PropInfo (propertyType: .float, propertyName: "a", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_5 = PropInfo (propertyType: .float, propertyName: "b", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let divideArgs = [
-                    		prop_4,
-                    		prop_5,
-                    	]
-                    	classInfo.registerMethod(name: StringName("divide"), flags: .default, returnValue: prop_3, arguments: divideArgs, function: MathHelper._mproxy_divide)
-                    	let prop_6 = PropInfo (propertyType: .bool, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_7 = PropInfo (propertyType: .bool, propertyName: "a", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let prop_8 = PropInfo (propertyType: .bool, propertyName: "b", className: StringName(""), hint: .none, hintStr: "", usage: .default)
-                    	let areBothTrueArgs = [
-                    		prop_7,
-                    		prop_8,
-                    	]
-                    	classInfo.registerMethod(name: StringName("areBothTrue"), flags: .default, returnValue: prop_6, arguments: areBothTrueArgs, function: MathHelper._mproxy_areBothTrue)
+                        let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let prop_1 = PropInfo (propertyType: .int, propertyName: "a", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let prop_2 = PropInfo (propertyType: .int, propertyName: "b", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let multiplyArgs = [
+                            prop_1,
+                            prop_2,
+                        ]
+                        classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MathHelper._mproxy_multiply)
+                        let prop_3 = PropInfo (propertyType: .float, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let prop_4 = PropInfo (propertyType: .float, propertyName: "a", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let prop_5 = PropInfo (propertyType: .float, propertyName: "b", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let divideArgs = [
+                            prop_4,
+                            prop_5,
+                        ]
+                        classInfo.registerMethod(name: StringName("divide"), flags: .default, returnValue: prop_3, arguments: divideArgs, function: MathHelper._mproxy_divide)
+                        let prop_6 = PropInfo (propertyType: .bool, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let prop_7 = PropInfo (propertyType: .bool, propertyName: "a", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let prop_8 = PropInfo (propertyType: .bool, propertyName: "b", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                        let areBothTrueArgs = [
+                            prop_7,
+                            prop_8,
+                        ]
+                        classInfo.registerMethod(name: StringName("areBothTrue"), flags: .default, returnValue: prop_6, arguments: areBothTrueArgs, function: MathHelper._mproxy_areBothTrue)
                     } ()
                 }
                 """,
-			macros: testMacros
-		)
+            macros: testMacros
+        )
     }
-	
-	func testExportGodotMacro() {
-		assertMacroExpansion(
-			"""
-			@Godot class Hi: Node {
-				@Export var goodName: String = "Supertop"
-			}
-			""",
-			expandedSource:
+    
+    func testExportGodotMacro() {
+        assertMacroExpansion(
+            """
+            @Godot class Hi: Node {
+                @Export var goodName: String = "Supertop"
+            }
+            """,
+            expandedSource:
             """
             class Hi: Node {
-            	var goodName: String = "Supertop"
+                var goodName: String = "Supertop"
             
-            	func _mproxy_set_goodName (args: borrowing Arguments) -> Variant? {
-            		guard let arg = args.first else {
-            			return nil
-            		}
-            		if let value = String (arg) {
-            			self.goodName = value
-            		} else {
-            			GD.printErr ("Unable to set `goodName` value: ", arg)
-            		}
-            		return nil
-            	}
+                func _mproxy_set_goodName (args: borrowing Arguments) -> Variant? {
+                    guard let arg = args.first else {
+                        return nil
+                    }
+                    if let value = String (arg) {
+                        self.goodName = value
+                    } else {
+                        GD.printErr ("Unable to set `goodName` value: ", arg)
+                    }
+                    return nil
+                }
             
-            	func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
-            	    return Variant (goodName)
-            	}
+                func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
+                    return Variant (goodName)
+                }
             
                 override open class var classInitializer: Void {
                     let _ = super.classInitializer
@@ -851,13 +852,13 @@ final class MacroGodotTests: XCTestCase {
                         hint: .none,
                         hintStr: "",
                         usage: .default)
-                	classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
-                	classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
-                	classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
+                    classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
+                    classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
+                    classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
                 } ()
             }
             """,
-			macros: testMacros
-		)
-	}
+            macros: testMacros
+        )
+    }
 }

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -609,6 +609,25 @@ final class MemoryLeakTests: GodotTestCase {
         }
     }
     
+    func test_array_as_variant_indexing() {
+        let array = GArray()
+        let variant = Variant(array)
+        
+        array.append(Variant(10))
+        array.append(Variant(20))
+        
+        checkLeaks {
+            for i in 0 ..< 100 {
+                XCTAssertEqual(variant[0], Variant(10))
+                XCTAssertEqual(variant[1], Variant(20))
+                XCTAssertEqual(variant[2], Variant())
+                XCTAssertEqual(variant[0], array[0])
+                XCTAssertEqual(variant[1], array[1])
+                XCTAssertEqual(variant[2], array[2])
+            }
+        }
+    }
+    
     func test_dictionary_leaks() {
         checkLeaks {
             let dictionary = GDictionary()

--- a/Tests/SwiftGodotTests/VariantTests.swift
+++ b/Tests/SwiftGodotTests/VariantTests.swift
@@ -128,4 +128,14 @@ final class VariantTests: GodotTestCase {
         XCTAssertFalse (Variant (node) == Variant (Node ()))
     }
     
+    func testNilVariantContentAssumption() {
+        var lhs = Variant.zero
+        let rhs = Variant.zero
+        withUnsafeMutablePointer(to: &lhs) { dst in
+            gi.variant_new_nil(dst)
+        }
+        
+        XCTAssert(lhs == rhs)
+    }
+    
 }


### PR DESCRIPTION
Change API to reflect nullability as an intrinsic part of `Variant` semantics to avoid awkward states like `Variant?` containing `.some(Variant)` containing Godot `Nil`.