### PR TITLE
GenericSignal helper class

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -41,5 +41,9 @@ jobs:
           tag: 6.0.2-RELEASE
       - uses: actions/checkout@v4
       - name: Build
-        run: swift build -v
+        run: swift build --build-tests --quiet
+      - name: Run tests (XCTest)
+        run: swift test --skip-build --no-parallel --disable-swift-testing
+      - name: Run tests (Swift testing)
+        run: swift test --skip-build --no-parallel --disable-xctest
         

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -37,8 +37,8 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-5.10-release
-          tag: 5.10-RELEASE
+          branch: swift-6.0.2-release
+          tag: 6.0.2-RELEASE
       - uses: actions/checkout@v4
       - name: Build
         run: swift build -v

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,6 +34,9 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+
+    timeout-minutes: 10
+    
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -557,7 +557,11 @@ func getGenericSignalType(_ signal: JGodotSignal) -> String {
     for signalArgument in signal.arguments ?? [] {
         let godotType = getGodotType(signalArgument)
         if !godotType.isEmpty && godotType != "Variant" {
-            argTypes.append(godotType)
+            var t = godotType
+            if !isCoreType(name: t) && !isPrimitiveType(name: t) {
+                t += "?"
+            }
+            argTypes.append(t)
         }
     }
                 

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -558,7 +558,7 @@ func getGenericSignalType(_ signal: JGodotSignal) -> String {
         let godotType = getGodotType(signalArgument)
         if !godotType.isEmpty && godotType != "Variant" {
             var t = godotType
-            if !isCoreType(name: t) && !isPrimitiveType(name: t) {
+            if !isCoreType(name: t) && !isPrimitiveType(name: signalArgument.type) {
                 t += "?"
             }
             argTypes.append(t)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -231,7 +231,7 @@ targets.append(contentsOf: [
 let package = Package(
     name: "SwiftGodot",
     platforms: [
-        .macOS(.v13),
+        .macOS(.v14),
         .iOS (.v15)
     ],
     products: products,

--- a/Sources/SwiftGodot/Core/GenericSignal.swift
+++ b/Sources/SwiftGodot/Core/GenericSignal.swift
@@ -27,7 +27,7 @@ public class GenericSignal<each T: VariantStorable> {
     /// - Returns: an object token that can be used to disconnect the object from the target on success, or the error produced by Godot.
     ///
     @discardableResult /* Signal1 */
-    public func connect(flags: Object.ConnectFlags = [], _ callback: @escaping (_ t: repeat (each T)?) -> Void) -> Object {
+    public func connect(flags: Object.ConnectFlags = [], _ callback: @escaping (_ t: repeat each T) -> Void) -> Object {
         let signalProxy = SignalProxy()
         signalProxy.proxy = { args in
             var index = 0
@@ -71,23 +71,23 @@ extension Arguments {
     enum UnpackError: Error {
         /// The argument could not be coerced to the expected type.
         case typeMismatch
-
+        
         /// The argument was nil.
         case nilArgument
     }
-
+    
     /// Unpack an argument as a specific type.
     /// We throw a runtime error if the argument is not of the expected type,
     /// or if there are not enough arguments to unpack.
-    func unwrap<T: VariantStorable>(ofType type: T.Type, index: inout Int) throws -> T? {
+    func unwrap<T: VariantStorable>(ofType type: T.Type, index: inout Int) throws -> T {
         let argument = try optionalVariantArgument(at: index)
         index += 1
-
-        // if the argument was nil, return nil
+        
+        // if the argument was nil, throw error
         guard let argument else {
-            return nil
+            throw UnpackError.nilArgument
         }
-                
+        
         // NOTE:
         // Ideally we could just call T.unpack(from: argument) here.
         // Unfortunately, T.unpack is dispatched statically, but we don't
@@ -98,7 +98,42 @@ extension Arguments {
         
         // try to unpack the variant as the expected type
         let value: T?
-        if let objectType = type as? Object.Type, (argument.gtype == .object) && (T.Representable.godotType == .object) {
+        if (argument.gtype == .object) && (T.Representable.godotType == .object) {
+            value = argument.asObject(Object.self)?.unwrappedObject as? T
+        } else {
+            value = T(argument)
+        }
+        
+        guard let value else {
+            throw UnpackError.typeMismatch
+        }
+        
+        return value
+    }
+    
+    /// Unpack an argument as a specific type.
+    /// We throw a runtime error if the argument is not of the expected type,
+    /// or if there are not enough arguments to unpack.
+    func unwrap<T: VariantStorable>(ofType type: Optional<T>.Type, index: inout Int) throws -> T? {
+        let argument = try optionalVariantArgument(at: index)
+        index += 1
+        
+        // if the argument was nil, throw error
+        guard let argument else {
+            return nil
+        }
+        
+        // NOTE:
+        // Ideally we could just call T.unpack(from: argument) here.
+        // Unfortunately, T.unpack is dispatched statically, but we don't
+        // have the full dynamic type information for T when we're compiling.
+        // The only thing we know about type T is that it conforms to VariantStorable.
+        // We don't know if inherits from Object, so the compiler will always pick the
+        // default non-object implementation of T.unpack.
+        
+        // try to unpack the variant as the expected type
+        let value: T?
+        if let objectType = T.self as? Object.Type, (argument.gtype == .object) && (T.Representable.godotType == .object) {
             value = argument.asObject(objectType) as? T
         } else {
             value = T(argument)
@@ -109,5 +144,22 @@ extension Arguments {
         }
         
         return value
+    }
+}
+
+protocol OptionalUnwrappable {
+    var unwrappedObject: Object? { get }
+}
+
+extension Object: OptionalUnwrappable {
+    var unwrappedObject: Object? { self }
+}
+
+extension Optional: OptionalUnwrappable {
+    var unwrappedObject: Object? {
+        switch self {
+            case .none: return nil
+            case .some(let value): return value as? Object
+        }
     }
 }

--- a/Sources/SwiftGodot/Core/GenericSignal.swift
+++ b/Sources/SwiftGodot/Core/GenericSignal.swift
@@ -97,11 +97,11 @@ extension Arguments {
 
         // try to unpack the variant as the expected type
         let value: T?
-        if argument.gtype == .object {
-            value = T.Representable.godotType == .object ? argument.asObject(Object.self) as? T : nil
-        } else {
-            value = T(argument)
-        }
+       if T.self is Object.Type, (argument.gtype == .object) && (T.Representable.godotType == .object) {
+           value = argument.asObject(T.self as! Object.Type) as? T
+       } else {
+           value = T(argument)
+       }
 
         guard let value else {
             throw UnpackError.typeMismatch

--- a/Sources/SwiftGodot/Core/GenericSignal.swift
+++ b/Sources/SwiftGodot/Core/GenericSignal.swift
@@ -1,0 +1,99 @@
+//
+//  Created by Sam Deane on 25/10/2024.
+//
+
+/// Signal support.
+/// Use the ``GenericSignal/connect(flags:_:)`` method to connect to the signal on the container object,
+/// and ``GenericSignal/disconnect(_:)`` to drop the connection.
+///
+/// Use the ``GenericSignal/emit(...)`` method to emit a signal.
+///
+/// You can also await the ``Signal1/emitted`` property for waiting for a single emission of the signal.
+///
+public class GenericSignal<each T: VariantStorable> {
+    var target: Object
+    var signalName: StringName
+    public init(target: Object, signalName: StringName) {
+        self.target = target
+        self.signalName = signalName
+    }
+
+    /// Connects the signal to the specified callback
+    /// To disconnect, call the disconnect method, with the returned token on success
+    ///
+    /// - Parameters:
+    /// - callback: the method to invoke when this signal is raised
+    /// - flags: Optional, can be also added to configure the connection's behavior (see ``Object/ConnectFlags`` constants).
+    /// - Returns: an object token that can be used to disconnect the object from the target on success, or the error produced by Godot.
+    ///
+    @discardableResult /* Signal1 */
+    public func connect(flags: Object.ConnectFlags = [], _ callback: @escaping (_ t: repeat each T) -> Void) -> Object {
+        let signalProxy = SignalProxy()
+        signalProxy.proxy = { args in
+            var index = 0
+            do {
+                callback(repeat try args.unpack(as: (each T).self, index: &index))
+            } catch {
+                print("Error unpacking signal arguments: \(error)")
+            }
+        }
+
+        let callable = Callable(object: signalProxy, method: SignalProxy.proxyName)
+        let r = target.connect(signal: signalName, callable: callable, flags: UInt32(flags.rawValue))
+        if r != .ok { print("Warning, error connecting to signal, code: \(r)") }
+        return signalProxy
+    }
+
+    /// Disconnects a signal that was previously connected, the return value from calling
+    /// ``connect(flags:_:)``
+    public func disconnect(_ token: Object) {
+        target.disconnect(signal: signalName, callable: Callable(object: token, method: SignalProxy.proxyName))
+    }
+
+    /// You can await this property to wait for the signal to be emitted once.
+    public var emitted: Void {
+        get async {
+            await withCheckedContinuation { c in
+                let signalProxy = SignalProxy()
+                signalProxy.proxy = { _ in c.resume() }
+                let callable = Callable(object: signalProxy, method: SignalProxy.proxyName)
+                let r = target.connect(signal: signalName, callable: callable, flags: UInt32(Object.ConnectFlags.oneShot.rawValue))
+                if r != .ok { print("Warning, error connecting to signal, code: \(r)") }
+            }
+
+        }
+
+    }
+
+}
+
+
+extension Arguments {
+    enum UnpackError: Error {
+        case typeMismatch
+        case missingArgument
+    }
+
+    /// Unpack an argument as a specific type.
+    /// We throw a runtime error if the argument is not of the expected type,
+    /// or if there are not enough arguments to unpack.
+    func unpack<T: VariantStorable>(as type: T.Type, index: inout Int) throws -> T {
+        if index >= count {
+            throw UnpackError.missingArgument
+        }
+        let argument = self[index]
+        index += 1
+        let value: T?
+        if argument.gtype == .object {
+            value = T.Representable.godotType == .object ? argument.asObject(Object.self) as? T : nil
+        } else {
+            value = T(argument)
+        }
+
+        guard let value else {
+            throw UnpackError.typeMismatch
+        }
+
+        return value
+    }
+}

--- a/Sources/SwiftGodot/Core/GenericSignal.swift
+++ b/Sources/SwiftGodot/Core/GenericSignal.swift
@@ -99,7 +99,7 @@ extension Arguments {
         // try to unpack the variant as the expected type
         let value: T?
         if (argument.gtype == .object) && (T.Representable.godotType == .object) {
-            value = argument.asObject(Object.self)?.unwrappedObject as? T
+            value = argument.asObject(Object.self) as? T
         } else {
             value = T(argument)
         }
@@ -109,57 +109,5 @@ extension Arguments {
         }
         
         return value
-    }
-    
-    /// Unpack an argument as a specific type.
-    /// We throw a runtime error if the argument is not of the expected type,
-    /// or if there are not enough arguments to unpack.
-    func unwrap<T: VariantStorable>(ofType type: Optional<T>.Type, index: inout Int) throws -> T? {
-        let argument = try optionalVariantArgument(at: index)
-        index += 1
-        
-        // if the argument was nil, throw error
-        guard let argument else {
-            return nil
-        }
-        
-        // NOTE:
-        // Ideally we could just call T.unpack(from: argument) here.
-        // Unfortunately, T.unpack is dispatched statically, but we don't
-        // have the full dynamic type information for T when we're compiling.
-        // The only thing we know about type T is that it conforms to VariantStorable.
-        // We don't know if inherits from Object, so the compiler will always pick the
-        // default non-object implementation of T.unpack.
-        
-        // try to unpack the variant as the expected type
-        let value: T?
-        if let objectType = T.self as? Object.Type, (argument.gtype == .object) && (T.Representable.godotType == .object) {
-            value = argument.asObject(objectType) as? T
-        } else {
-            value = T(argument)
-        }
-        
-        guard let value else {
-            throw UnpackError.typeMismatch
-        }
-        
-        return value
-    }
-}
-
-protocol OptionalUnwrappable {
-    var unwrappedObject: Object? { get }
-}
-
-extension Object: OptionalUnwrappable {
-    var unwrappedObject: Object? { self }
-}
-
-extension Optional: OptionalUnwrappable {
-    var unwrappedObject: Object? {
-        switch self {
-            case .none: return nil
-            case .some(let value): return value as? Object
-        }
     }
 }

--- a/Sources/SwiftGodot/Core/GenericSignal.swift
+++ b/Sources/SwiftGodot/Core/GenericSignal.swift
@@ -27,7 +27,7 @@ public class GenericSignal<each T: VariantStorable> {
     /// - Returns: an object token that can be used to disconnect the object from the target on success, or the error produced by Godot.
     ///
     @discardableResult /* Signal1 */
-    public func connect(flags: Object.ConnectFlags = [], _ callback: @escaping (_ t: repeat each T) -> Void) -> Object {
+    public func connect(flags: Object.ConnectFlags = [], _ callback: @escaping (_ t: repeat (each T)?) -> Void) -> Object {
         let signalProxy = SignalProxy()
         signalProxy.proxy = { args in
             var index = 0
@@ -82,7 +82,7 @@ extension Arguments {
     /// Unpack an argument as a specific type.
     /// We throw a runtime error if the argument is not of the expected type,
     /// or if there are not enough arguments to unpack.
-    func unpack<T: VariantStorable>(as type: T.Type, index: inout Int) throws -> T {
+    func unpack<T: VariantStorable>(as type: T.Type, index: inout Int) throws -> T? {
         if index >= count {
             throw UnpackError.missingArgument
         }
@@ -92,7 +92,7 @@ extension Arguments {
 
         // if the argument was nil, throw an error
         guard let argument else {
-            throw UnpackError.nilArgument
+            return nil
         }
 
         // try to unpack the variant as the expected type

--- a/Sources/SwiftGodot/Core/GenericSignal.swift
+++ b/Sources/SwiftGodot/Core/GenericSignal.swift
@@ -67,11 +67,16 @@ public class GenericSignal<each T: VariantStorable> {
 
 }
 
-
 extension Arguments {
     enum UnpackError: Error {
+        /// The argument could not be coerced to the expected type.
         case typeMismatch
+
+        /// There are not enough arguments to unpack.
         case missingArgument
+
+        /// The argument was nil.
+        case nilArgument
     }
 
     /// Unpack an argument as a specific type.
@@ -81,8 +86,16 @@ extension Arguments {
         if index >= count {
             throw UnpackError.missingArgument
         }
+
         let argument = self[index]
         index += 1
+
+        // if the argument was nil, throw an error
+        guard let argument else {
+            throw UnpackError.nilArgument
+        }
+
+        // try to unpack the variant as the expected type
         let value: T?
         if argument.gtype == .object {
             value = T.Representable.godotType == .object ? argument.asObject(Object.self) as? T : nil

--- a/Sources/SwiftGodot/Core/GenericSignal.swift
+++ b/Sources/SwiftGodot/Core/GenericSignal.swift
@@ -90,15 +90,16 @@ extension Arguments {
                 
         // NOTE:
         // Ideally we could just call T.unpack(from: argument) here.
-        // Unfortunately, we don't have the full type information for T in this context.
-        // The only thing we know about type T is that it conforms to VariantStorable, but
-        // it doesn't know if it's an object, so it will always pick the default non-object
-        // implementation of T.unpack, which is no use.
+        // Unfortunately, T.unpack is dispatched statically, but we don't
+        // have the full dynamic type information for T when we're compiling.
+        // The only thing we know about type T is that it conforms to VariantStorable.
+        // We don't know if inherits from Object, so the compiler will always pick the
+        // default non-object implementation of T.unpack.
         
         // try to unpack the variant as the expected type
         let value: T?
-        if (argument.gtype == .object) && (T.Representable.godotType == .object) {
-            value = argument.asObject(T.self as! Object.Type) as? T
+        if let objectType = type as? Object.Type, (argument.gtype == .object) && (T.Representable.godotType == .object) {
+            value = argument.asObject(objectType) as? T
         } else {
             value = T(argument)
         }

--- a/Sources/SwiftGodot/Core/SignalSupport.swift
+++ b/Sources/SwiftGodot/Core/SignalSupport.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Miguel de Icaza on 4/30/23.
 //
@@ -18,129 +18,31 @@
 /// invokeScript ("myDemo.proxy ()", params: ["myDemo", demo])
 /// ```
 public class SignalProxy: Object {
-    public static var proxyName = StringName ("proxy")
+    public static var proxyName = StringName("proxy")
     static var initClass: Bool = {
         register(type: SignalProxy.self)
-        
+
         let s = ClassInfo<SignalProxy>(name: "SignalProxy")
-        
+
         s.registerMethod(name: SignalProxy.proxyName, flags: .default, returnValue: nil, arguments: [], function: SignalProxy.proxyFunc)
         return true
-    } ()
-    
+    }()
+
     /// The code invoked when Godot invokes the `proxy` method on this object.
     public typealias Proxy = (borrowing Arguments) -> ()
     public var proxy: Proxy?
-    
-    public required init () {
+
+    public required init() {
         let _ = SignalProxy.initClass
         super.init()
     }
-    
-    public required init (nativeHandle: UnsafeRawPointer) {
-        super.init (nativeHandle: nativeHandle)
-    }
-    
-    func proxyFunc (args: borrowing Arguments) -> Variant? {
-        proxy? (args)
-        return nil
-    }
-}
 
-/// The simple signal is used to raise signals that take no arguments and return no values.
-///
-/// To connect, you access the connect method, and pass you callback function, like this:
-/// ```
-/// let myClass = MyClass ()
-/// let token = myClass.wakeup.connect {
-///    print ("wakeup triggered")
-/// }
-/// ```
-///
-/// If you want to disconnect, you call:
-/// ```
-/// myClass.wakeup.disconnect (token)
-/// ```
-///
-/// To merely wait for one emission of the signal you can await the ``emitted`` property.
-///
-/// Subclasses that use this, implement signals like this:
-///
-/// ```
-/// class MyClass: Object {
-///     // the `wakeup` signal
-///     public var wakeup: SimpleSignal { SimpleSignal (self, "wakeup") }
-/// }
-/// ```
-///
-public class SimpleSignal {
-    var target: Object
-    var signalName: StringName
-    
-    /// - Parameters:
-    ///  - target: the object where we will be operating on, to connect or disconnect the signal
-    ///  - name: the name of the signal
-    public init (target: Object, signalName: StringName) {
-        self.target = target
-        self.signalName = signalName
+    public required init(nativeHandle: UnsafeRawPointer) {
+        super.init(nativeHandle: nativeHandle)
     }
-    
-    /// Connects the signal to the specified callback.
-    ///
-    /// To disconnect, call the disconnect method, with the returned token on success
-    ///
-    /// Example:
-    /// ```swift
-    /// node.ready.connect {
-    ///     print ("Node is ready")
-    /// }
-    /// ```
-    ///
-    /// - Parameters:
-    ///  - callback: the method to invoke when the signal is raised
-    ///  - flags: Optional, can be also added to configure the connection's behavior (see ``Object/ConnectFlags`` constants).
-    /// - Returns: an object token that can be used to disconnect the object from the target.
-    @discardableResult
-    public func connect (flags: Object.ConnectFlags = [], _ callback: @escaping () -> ()) -> Object {
-        let signalProxy = SignalProxy()
-        if flags.contains(.oneShot) {
-            signalProxy.proxy = { [weak signalProxy] args in
-                callback ()
-                guard let signalProxy else { return }
-                signalProxy.proxy = nil
-                _ = signalProxy.callDeferred(method: "free")
-            }
-        } else {
-            signalProxy.proxy = { args in
-                callback ()
-            }
-        }
-        
-        let callable = Callable(object: signalProxy, method: SignalProxy.proxyName)
-        let r = target.connect(signal: signalName, callable: callable, flags: UInt32 (flags.rawValue))
-        if r != .ok {
-            print ("Warning, error connecting to signal \(signalName.description): \(r)")
-        }
-        return signalProxy
-    }
-    
-    /// Disconnects a signal that was previously connected, the return value from calling ``connect(flags:_:)``
-    public func disconnect (_ token: Object) {
-        guard let signalProxy = token as? SignalProxy else { return }
-        signalProxy.proxy = nil
-        _ = signalProxy.callDeferred(method: "free")
-        target.disconnect(signal: signalName, callable: Callable (object: token, method: SignalProxy.proxyName))
-    }
-    
-    /// You can await this property to wait for the signal to be emitted once
-    @MainActor
-    public var emitted: Void {
-        get async {
-            await withCheckedContinuation { c in
-                connect (flags: .oneShot) {
-                    c.resume()
-                }
-            }
-        }
+
+    func proxyFunc(args: borrowing Arguments) -> Variant? {
+        proxy?(args)
+        return nil
     }
 }

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -169,6 +169,12 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
         return ret
     }
     
+    /// Fallback for when the type is not an object.
+    /// Will always return nil.
+    public func asObject<T: Any> (_ type: T.Type) -> T? {
+        return nil
+    }
+
     public var description: String {
         var ret = GDExtensionStringPtr (bitPattern: 0xdeaddead)
         gi.variant_stringify (&content, &ret)

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -169,12 +169,6 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
         return ret
     }
     
-    /// Fallback for when the type is not an object.
-    /// Will always return nil.
-    public func asObject<T: Any> (_ type: T.Type) -> T? {
-        return nil
-    }
-
     public var description: String {
         var ret = GDExtensionStringPtr (bitPattern: 0xdeaddead)
         gi.variant_stringify (&content, &ret)

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -26,48 +26,6 @@ final class MarshalTests: GodotTestCase {
         return [TestNode.self]
     }
 
-    func testVarArgs() {
-        let node = TestNode()
-        
-        node.probe ()
-        XCTAssertEqual (node.receivedInt, 22, "Integers should have been the same")
-        XCTAssertEqual (node.receivedString, "Joey", "Strings should have been the same")
-    }
-
-    func testBuiltInSignalWithNoArgument() {
-        let node = TestNode()
-        var signalReceived = false
-        node.ready.connect {
-            signalReceived = true
-        }
-        node.emitSignal("ready")
-        XCTAssertTrue (signalReceived, "signal should have been received")
-    }
-
-    func testBuiltInSignalWithArgument() {
-        let node = TestNode()
-        var signalReceived = false
-        node.childExitingTree.connect { nodeParameter in
-            signalReceived = true
-            XCTAssertEqual(node, nodeParameter)
-        }
-        node.emitSignal("child_exiting_tree", Variant(node))
-        XCTAssertTrue (signalReceived, "signal should have been received")
-    }
-
-    func testBuiltInSignalWithPrimitiveArguments() {
-        let node = AnimationNode()
-        var signalReceived = false
-        node.animationNodeRenamed.connect { id, oldName, newName in
-            signalReceived = true
-            XCTAssertEqual(id, 123)
-            XCTAssertEqual(oldName, "old name")
-            XCTAssertEqual(newName, "new name")
-        }
-        node.emitSignal("animation_node_renamed", Variant(123), Variant("old name"), Variant("new name"))
-        XCTAssertTrue (signalReceived, "signal should have been received")
-    }
-    
     func testClassesMethodsPerformance() {
         let node = TestNode()
         let child = TestNode()

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -34,7 +34,7 @@ final class MarshalTests: GodotTestCase {
         XCTAssertEqual (node.receivedString, "Joey", "Strings should have been the same")
     }
 
-    func testBuiltInSignals() {
+    func testBuiltInSignalWithNoArgument() {
         let node = TestNode()
         var signalReceived = false
         node.ready.connect {
@@ -42,6 +42,17 @@ final class MarshalTests: GodotTestCase {
         }
         node.emitSignal("ready")
         XCTAssertTrue (signalReceived, "ready signal should have been received")
+    }
+
+    func testBuiltInSignalWithArgument() {
+        let node = TestNode()
+        var signalReceived = false
+        node.childExitingTree.connect { nodeParameter in
+            signalReceived = true
+            XCTAssertEqual(node, nodeParameter)
+        }
+        node.emitSignal("child_exiting_tree", Variant(node))
+        XCTAssertTrue (signalReceived, "childExitingTree signal should have been received with a node parameter")
     }
 
     func testClassesMethodsPerformance() {

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -33,7 +33,17 @@ final class MarshalTests: GodotTestCase {
         XCTAssertEqual (node.receivedInt, 22, "Integers should have been the same")
         XCTAssertEqual (node.receivedString, "Joey", "Strings should have been the same")
     }
-    
+
+    func testBuiltInSignals() {
+        let node = TestNode()
+        var signalReceived = false
+        node.ready.connect {
+            signalReceived = true
+        }
+        node.emitSignal("ready")
+        XCTAssertTrue (signalReceived, "ready signal should have been received")
+    }
+
     func testClassesMethodsPerformance() {
         let node = TestNode()
         let child = TestNode()

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -41,7 +41,7 @@ final class MarshalTests: GodotTestCase {
             signalReceived = true
         }
         node.emitSignal("ready")
-        XCTAssertTrue (signalReceived, "ready signal should have been received")
+        XCTAssertTrue (signalReceived, "signal should have been received")
     }
 
     func testBuiltInSignalWithArgument() {
@@ -52,9 +52,22 @@ final class MarshalTests: GodotTestCase {
             XCTAssertEqual(node, nodeParameter)
         }
         node.emitSignal("child_exiting_tree", Variant(node))
-        XCTAssertTrue (signalReceived, "childExitingTree signal should have been received with a node parameter")
+        XCTAssertTrue (signalReceived, "signal should have been received")
     }
 
+    func testBuiltInSignalWithPrimitiveArguments() {
+        let node = AnimationNode()
+        var signalReceived = false
+        node.animationNodeRenamed.connect { id, oldName, newName in
+            signalReceived = true
+            XCTAssertEqual(id, 123)
+            XCTAssertEqual(oldName, "old name")
+            XCTAssertEqual(newName, "new name")
+        }
+        node.emitSignal("animation_node_renamed", Variant(123), Variant("old name"), Variant("new name"))
+        XCTAssertTrue (signalReceived, "signal should have been received")
+    }
+    
     func testClassesMethodsPerformance() {
         let node = TestNode()
         let child = TestNode()

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -613,7 +613,7 @@ final class MemoryLeakTests: GodotTestCase {
                 Foo(myInt: 30, myText: "Nested2", myIntArray: [2,2,2])])
             try? foon.encode(to: g)
             
-            print(g.data?.description ?? "nil")
+            buffer += g.data?.description ?? "nil"
         }
     }
     

--- a/Tests/SwiftGodotTests/SignalTests.swift
+++ b/Tests/SwiftGodotTests/SignalTests.swift
@@ -3,7 +3,7 @@ import SwiftGodotTestability
 @testable import SwiftGodot
 
 @Godot
-private class TestNode: Node {
+private class TestSignalNode: Node {
     #signal("mySignal", arguments: ["age": Int.self, "name": String.self])
     var receivedInt: Int? = nil
     var receivedString: String? = nil
@@ -17,14 +17,14 @@ private class TestNode: Node {
 final class SignalTests: GodotTestCase {
     
     override static var godotSubclasses: [Wrapped.Type] {
-        return [TestNode.self]
+        return [TestSignalNode.self]
     }
     
     func testUserDefinedSignal() {
-        let node = TestNode()
+        let node = TestSignalNode()
 
-        node.connect (signal: TestNode.mySignal, to: node, method: "receiveSignal")
-        node.emit (signal: TestNode.mySignal, 22, "Joey")
+        node.connect (signal: TestSignalNode.mySignal, to: node, method: "receiveSignal")
+        node.emit (signal: TestSignalNode.mySignal, 22, "Joey")
 
         XCTAssertEqual (node.receivedInt, 22, "Integers should have been the same")
         XCTAssertEqual (node.receivedString, "Joey", "Strings should have been the same")

--- a/Tests/SwiftGodotTests/SignalTests.swift
+++ b/Tests/SwiftGodotTests/SignalTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+@Godot
+private class TestNode: Node {
+    #signal("mySignal", arguments: ["age": Int.self, "name": String.self])
+    var receivedInt: Int? = nil
+    var receivedString: String? = nil
+    
+    @Callable func receiveSignal (_ age: Int, name: String) {
+        receivedInt = age
+        receivedString = name
+    }
+}
+
+final class SignalTests: GodotTestCase {
+    
+    override static var godotSubclasses: [Wrapped.Type] {
+        return [TestNode.self]
+    }
+    
+    func testUserDefinedSignal() {
+        let node = TestNode()
+
+        node.connect (signal: TestNode.mySignal, to: node, method: "receiveSignal")
+        node.emit (signal: TestNode.mySignal, 22, "Joey")
+
+        XCTAssertEqual (node.receivedInt, 22, "Integers should have been the same")
+        XCTAssertEqual (node.receivedString, "Joey", "Strings should have been the same")
+    }
+
+    func testBuiltInSignalWithNoArgument() {
+        let node = Node()
+        var signalReceived = false
+        node.ready.connect {
+            signalReceived = true
+        }
+        node.emitSignal("ready")
+        XCTAssertTrue (signalReceived, "signal should have been received")
+    }
+    
+    func testBuiltInSignalWithArgument() {
+        let node = Node()
+        var signalReceived = false
+        node.childExitingTree.connect { (nodeParameter: Node?) in // full signature is specified here to check that it's being generated with the right types
+            signalReceived = true
+            XCTAssertEqual(node, nodeParameter)
+        }
+        node.emitSignal("child_exiting_tree", Variant(node))
+        XCTAssertTrue (signalReceived, "signal should have been received")
+    }
+    
+    func testBuiltInSignalWithPrimitiveArguments() {
+        let node = AnimationNode()
+        var signalReceived = false
+        node.animationNodeRenamed.connect { (id: Int64, oldName: String, newName: String) in  // full signature is specified here to check that it's being generated with the right types
+            signalReceived = true
+            XCTAssertEqual(id, 123)
+            XCTAssertEqual(oldName, "old name")
+            XCTAssertEqual(newName, "new name")
+        }
+        node.emitSignal("animation_node_renamed", Variant(123), Variant("old name"), Variant("new name"))
+        XCTAssertTrue (signalReceived, "signal should have been received")
+    }
+}
+

--- a/Tests/SwiftGodotTests/VariantTests.swift
+++ b/Tests/SwiftGodotTests/VariantTests.swift
@@ -21,7 +21,7 @@ final class VariantTests: GodotTestCase {
 
     func testWrap() {
         let x: Node? = Node()
-        let j = Variant(x)
+        let _ = Variant(x)
         
     }
     func testVariantCall() {


### PR DESCRIPTION
See also #42 

Instead of generating a helper class for each signal property, we use a single GenericSignal which can be specialised with the list of argument types that the signal contains.