### PR TITLE
Suppress Generator warnings

### DIFF
--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -32,8 +32,10 @@ func getArgumentDeclaration(_ argument: JGodotArgument, omitLabel: Bool, kind: A
     
     var def: String = ""
     if var dv = argument.defaultValue, dv != "" {
-        func dvMissing (_ kind: String) {
-            print ("Generator/default_value: no support for [\(kind)] = \(dv)")
+        func dvMissing(_ kind: String) {
+            #if WARN_MISSING
+                print("Generator/default_value: no support for [\(kind)] = \(dv)")
+            #endif
         }
         
         let argumentType = argument.type


### PR DESCRIPTION
Disabled the generator's `no support for...` warnings by default.

They can be enabled by defining WARN_MISSING, by adding `"-Xswiftc" "-D" "-Xswiftc" "WARN_MISSING"` to the build arguments when building with SPM (or doing the equivalent in Xcode).
