### PR TITLE
Don't add `.arrayType` hint when registering `@Callable` methods returning `GArray`

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -122,7 +122,14 @@ class GodotMacroProcessor {
         }
         
         let name = "prop_\(propertyDeclarations.count)"
-        let hint = propType == ".array" ? ".arrayType" : ".none"
+        let hint: String
+        
+        if propType == ".array" && hintStr != "" {
+            hint = ".arrayType"
+        } else {
+            hint = ".none"
+        }
+        
         // TODO: perhaps for these prop infos that are parameters to functions, we should not bother making them unique
         // and instead share all the Ints, all the Floats and so on.
         ctor.append ("    let \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: .default)\n")


### PR DESCRIPTION
As per doc, Godot will expect a type name in `hintStr`, in our case it was en empty string that was treated as "TypedArray of type with empty name".

Now the methods are properly exported:
<img width="608" alt="Screenshot 2024-10-19 at 13 49 52" src="https://github.com/user-attachments/assets/d8bdd355-93a7-44d6-9709-77365a98ad4e">
<img width="565" alt="Screenshot 2024-10-19 at 13 49 14" src="https://github.com/user-attachments/assets/b98120c8-1aab-49b6-af38-222a6d9d7473">

Fixes: https://github.com/migueldeicaza/SwiftGodot/issues/537