### PR TITLE
Ignore auto-generated index.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .godot/
 .DS_Store
 /.build
+/.index-build
 /Packages
 /*.xcodeproj
 xcuserdata/


### PR DESCRIPTION
The vs-code Swift plugin has an experimental background indexing mode.
If it's enabled, it makes the index in `.index-build`.
This PR just adds that to the .gitignore.