### PR TITLE
Explicitly exclude files to suppress warning.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,8 @@
 // swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
-import PackageDescription
 import CompilerPluginSupport
+import PackageDescription
 
 //var linkerSettings: [LinkerSetting] = []
 //#if os(macOS)
@@ -14,9 +14,9 @@ import CompilerPluginSupport
 
 var libraryType: Product.Library.LibraryType
 #if os(Windows)
-libraryType = .static
+    libraryType = .static
 #else
-libraryType = .dynamic
+    libraryType = .dynamic
 #endif
 
 // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -32,27 +32,27 @@ var products: [Product] = [
         name: "ExtensionApi",
         targets: [
             "ExtensionApi",
-            "ExtensionApiJson"
+            "ExtensionApiJson",
         ]),
     .plugin(name: "CodeGeneratorPlugin", targets: ["CodeGeneratorPlugin"]),
-    .plugin(name: "EntryPointGeneratorPlugin", targets: ["EntryPointGeneratorPlugin"])
+    .plugin(name: "EntryPointGeneratorPlugin", targets: ["EntryPointGeneratorPlugin"]),
 ]
 
 // Macros aren't supported on Windows before 5.9.1 and this sample uses them
 #if !(os(Windows) && swift(<5.9.1))
-products.append(
-    .library(
-        name: "SimpleExtension",
-        type: libraryType,
-        targets: ["SimpleExtension"]))
+    products.append(
+        .library(
+            name: "SimpleExtension",
+            type: libraryType,
+            targets: ["SimpleExtension"]))
 #endif
 
 // libgodot is only available for macOS and testability runtime depends on it
 #if os(macOS)
-products.append(
-    .library(
-        name: "SwiftGodotTestability",
-        targets: ["SwiftGodotTestability"]))
+    products.append(
+        .library(
+            name: "SwiftGodotTestability",
+            targets: ["SwiftGodotTestability"]))
 #endif
 
 var targets: [Target] = [
@@ -72,9 +72,10 @@ var targets: [Target] = [
     .target(
         name: "ExtensionApiJson",
         path: "Sources/ExtensionApi",
+        exclude: ["ApiJsonModel.swift", "ApiJsonModel+Extra.swift"],
         sources: ["ExtensionApiJson.swift"],
         resources: [.process("extension_api.json")]),
-    
+
     // The generator takes Godot's JSON-based API description as input and
     // produces Swift API bindings that can be used to call into Godot.
     .executableTarget(
@@ -82,7 +83,7 @@ var targets: [Target] = [
         dependencies: [
             "ExtensionApi",
             .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxBuilder", package: "swift-syntax")
+            .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
         ],
         path: "Generator",
         exclude: ["README.md"],
@@ -91,21 +92,21 @@ var targets: [Target] = [
             //.define("LEGACY_MARSHALING")
         ]
     ),
-    
+
     // This is a build-time plugin that invokes the generator and produces
     // the bindings that are compiled into SwiftGodot
-        .plugin(
-            name: "CodeGeneratorPlugin",
-            capability: .buildTool(),
-            dependencies: ["Generator"]
-        ),
-    
-        .plugin(
-            name: "EntryPointGeneratorPlugin",
-            capability: .buildTool(),
-            dependencies: ["EntryPointGenerator"]
-        ),
-    
+    .plugin(
+        name: "CodeGeneratorPlugin",
+        capability: .buildTool(),
+        dependencies: ["Generator"]
+    ),
+
+    .plugin(
+        name: "EntryPointGeneratorPlugin",
+        capability: .buildTool(),
+        dependencies: ["EntryPointGenerator"]
+    ),
+
     // This allows the Swift code to call into the Godot bridge API (GDExtension)
     .target(
         name: "GDExtension"),
@@ -115,91 +116,93 @@ var swiftGodotPlugins: [Target.PluginUsage] = ["CodeGeneratorPlugin"]
 
 // Macros aren't supported on Windows before 5.9.1
 #if !(os(Windows) && swift(<5.9.1))
-targets.append(contentsOf: [
-    // These are macros that can be used by third parties to simplify their
-    // SwiftGodot development experience, these are used at compile time by
-    // third party projects
-    .macro(name: "SwiftGodotMacroLibrary",
-           dependencies: [
-            .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-            .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
-           ]),
-    // This contains sample code showing how to use the SwiftGodot API
-    .target(
-        name: "SimpleExtension",
-        dependencies: ["SwiftGodot"],
-        exclude: ["SwiftSprite.gdextension", "README.md"]),
+    targets.append(contentsOf: [
+        // These are macros that can be used by third parties to simplify their
+        // SwiftGodot development experience, these are used at compile time by
+        // third party projects
+        .macro(
+            name: "SwiftGodotMacroLibrary",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+            ]),
+        // This contains sample code showing how to use the SwiftGodot API
+        .target(
+            name: "SimpleExtension",
+            dependencies: ["SwiftGodot"],
+            exclude: ["SwiftSprite.gdextension", "README.md"]),
         //linkerSettings: linkerSettings),
-])
-swiftGodotPlugins.append("SwiftGodotMacroLibrary")
+    ])
+    swiftGodotPlugins.append("SwiftGodotMacroLibrary")
 #endif
 
 // Macro tests don't work on Windows yet
 #if !os(Windows)
-// Idea: -mark_dead_strippable_dylib
-targets.append(
-    .testTarget(name: "SwiftGodotMacrosTests",
+    // Idea: -mark_dead_strippable_dylib
+    targets.append(
+        .testTarget(
+            name: "SwiftGodotMacrosTests",
             dependencies: [
                 "SwiftGodotMacroLibrary",
                 "SwiftGodot",
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ]))
 #endif
 
 // libgodot is only available for macOS
 #if os(macOS)
 
-/// You might want to build your own libgodot, so you can step into it in the debugger when fixing failing tests. Here's how:
-///
-/// 1. Check out the appropriate branch of https://github.com/migueldeicaza/libgodot
-/// 2. Build with `scons platform=macos target=template_debug dev_build=yes library_type=shared_library`. The `target=template_debug` is important, because `target=editor` will get you a `TOOLS_ENABLED` build that breaks some test cases.
-/// 3. Use `scripts/make-libgodot.framework` to build an `xcframework` and put it at the root of your SwiftGodot work tree.
-/// 4. Change `#if true` to `#if false` below.
-///
-#if true
-let libgodot_tests = Target.binaryTarget(
-    name: "libgodot_tests",
-    url: "https://github.com/migueldeicaza/SwiftGodotKit/releases/download/4.3.5/libgodot.xcframework.zip",
-    checksum: "865ea17ad3e20caab05b3beda35061f57143c4acf0e4ad2684ddafdcc6c4f199"
-)
-#else
-let libgodot_tests = Target .binaryTarget(
-    name: "libgodot_tests",
-    path: "libgodot.xcframework"
-)
-#endif
+    /// You might want to build your own libgodot, so you can step into it in the debugger when fixing failing tests. Here's how:
+    ///
+    /// 1. Check out the appropriate branch of https://github.com/migueldeicaza/libgodot
+    /// 2. Build with `scons platform=macos target=template_debug dev_build=yes library_type=shared_library`. The `target=template_debug` is important, because `target=editor` will get you a `TOOLS_ENABLED` build that breaks some test cases.
+    /// 3. Use `scripts/make-libgodot.framework` to build an `xcframework` and put it at the root of your SwiftGodot work tree.
+    /// 4. Change `#if true` to `#if false` below.
+    ///
+    #if true
+        let libgodot_tests = Target.binaryTarget(
+            name: "libgodot_tests",
+            url: "https://github.com/migueldeicaza/SwiftGodotKit/releases/download/4.3.5/libgodot.xcframework.zip",
+            checksum: "865ea17ad3e20caab05b3beda35061f57143c4acf0e4ad2684ddafdcc6c4f199"
+        )
+    #else
+        let libgodot_tests = Target.binaryTarget(
+            name: "libgodot_tests",
+            path: "libgodot.xcframework"
+        )
+    #endif
 
-targets.append(contentsOf: [
-    // Godot runtime as a library
+    targets.append(contentsOf: [
+        // Godot runtime as a library
 
-    libgodot_tests,
+        libgodot_tests,
 
-    // Base functionality for Godot runtime dependant tests
-    .target(
-        name: "SwiftGodotTestability",
-        dependencies: [            
-            "SwiftGodot",
-            "libgodot_tests",
-            "GDExtension"
-        ]),
-    
-    // General purpose runtime dependant tests
-    .testTarget(
-        name: "SwiftGodotTests",
-        dependencies: [
-            "SwiftGodotTestability",
-        ]
-    ),
-    
-    // Runtime dependant tests based on the engine tests from Godot's repository
-    .testTarget(
-        name: "SwiftGodotEngineTests",
-        dependencies: [
-            "SwiftGodotTestability",
-        ]
-    ),
-])
+        // Base functionality for Godot runtime dependant tests
+        .target(
+            name: "SwiftGodotTestability",
+            dependencies: [
+                "SwiftGodot",
+                "libgodot_tests",
+                "GDExtension",
+            ]),
+
+        // General purpose runtime dependant tests
+        .testTarget(
+            name: "SwiftGodotTests",
+            dependencies: [
+                "SwiftGodotTestability"
+            ]
+        ),
+
+        // Runtime dependant tests based on the engine tests from Godot's repository
+        .testTarget(
+            name: "SwiftGodotEngineTests",
+            dependencies: [
+                "SwiftGodotTestability"
+            ]
+        ),
+    ])
 #endif
 
 targets.append(contentsOf: [
@@ -215,7 +218,7 @@ targets.append(contentsOf: [
         ],
         plugins: swiftGodotPlugins
     ),
-    
+
     // General purpose cross-platform tests
     .testTarget(
         name: "SwiftGodotUniversalTests",
@@ -231,7 +234,7 @@ let package = Package(
     name: "SwiftGodot",
     platforms: [
         .macOS(.v13),
-        .iOS (.v15)
+        .iOS(.v15),
     ],
     products: products,
     dependencies: [


### PR DESCRIPTION
When building, the following warning is emitted:

```
warning: 'swiftgodot': found 2 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/sam/Developer/Projects/Godot/Sandbox/SwiftGodot/Sources/ExtensionApi/ApiJsonModel.swift
    /Users/sam/Developer/Projects/Godot/Sandbox/SwiftGodot/Sources/ExtensionApi/ApiJsonModel+Extra.swift
```

This change does what the warning suggests!