### PR TITLE
Fixes @Callable macro expansion for Godot's collection params

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -56,9 +56,9 @@ public struct GodotCallable: PeerMacro {
             } else if parameter.isArray, let elementType = parameter.arrayElementTypeName {
                 genMethod.append ("GArray (args [\(argc)])!.compactMap(\(elementType).makeOrUnwrap)")
             } else if parameter.isVariantCollection, let elementType = parameter.variantCollectionElementTypeName {
-                genMethod.append ("GArray(args[\(argc)])!.reduce(into: VariantCollection<\(elementType)>()) { $0.append(\(elementType).makeOrUnwrap($1)!) }")
+                genMethod.append ("GArray(args[\(argc)])!.reduce(into: VariantCollection<\(elementType)>()) { $0.append(value: \(elementType).makeOrUnwrap($1)!) }")
             } else if parameter.isObjectCollection, let elementType = parameter.objectCollectionElementTypeName {
-                genMethod.append ("GArray(args[\(argc)])!.reduce(into: ObjectCollection<\(elementType)>()) { $0.append(\(elementType).makeOrUnwrap($1)!) }")
+                genMethod.append ("GArray(args[\(argc)])!.reduce(into: ObjectCollection<\(elementType)>()) { $0.append(value: \(elementType).makeOrUnwrap($1)!) }")
             } else {
                 genMethod.append ("\(ptype).makeOrUnwrap (args [\(argc)])!")
             }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -19,3 +19,12 @@ class Demo2: Object {
     @Export var demo: Variant = Variant()
 }
 
+@Godot
+class Demo3: Object {
+    @Callable func demo(options: VariantCollection<String>) {}
+}
+
+@Godot
+class Demo4: Object {
+    @Callable func demo(options: ObjectCollection<Node>) {}
+}

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -406,7 +406,7 @@ final class MacroGodotTests: XCTestCase {
                 
                     func _mproxy_square (args: borrowing Arguments) -> SwiftGodot.Variant? {
                         let result = square (GArray(args[0])!.reduce(into: VariantCollection<Int>()) {
-                                $0.append(Int.makeOrUnwrap($1)!)
+                                $0.append(value: Int.makeOrUnwrap($1)!)
                             })
                         return Variant (result)
                     }
@@ -497,7 +497,7 @@ final class MacroGodotTests: XCTestCase {
                 
                     func _mproxy_printNames (args: borrowing Arguments) -> SwiftGodot.Variant? {
                         printNames (of: GArray(args[0])!.reduce(into: ObjectCollection<Node>()) {
-                                $0.append(Node.makeOrUnwrap($1)!)
+                                $0.append(value: Node.makeOrUnwrap($1)!)
                             })
                         return nil
                     }


### PR DESCRIPTION
### Description

Fixes a build time error where expanding the `@Callable` macro in functions that have `VariantCollection<T>` or `ObjectCollection<T>` parameters calls for a missing `value:` label.

### Example Function
```swift
@Callable
    func importResource(
        sourceFile: String,
        savePath: String,
        options: GDictionary,
        platformVariants: VariantCollection<String>,
        genFiles: VariantCollection<String>
    ) -> Int {
    //...
}
````
    