### PR TITLE
Fail the GH build/test steps if the swift build/test actually failed.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,6 +29,11 @@ jobs:
       run: swift build -v
     - name: Run tests
       run: set -o pipefail && swift test -v --xunit-output test-results.xml
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: test-results.xml
   build-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,14 +25,12 @@ jobs:
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: "16.0"
-    - name: Install XCPretty
-      run: gem install xcpretty
     - name: Build
-      run: swift build -v | xcpretty
+      run: swift build --build-tests --quiet
     - name: Run tests (XCTest)
-      run: swift test --no-parallel --disable-swift-testing --verbose | xcpretty
+      run: swift test --skip-build --no-parallel --disable-swift-testing
     - name: Run tests (Swift testing)
-      run: swift test --no-parallel --disable-xctest --verbose
+      run: swift test --skip-build --no-parallel --disable-xctest
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,10 +25,12 @@ jobs:
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: "16.0"
+    - name: Install XCPretty
+      run: gem install xcpretty
     - name: Build
-      run: swift build -v
+      run: swift build -v | xcpretty
     - name: Run tests (XCTest)
-      run: swift test --no-parallel --disable-swift-testing --verbose
+      run: swift test --no-parallel --disable-swift-testing --verbose | xcpretty
     - name: Run tests (Swift testing)
       run: swift test --no-parallel --disable-xctest --verbose
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: "15.3"
+        xcode-version: "16.0"
     - name: Build
       run: swift build -v
     - name: Run tests (XCTest)

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -27,13 +27,11 @@ jobs:
         xcode-version: "15.3"
     - name: Build
       run: swift build -v
-    - name: Run tests
-      run: set -o pipefail && swift test -v --xunit-output test-results.xml
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results
-        path: test-results.xml
+    - name: Run tests (XCTest)
+      run: swift test --no-parallel --disable-swift-testing --verbose
+    - name: Run tests (Swift testing)
+      run: swift test --no-parallel --disable-xctest --verbose
+
   build-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,8 +28,7 @@ jobs:
     - name: Build
       run: swift build -v
     - name: Run tests
-      run: swift test -v
-
+      run: set -o pipefail && swift test -v --xunit-output test-results.xml
   build-windows:
     runs-on: windows-latest
     steps:

--- a/Sources/SwiftGodotTestability/GodotTestCase.swift
+++ b/Sources/SwiftGodotTestability/GodotTestCase.swift
@@ -6,165 +6,174 @@
 //
 
 import XCTest
+
 @testable import SwiftGodot
 
-open class GodotTestCase: XCTestCase {
-    
-    private static var testSuites: [XCTestSuite] = []
-    
-    override open class var defaultTestSuite: XCTestSuite {
-        let testSuite = super.defaultTestSuite
-        testSuites.append (testSuite)
-        return testSuite
+class __GodotTestRunner: XCTestCase {
+    static var failureCount = 0
+
+    func testAAAARunEverythingInGodot() {
+        XCTAssert(Self.failureCount == 0, "Some tests failed when running in Godot")
     }
-    
-    override open func run () {
-        if GodotRuntime.isRunning {
-            super.run ()
-        } else {
-            guard !GodotRuntime.isInitialized else { return }
+
+    override func run() {
+        if !GodotRuntime.isInitialized {
             GodotRuntime.run {
-                if !Self.testSuites.isEmpty {
-                    // Executing all test suites from the context
-                    for testSuite in Self.testSuites {
-                        testSuite.perform (XCTestSuiteRun (test: testSuite))
-                    }
-                } else {
-                    Self.godotSetUp ()
-                    // Executing single test method
-                    super.run ()
-                    Self.godotTearDown ()
+                let allTests = XCTestSuite.default
+                let suite = XCTestSuite(name: "All Tests In Godot")
+                for test in allTests.tests {
+                    suite.addTest(test)
                 }
-                
-                GodotRuntime.stop ()
+                suite.run()
+                GodotRuntime.stop()
+                Self.failureCount = suite.testRun!.totalFailureCount
             }
+            super.run()
         }
     }
-    
+}
+
+open class GodotTestCase: XCTestCase {
+    override open func run() {
+        if GodotRuntime.isRunning {
+            super.run()
+        }
+    }
+
+    open override var name: String {
+        var name = super.name
+        if GodotRuntime.isRunning {
+            name.replace("-[", with: "-[Godot.")
+            return "Godot." + super.name
+        }
+        return name
+    }
+
+    override open class func setUp() {
+        if GodotRuntime.isRunning {
+            godotSetUp()
+        }
+    }
+
+    override open class func tearDown() {
+        if GodotRuntime.isRunning {
+            godotTearDown()
+        }
+    }
+
+    override open func tearDown() async throws {
+        if GodotRuntime.isRunning {
+            // Cleaning up test objects
+            let liveObjects: [Wrapped] = Array(liveFrameworkObjects.values) + Array(liveSubtypedObjects.values)
+            for liveObject in liveObjects {
+                switch liveObject {
+                case let node as Node:
+                    node.queueFree()
+                case let refCounted as RefCounted:
+                    refCounted._exp_unref()
+                case let object as Object:
+                    _ = object.call(method: "free")
+                default:
+                    print("Unable to free \(liveObject)")
+                }
+            }
+            liveFrameworkObjects.removeAll()
+            liveSubtypedObjects.removeAll()
+
+            // Waiting for queueFree to take effect
+            let scene = try GodotRuntime.getScene()
+            await scene.processFrame.emitted
+        }
+    }
+
     open class var godotSubclasses: [Wrapped.Type] {
         return []
     }
-    
-    open class func godotSetUp () {
+
+    open class func godotSetUp() {
         for subclass in godotSubclasses {
-            register (type: subclass)
+            register(type: subclass)
         }
     }
-    
-    open class func godotTearDown () {
+
+    open class func godotTearDown() {
         for subclass in godotSubclasses {
-            unregister (type: subclass)
+            unregister(type: subclass)
         }
     }
-    
-    override open class func setUp () {
-        if GodotRuntime.isRunning {
-            godotSetUp ()
-        }
-    }
-    
-    override open class func tearDown () {
-        if GodotRuntime.isRunning {
-            godotTearDown ()
-        }
-    }
-    
-    override open func tearDown () async throws {
-        // Cleaning up test objects
-        let liveObjects: [Wrapped] = Array (liveFrameworkObjects.values) + Array (liveSubtypedObjects.values)
-        for liveObject in liveObjects {
-            switch liveObject {
-            case let node as Node:
-                node.queueFree ()
-            case let refCounted as RefCounted:
-                refCounted._exp_unref ()
-            case let object as Object:
-                _ = object.call (method: "free")
-            default:
-                print ("Unable to free \(liveObject)")
-            }
-        }
-        liveFrameworkObjects.removeAll ()
-        liveSubtypedObjects.removeAll ()
-        
-        // Waiting for queueFree to take effect
-        let scene = try GodotRuntime.getScene ()
-        await scene.processFrame.emitted
-    }
-    
 }
 
-public extension GodotTestCase {
-    
+extension GodotTestCase {
+
     /// Asserts approximate equality of two floating point values based on `Math::is_equal_approx` implementation in Godot
-    func assertApproxEqual<T: FloatingPoint & ExpressibleByFloatLiteral> (_ a: T?, _ b: T?, epsilon: T = 0.00001, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    public func assertApproxEqual<T: FloatingPoint & ExpressibleByFloatLiteral>(_ a: T?, _ b: T?, epsilon: T = 0.00001, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         // Check for exact equality first, required to handle "infinity" values.
         guard a != b else { return }
         guard let a, let b else {
-            XCTAssertEqual (a, b, message, file: file, line: line)
+            XCTAssertEqual(a, b, message, file: file, line: line)
             return
         }
-        
+
         // Then check for approximate equality.
-        let tolerance: T = max (epsilon * abs (a), epsilon)
-        XCTAssertEqual (a, b, accuracy: tolerance, message, file: file, line: line)
+        let tolerance: T = max(epsilon * abs(a), epsilon)
+        XCTAssertEqual(a, b, accuracy: tolerance, message, file: file, line: line)
     }
-    
+
     /// Asserts approximate equality of two vectors by comparing approximately each component
-    func assertApproxEqual (_ a: Vector2?, _ b: Vector2?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    public func assertApproxEqual(_ a: Vector2?, _ b: Vector2?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual (a, b, message, file: file, line: line)
+            XCTAssertEqual(a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
-        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual(a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual(a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
     }
-    
+
     /// Asserts approximate equality of two vectors by comparing approximately each component
-    func assertApproxEqual (_ a: Vector3?, _ b: Vector3?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    public func assertApproxEqual(_ a: Vector3?, _ b: Vector3?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual (a, b, message, file: file, line: line)
+            XCTAssertEqual(a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
-        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
-        assertApproxEqual (a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
+        assertApproxEqual(a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual(a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual(a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
     }
-    
+
     /// Asserts approximate equality of two vectors by comparing approximately each component
-    func assertApproxEqual (_ a: Vector4?, _ b: Vector4?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    public func assertApproxEqual(_ a: Vector4?, _ b: Vector4?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual (a, b, message, file: file, line: line)
+            XCTAssertEqual(a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
-        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
-        assertApproxEqual (a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
-        assertApproxEqual (a.w, b.w, "Fail due to W. " + message, file: file, line: line)
+        assertApproxEqual(a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual(a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual(a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
+        assertApproxEqual(a.w, b.w, "Fail due to W. " + message, file: file, line: line)
     }
-    
+
     /// Asserts approximate equality of two quaternions by comparing approximately each component
-    func assertApproxEqual (_ a: Quaternion?, _ b: Quaternion?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    public func assertApproxEqual(_ a: Quaternion?, _ b: Quaternion?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual (a, b, message, file: file, line: line)
+            XCTAssertEqual(a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
-        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
-        assertApproxEqual (a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
-        assertApproxEqual (a.w, b.w, "Fail due to W. " + message, file: file, line: line)
+        assertApproxEqual(a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual(a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual(a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
+        assertApproxEqual(a.w, b.w, "Fail due to W. " + message, file: file, line: line)
     }
-    
+
     /// Asserts approximate equality of two colors by comparing approximately each component
-    func assertApproxEqual (_ a: Color?, _ b: Color?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    public func assertApproxEqual(_ a: Color?, _ b: Color?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual (a, b, message, file: file, line: line)
+            XCTAssertEqual(a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual (a.red, b.red, "Fail due to R. " + message, file: file, line: line)
-        assertApproxEqual (a.green, b.green, "Fail due to G. " + message, file: file, line: line)
-        assertApproxEqual (a.blue, b.blue, "Fail due to B. " + message, file: file, line: line)
-        assertApproxEqual (a.alpha, b.alpha, "Fail due to A. " + message, file: file, line: line)
+        assertApproxEqual(a.red, b.red, "Fail due to R. " + message, file: file, line: line)
+        assertApproxEqual(a.green, b.green, "Fail due to G. " + message, file: file, line: line)
+        assertApproxEqual(a.blue, b.blue, "Fail due to B. " + message, file: file, line: line)
+        assertApproxEqual(a.alpha, b.alpha, "Fail due to A. " + message, file: file, line: line)
     }
-    
+
 }

--- a/Sources/SwiftGodotTestability/GodotTestCase.swift
+++ b/Sources/SwiftGodotTestability/GodotTestCase.swift
@@ -72,77 +72,78 @@ open class GodotTestCase: XCTestCase {
 }
 
 /// Godot testing support.
-extension GodotTestCase {
 
+public extension GodotTestCase {
+    
     /// Asserts approximate equality of two floating point values based on `Math::is_equal_approx` implementation in Godot
-    public func assertApproxEqual<T: FloatingPoint & ExpressibleByFloatLiteral>(_ a: T?, _ b: T?, epsilon: T = 0.00001, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    func assertApproxEqual<T: FloatingPoint & ExpressibleByFloatLiteral> (_ a: T?, _ b: T?, epsilon: T = 0.00001, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         // Check for exact equality first, required to handle "infinity" values.
         guard a != b else { return }
         guard let a, let b else {
-            XCTAssertEqual(a, b, message, file: file, line: line)
+            XCTAssertEqual (a, b, message, file: file, line: line)
             return
         }
-
+        
         // Then check for approximate equality.
-        let tolerance: T = max(epsilon * abs(a), epsilon)
-        XCTAssertEqual(a, b, accuracy: tolerance, message, file: file, line: line)
+        let tolerance: T = max (epsilon * abs (a), epsilon)
+        XCTAssertEqual (a, b, accuracy: tolerance, message, file: file, line: line)
     }
-
+    
     /// Asserts approximate equality of two vectors by comparing approximately each component
-    public func assertApproxEqual(_ a: Vector2?, _ b: Vector2?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    func assertApproxEqual (_ a: Vector2?, _ b: Vector2?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual(a, b, message, file: file, line: line)
+            XCTAssertEqual (a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual(a.x, b.x, "Fail due to X. " + message, file: file, line: line)
-        assertApproxEqual(a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
     }
-
+    
     /// Asserts approximate equality of two vectors by comparing approximately each component
-    public func assertApproxEqual(_ a: Vector3?, _ b: Vector3?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    func assertApproxEqual (_ a: Vector3?, _ b: Vector3?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual(a, b, message, file: file, line: line)
+            XCTAssertEqual (a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual(a.x, b.x, "Fail due to X. " + message, file: file, line: line)
-        assertApproxEqual(a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
-        assertApproxEqual(a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
+        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual (a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
     }
-
+    
     /// Asserts approximate equality of two vectors by comparing approximately each component
-    public func assertApproxEqual(_ a: Vector4?, _ b: Vector4?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    func assertApproxEqual (_ a: Vector4?, _ b: Vector4?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual(a, b, message, file: file, line: line)
+            XCTAssertEqual (a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual(a.x, b.x, "Fail due to X. " + message, file: file, line: line)
-        assertApproxEqual(a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
-        assertApproxEqual(a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
-        assertApproxEqual(a.w, b.w, "Fail due to W. " + message, file: file, line: line)
+        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual (a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
+        assertApproxEqual (a.w, b.w, "Fail due to W. " + message, file: file, line: line)
     }
-
+    
     /// Asserts approximate equality of two quaternions by comparing approximately each component
-    public func assertApproxEqual(_ a: Quaternion?, _ b: Quaternion?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    func assertApproxEqual (_ a: Quaternion?, _ b: Quaternion?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual(a, b, message, file: file, line: line)
+            XCTAssertEqual (a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual(a.x, b.x, "Fail due to X. " + message, file: file, line: line)
-        assertApproxEqual(a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
-        assertApproxEqual(a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
-        assertApproxEqual(a.w, b.w, "Fail due to W. " + message, file: file, line: line)
+        assertApproxEqual (a.x, b.x, "Fail due to X. " + message, file: file, line: line)
+        assertApproxEqual (a.y, b.y, "Fail due to Y. " + message, file: file, line: line)
+        assertApproxEqual (a.z, b.z, "Fail due to Z. " + message, file: file, line: line)
+        assertApproxEqual (a.w, b.w, "Fail due to W. " + message, file: file, line: line)
     }
-
+    
     /// Asserts approximate equality of two colors by comparing approximately each component
-    public func assertApproxEqual(_ a: Color?, _ b: Color?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+    func assertApproxEqual (_ a: Color?, _ b: Color?, _ message: String = "", file: StaticString = #file, line: UInt = #line) {
         guard let a, let b else {
-            XCTAssertEqual(a, b, message, file: file, line: line)
+            XCTAssertEqual (a, b, message, file: file, line: line)
             return
         }
-        assertApproxEqual(a.red, b.red, "Fail due to R. " + message, file: file, line: line)
-        assertApproxEqual(a.green, b.green, "Fail due to G. " + message, file: file, line: line)
-        assertApproxEqual(a.blue, b.blue, "Fail due to B. " + message, file: file, line: line)
-        assertApproxEqual(a.alpha, b.alpha, "Fail due to A. " + message, file: file, line: line)
+        assertApproxEqual (a.red, b.red, "Fail due to R. " + message, file: file, line: line)
+        assertApproxEqual (a.green, b.green, "Fail due to G. " + message, file: file, line: line)
+        assertApproxEqual (a.blue, b.blue, "Fail due to B. " + message, file: file, line: line)
+        assertApproxEqual (a.alpha, b.alpha, "Fail due to A. " + message, file: file, line: line)
     }
-
+    
 }

--- a/Sources/SwiftGodotTestability/GodotTestRunner.swift
+++ b/Sources/SwiftGodotTestability/GodotTestRunner.swift
@@ -1,0 +1,47 @@
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+//  Created by Sam Deane on 31/10/24.
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+import XCTest
+
+@testable import SwiftGodot
+
+/// Test case which runs all the other tests from within the Godot runtime.
+/// It doesn't actually matter when this suite is run, but we name it with
+/// __ to try to make it run first, since `swift test` seems to run test
+/// suites in alphabetical order.
+class __GodotTestRunner: XCTestCase {
+    /// Failure count from the tests run in Godot
+    static var failureCount = 0
+
+    /// By the time this test runs, all the other tests have already run
+    /// in the Godot runtime. We can check the failure count here to see
+    /// if any tests failed.
+    func testRunEverythingInGodot() {
+        XCTAssert(Self.failureCount == 0, "Some tests failed when running in Godot")
+    }
+
+    /// Set up the Godot runtime and run all the tests in it.
+    override func run() {
+        // this call will be re-entered inside the Godot runtime, so we
+        // need to check if the runtime is already initialized.
+        if !GodotRuntime.isInitialized {
+            GodotRuntime.run {
+                /// make a copy of all the tests and run them in Godot
+                let allTests = XCTestSuite.default
+                let suite = XCTestSuite(name: "All Tests In Godot")
+                for test in allTests.tests {
+                    suite.addTest(test)
+                }
+                suite.run()
+
+                // record the failure count
+                Self.failureCount = suite.testRun!.totalFailureCount
+
+                // shut down the Godot runtime
+                GodotRuntime.stop()
+            }
+            super.run()
+        }
+    }
+}

--- a/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
@@ -8,7 +8,6 @@ import XCTest
 final class AABBTests: GodotTestCase {
 
     func testConstructorMethods() {
-        XCTFail("deliberate failure")
         let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
         let aabbCopy: AABB = AABB(from: aabb)
         XCTAssertEqual(aabb, aabbCopy, "AABBs created with the same dimensions but by different methods should be equal.")

--- a/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
@@ -1,219 +1,236 @@
 // Based on godot/tests/core/math/test_aabb.h
 
-import XCTest
 import SwiftGodotTestability
+import XCTest
+
 @testable import SwiftGodot
 
 final class AABBTests: GodotTestCase {
-    
-    func testConstructorMethods () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        let aabbCopy: AABB = AABB (from: aabb)
-        XCTAssertEqual (aabb, aabbCopy, "AABBs created with the same dimensions but by different methods should be equal.")
-    }
-    
-    func testStringConversion () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertEqual (Variant (aabb).description, "[P: (-1.5, 2, -2.5), S: (4, 5, 6)]", "The string representation should match the expected value.")
-    }
-    
-    func testBasicGetters () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertEqual (aabb.position, Vector3 (x: -1.5, y: 2, z: -2.5), "position getter should return the expected value.")
-        XCTAssertEqual (aabb.size, Vector3 (x: 4, y: 5, z: 6), "size getter should return the expected value.")
-        XCTAssertEqual (aabb.end, Vector3 (x: 2.5, y: 7, z: 3.5), "end getter should return the expected value.")
-        XCTAssertEqual (aabb.getCenter (), Vector3 (x: 0.5, y: 4.5, z: 0.5), "getCenter() should return the expected value.")
-    }
-    
-    func testBasicSetters () {
-        var aabb: AABB
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        aabb.end = Vector3 (x: 100, y: 0, z: 100)
-        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 101.5, y: -2, z: 102.5)), "Setting end should result in the expected AABB.")
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        aabb.position = Vector3 (x: -1000, y: -2000, z: -3000)
-        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1000, y: -2000, z: -3000), size: Vector3 (x: 4, y: 5, z: 6)), "Setting position should result in the expected AABB.")
 
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        aabb.size = Vector3 (x: 0, y: 0, z: -50)
-        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 0, y: 0, z: -50)), "Setting position should result in the expected AABB.")
+    func testConstructorMethods() {
+        XCTFail("deliberate failure")
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        let aabbCopy: AABB = AABB(from: aabb)
+        XCTAssertEqual(aabb, aabbCopy, "AABBs created with the same dimensions but by different methods should be equal.")
     }
-    
-    func testVolumeGetters () {
+
+    func testStringConversion() {
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertEqual(Variant(aabb).description, "[P: (-1.5, 2, -2.5), S: (4, 5, 6)]", "The string representation should match the expected value.")
+    }
+
+    func testBasicGetters() {
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertEqual(aabb.position, Vector3(x: -1.5, y: 2, z: -2.5), "position getter should return the expected value.")
+        XCTAssertEqual(aabb.size, Vector3(x: 4, y: 5, z: 6), "size getter should return the expected value.")
+        XCTAssertEqual(aabb.end, Vector3(x: 2.5, y: 7, z: 3.5), "end getter should return the expected value.")
+        XCTAssertEqual(aabb.getCenter(), Vector3(x: 0.5, y: 4.5, z: 0.5), "getCenter() should return the expected value.")
+    }
+
+    func testBasicSetters() {
         var aabb: AABB
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertEqual (aabb.getVolume (), 120, "getVolume() should return the expected value with positive size.")
-        XCTAssertTrue (aabb.hasVolume (), "Non-empty volumetric AABB should have a volume.")
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: 5, z: 6))
-        XCTAssertEqual (aabb.getVolume (), -120, "getVolume() should return the expected value with negative size (1 component).")
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: -5, z: 6))
-        XCTAssertEqual (aabb.getVolume (), 120, "getVolume() should return the expected value with positive size (2 components).")
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: -5, z: -6))
-        XCTAssertEqual (aabb.getVolume (), -120, "getVolume() should return the expected value with negative size (3 components).")
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 6))
-        XCTAssertFalse (aabb.hasVolume (), "Non-empty flat AABB should not have a volume.")
-        
-        aabb = AABB ()
-        XCTAssertFalse (aabb.hasVolume (), "Empty AABB should not have a volume.")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        aabb.end = Vector3(x: 100, y: 0, z: 100)
+        XCTAssertEqual(aabb, AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 101.5, y: -2, z: 102.5)), "Setting end should result in the expected AABB.")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        aabb.position = Vector3(x: -1000, y: -2000, z: -3000)
+        XCTAssertEqual(aabb, AABB(position: Vector3(x: -1000, y: -2000, z: -3000), size: Vector3(x: 4, y: 5, z: 6)), "Setting position should result in the expected AABB.")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        aabb.size = Vector3(x: 0, y: 0, z: -50)
+        XCTAssertEqual(aabb, AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 0, y: 0, z: -50)), "Setting position should result in the expected AABB.")
     }
-    
-    func testSurfaceGetters () {
+
+    func testVolumeGetters() {
         var aabb: AABB
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertTrue (aabb.hasSurface (), "Non-empty volumetric AABB should have an surface.")
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 6))
-        XCTAssertTrue (aabb.hasSurface (), "Non-empty flat AABB should have a surface.")
-        
-        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 0))
-        XCTAssertTrue (aabb.hasSurface (), "Non-empty linear AABB should have a surface.")
-        
-        aabb = AABB ()
-        XCTAssertFalse (aabb.hasSurface (), "Empty AABB should not have an surface.")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertEqual(aabb.getVolume(), 120, "getVolume() should return the expected value with positive size.")
+        XCTAssertTrue(aabb.hasVolume(), "Non-empty volumetric AABB should have a volume.")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: -4, y: 5, z: 6))
+        XCTAssertEqual(aabb.getVolume(), -120, "getVolume() should return the expected value with negative size (1 component).")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: -4, y: -5, z: 6))
+        XCTAssertEqual(aabb.getVolume(), 120, "getVolume() should return the expected value with positive size (2 components).")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: -4, y: -5, z: -6))
+        XCTAssertEqual(aabb.getVolume(), -120, "getVolume() should return the expected value with negative size (3 components).")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 0, z: 6))
+        XCTAssertFalse(aabb.hasVolume(), "Non-empty flat AABB should not have a volume.")
+
+        aabb = AABB()
+        XCTAssertFalse(aabb.hasVolume(), "Empty AABB should not have a volume.")
     }
-    
-    func testIntersection () {
-        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+
+    func testSurfaceGetters() {
+        var aabb: AABB
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertTrue(aabb.hasSurface(), "Non-empty volumetric AABB should have an surface.")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 0, z: 6))
+        XCTAssertTrue(aabb.hasSurface(), "Non-empty flat AABB should have a surface.")
+
+        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 0, z: 0))
+        XCTAssertTrue(aabb.hasSurface(), "Non-empty linear AABB should have a surface.")
+
+        aabb = AABB()
+        XCTAssertFalse(aabb.hasSurface(), "Empty AABB should not have an surface.")
+    }
+
+    func testIntersection() {
+        let aabbBig: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
         var aabbSmall: AABB
-        
-        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertTrue (aabbBig.intersects (with: aabbSmall), "intersects() with fully contained AABB (touching the edge) should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertTrue (aabbBig.intersects (with: aabbSmall), "intersects() with partially contained AABB (overflowing on Y axis) should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertFalse (aabbBig.intersects (with: aabbSmall), "intersects() with non-contained AABB should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), aabbSmall, "intersection() with fully contained AABB (touching the edge) should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), AABB (position: Vector3 (x: 0.5, y: 2, z: -2), size: Vector3 (x: 1, y: 0.5, z: 1)), "intersection() with partially contained AABB (overflowing on Y axis) should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), AABB (), "intersection() with non-contained AABB should return the expected result.")
-        
-        XCTAssertTrue (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 4)), "intersectsPlane() should return the expected result.")
-        XCTAssertTrue (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: -1, z: 0), d: -4)), "intersectsPlane() should return the expected result.")
-        XCTAssertFalse (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 200)), "intersectsPlane() should return the expected result.")
-        
-        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 1, y: 3, z: 0), to: Vector3 (x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
-        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 3, z: 0), to: Vector3 (x: 0, y: -300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
-        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: -50, y: 3, z: -50), to: Vector3 (x: 50, y: 3, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
-        XCTAssertEqual (aabbBig.intersectsSegment (from: Vector3 (x: -50, y: 25, z: -50), to: Vector3 (x: 50, y: 25, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
-        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 3, z: 0), to: Vector3 (x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result with segment of length 0.")
-        XCTAssertEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 300, z: 0), to: Vector3 (x: 0, y: 300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result with segment of length 0.")
+
+        aabbSmall = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertTrue(aabbBig.intersects(with: aabbSmall), "intersects() with fully contained AABB (touching the edge) should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: 0.5, y: 1.5, z: -2), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertTrue(aabbBig.intersects(with: aabbSmall), "intersects() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: 10, y: -10, z: -10), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertFalse(aabbBig.intersects(with: aabbSmall), "intersects() with non-contained AABB should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertEqual(aabbBig.intersection(with: aabbSmall), aabbSmall, "intersection() with fully contained AABB (touching the edge) should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: 0.5, y: 1.5, z: -2), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertEqual(
+            aabbBig.intersection(with: aabbSmall), AABB(position: Vector3(x: 0.5, y: 2, z: -2), size: Vector3(x: 1, y: 0.5, z: 1)),
+            "intersection() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: 10, y: -10, z: -10), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertEqual(aabbBig.intersection(with: aabbSmall), AABB(), "intersection() with non-contained AABB should return the expected result.")
+
+        XCTAssertTrue(aabbBig.intersectsPlane(Plane(normal: Vector3(x: 0, y: 1, z: 0), d: 4)), "intersectsPlane() should return the expected result.")
+        XCTAssertTrue(aabbBig.intersectsPlane(Plane(normal: Vector3(x: 0, y: -1, z: 0), d: -4)), "intersectsPlane() should return the expected result.")
+        XCTAssertFalse(aabbBig.intersectsPlane(Plane(normal: Vector3(x: 0, y: 1, z: 0), d: 200)), "intersectsPlane() should return the expected result.")
+
+        XCTAssertNotEqual(aabbBig.intersectsSegment(from: Vector3(x: 1, y: 3, z: 0), to: Vector3(x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual(
+            aabbBig.intersectsSegment(from: Vector3(x: 0, y: 3, z: 0), to: Vector3(x: 0, y: -300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual(
+            aabbBig.intersectsSegment(from: Vector3(x: -50, y: 3, z: -50), to: Vector3(x: 50, y: 3, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertEqual(
+            aabbBig.intersectsSegment(from: Vector3(x: -50, y: 25, z: -50), to: Vector3(x: 50, y: 25, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual(
+            aabbBig.intersectsSegment(from: Vector3(x: 0, y: 3, z: 0), to: Vector3(x: 0, y: 3, z: 0)).gtype, Variant.GType.nil,
+            "intersectsSegment() should return the expected result with segment of length 0.")
+        XCTAssertEqual(
+            aabbBig.intersectsSegment(from: Vector3(x: 0, y: 300, z: 0), to: Vector3(x: 0, y: 300, z: 0)).gtype, Variant.GType.nil,
+            "intersectsSegment() should return the expected result with segment of length 0.")
     }
-    
-    func testMerging () {
-        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+
+    func testMerging() {
+        let aabbBig: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
         var aabbSmall: AABB
-        
-        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertEqual (aabbBig.merge (with: aabbSmall), aabbBig, "merge() with fully contained AABB (touching the edge) should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertEqual (aabbBig.merge (with: aabbSmall), AABB (position: Vector3 (x: -1.5, y: 1.5, z: -2.5), size: Vector3 (x: 4, y: 5.5, z: 6)), "merge() with partially contained AABB (overflowing on Y axis) should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertEqual (aabbBig.merge (with: aabbSmall), AABB (position: Vector3 (x: -1.5, y: -10, z: -10), size: Vector3 (x: 12.5, y: 17, z: 13.5)), "merge() with non-contained AABB should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertEqual(aabbBig.merge(with: aabbSmall), aabbBig, "merge() with fully contained AABB (touching the edge) should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: 0.5, y: 1.5, z: -2), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertEqual(
+            aabbBig.merge(with: aabbSmall), AABB(position: Vector3(x: -1.5, y: 1.5, z: -2.5), size: Vector3(x: 4, y: 5.5, z: 6)),
+            "merge() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: 10, y: -10, z: -10), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertEqual(
+            aabbBig.merge(with: aabbSmall), AABB(position: Vector3(x: -1.5, y: -10, z: -10), size: Vector3(x: 12.5, y: 17, z: 13.5)),
+            "merge() with non-contained AABB should return the expected result.")
     }
-    
-    func testEncloses () {
-        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+
+    func testEncloses() {
+        let aabbBig: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
         var aabbSmall: AABB
-        
-        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertTrue (aabbBig.encloses (with: aabbSmall), "encloses() with fully contained AABB (touching the edge) should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertFalse (aabbBig.encloses (with: aabbSmall), "encloses() with partially contained AABB (overflowing on Y axis) should return the expected result.")
-        
-        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
-        XCTAssertFalse (aabbBig.encloses (with: aabbSmall), "encloses() with non-contained AABB should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertTrue(aabbBig.encloses(with: aabbSmall), "encloses() with fully contained AABB (touching the edge) should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: 0.5, y: 1.5, z: -2), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertFalse(aabbBig.encloses(with: aabbSmall), "encloses() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+
+        aabbSmall = AABB(position: Vector3(x: 10, y: -10, z: -10), size: Vector3(x: 1, y: 1, z: 1))
+        XCTAssertFalse(aabbBig.encloses(with: aabbSmall), "encloses() with non-contained AABB should return the expected result.")
     }
-    
-    func testGetEndpoints () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertEqual (aabb.getEndpoint (idx: 0), Vector3 (x: -1.5, y: 2, z: -2.5), "The endpoint at index 0 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: 1), Vector3 (x: -1.5, y: 2, z: 3.5), "The endpoint at index 1 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: 2), Vector3 (x: -1.5, y: 7, z: -2.5), "The endpoint at index 2 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: 3), Vector3 (x: -1.5, y: 7, z: 3.5), "The endpoint at index 3 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: 4), Vector3 (x: 2.5, y: 2, z: -2.5), "The endpoint at index 4 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: 5), Vector3 (x: 2.5, y: 2, z: 3.5), "The endpoint at index 5 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: 6), Vector3 (x: 2.5, y: 7, z: -2.5), "The endpoint at index 6 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: 7), Vector3 (x: 2.5, y: 7, z: 3.5), "The endpoint at index 7 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: 8), Vector3 (), "The endpoint at invalid index 8 should match the expected value.")
-        XCTAssertEqual (aabb.getEndpoint (idx: -1), Vector3 (), "The endpoint at invalid index -1 should match the expected value.")
+
+    func testGetEndpoints() {
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertEqual(aabb.getEndpoint(idx: 0), Vector3(x: -1.5, y: 2, z: -2.5), "The endpoint at index 0 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: 1), Vector3(x: -1.5, y: 2, z: 3.5), "The endpoint at index 1 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: 2), Vector3(x: -1.5, y: 7, z: -2.5), "The endpoint at index 2 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: 3), Vector3(x: -1.5, y: 7, z: 3.5), "The endpoint at index 3 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: 4), Vector3(x: 2.5, y: 2, z: -2.5), "The endpoint at index 4 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: 5), Vector3(x: 2.5, y: 2, z: 3.5), "The endpoint at index 5 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: 6), Vector3(x: 2.5, y: 7, z: -2.5), "The endpoint at index 6 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: 7), Vector3(x: 2.5, y: 7, z: 3.5), "The endpoint at index 7 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: 8), Vector3(), "The endpoint at invalid index 8 should match the expected value.")
+        XCTAssertEqual(aabb.getEndpoint(idx: -1), Vector3(), "The endpoint at invalid index -1 should match the expected value.")
     }
-    
-    func testGetLongestShortestAxis () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertEqual (aabb.getLongestAxis (), Vector3 (x: 0, y: 0, z: 1), "getLongestAxis() should return the expected value.")
-        XCTAssertEqual (aabb.getLongestAxisIndex (), Int64 (Vector3.Axis.z.rawValue), "getLongestAxisIndex() should return the expected value.")
-        XCTAssertEqual (aabb.getLongestAxisSize (), 6, "getLongestAxisSize() should return the expected value.")
-        XCTAssertEqual (aabb.getShortestAxis (), Vector3 (x: 1, y: 0, z: 0), "getShortestAxis() should return the expected value.")
-        XCTAssertEqual (aabb.getShortestAxisIndex (), Int64 (Vector3.Axis.x.rawValue), "getShortestAxisIndex() should return the expected value.")
-        XCTAssertEqual (aabb.getShortestAxisSize (), 4, "getShortestAxisSize() should return the expected value.")
+
+    func testGetLongestShortestAxis() {
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertEqual(aabb.getLongestAxis(), Vector3(x: 0, y: 0, z: 1), "getLongestAxis() should return the expected value.")
+        XCTAssertEqual(aabb.getLongestAxisIndex(), Int64(Vector3.Axis.z.rawValue), "getLongestAxisIndex() should return the expected value.")
+        XCTAssertEqual(aabb.getLongestAxisSize(), 6, "getLongestAxisSize() should return the expected value.")
+        XCTAssertEqual(aabb.getShortestAxis(), Vector3(x: 1, y: 0, z: 0), "getShortestAxis() should return the expected value.")
+        XCTAssertEqual(aabb.getShortestAxisIndex(), Int64(Vector3.Axis.x.rawValue), "getShortestAxisIndex() should return the expected value.")
+        XCTAssertEqual(aabb.getShortestAxisSize(), 4, "getShortestAxisSize() should return the expected value.")
     }
-    
-    func testGetSupport () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 1, y: 0, z: 0)), Vector3 (x: 2.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0.5, y: 1, z: 0)), Vector3 (x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0.5, y: 1, z: -400)), Vector3 (x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0, y: -1, z: 0)), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0, y: -0.1, z: 0)), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual (aabb.getSupport (dir: Vector3 ()), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value with a null vector.")
+
+    func testGetSupport() {
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 1, y: 0, z: 0)), Vector3(x: 2.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 0.5, y: 1, z: 0)), Vector3(x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 0.5, y: 1, z: -400)), Vector3(x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 0, y: -1, z: 0)), Vector3(x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 0, y: -0.1, z: 0)), Vector3(x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual(aabb.getSupport(dir: Vector3()), Vector3(x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value with a null vector.")
     }
-    
-    func testGrow () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertEqual (aabb.grow (by: 0.25), AABB (position: Vector3 (x: -1.75, y: 1.75, z: -2.75), size: Vector3 (x: 4.5, y: 5.5, z: 6.5)), "grow() with positive value should return the expected AABB.")
-        XCTAssertEqual (aabb.grow (by: -0.25), AABB (position: Vector3 (x: -1.25, y: 2.25, z: -2.25), size: Vector3 (x: 3.5, y: 4.5, z: 5.5)), "grow() with negative value should return the expected AABB.")
-        XCTAssertEqual (aabb.grow (by: -10), AABB (position: Vector3 (x: 8.5, y: 12, z: 7.5), size: Vector3 (x: -16, y: -15, z: -14)), "grow() with large negative value should return the expected AABB.")
+
+    func testGrow() {
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertEqual(aabb.grow(by: 0.25), AABB(position: Vector3(x: -1.75, y: 1.75, z: -2.75), size: Vector3(x: 4.5, y: 5.5, z: 6.5)), "grow() with positive value should return the expected AABB.")
+        XCTAssertEqual(aabb.grow(by: -0.25), AABB(position: Vector3(x: -1.25, y: 2.25, z: -2.25), size: Vector3(x: 3.5, y: 4.5, z: 5.5)), "grow() with negative value should return the expected AABB.")
+        XCTAssertEqual(aabb.grow(by: -10), AABB(position: Vector3(x: 8.5, y: 12, z: 7.5), size: Vector3(x: -16, y: -15, z: -14)), "grow() with large negative value should return the expected AABB.")
     }
-    
-    func testHasPoint () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        
-        XCTAssertTrue (aabb.hasPoint (Vector3 (x: -1, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
-        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 2, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
-        XCTAssertFalse (aabb.hasPoint (Vector3 (x: -20, y: 0, z: 0)), "hasPoint() with non-contained point should return the expected value.")
-        
-        XCTAssertTrue (aabb.hasPoint (Vector3 (x: -1.5, y: 3, z: 0)), "hasPoint() with positive size should include point on near face (X axis).")
-        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 2.5, y: 3, z: 0)), "hasPoint() with positive size should include point on far face (X axis).")
-        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 2, z: 0)), "hasPoint() with positive size should include point on near face (Y axis).")
-        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 7, z: 0)), "hasPoint() with positive size should include point on far face (Y axis).")
-        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 3, z: -2.5)), "hasPoint() with positive size should include point on near face (Z axis).")
-        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 3, z: 3.5)), "hasPoint() with positive size should include point on far face (Z axis).")
+
+    func testHasPoint() {
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+
+        XCTAssertTrue(aabb.hasPoint(Vector3(x: -1, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
+        XCTAssertTrue(aabb.hasPoint(Vector3(x: 2, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
+        XCTAssertFalse(aabb.hasPoint(Vector3(x: -20, y: 0, z: 0)), "hasPoint() with non-contained point should return the expected value.")
+
+        XCTAssertTrue(aabb.hasPoint(Vector3(x: -1.5, y: 3, z: 0)), "hasPoint() with positive size should include point on near face (X axis).")
+        XCTAssertTrue(aabb.hasPoint(Vector3(x: 2.5, y: 3, z: 0)), "hasPoint() with positive size should include point on far face (X axis).")
+        XCTAssertTrue(aabb.hasPoint(Vector3(x: 0, y: 2, z: 0)), "hasPoint() with positive size should include point on near face (Y axis).")
+        XCTAssertTrue(aabb.hasPoint(Vector3(x: 0, y: 7, z: 0)), "hasPoint() with positive size should include point on far face (Y axis).")
+        XCTAssertTrue(aabb.hasPoint(Vector3(x: 0, y: 3, z: -2.5)), "hasPoint() with positive size should include point on near face (Z axis).")
+        XCTAssertTrue(aabb.hasPoint(Vector3(x: 0, y: 3, z: 3.5)), "hasPoint() with positive size should include point on far face (Z axis).")
     }
-    
-    func testExpanding () {
-        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
-        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -1, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
-        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: 2, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
-        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -1.5, y: 3, z: 0)), aabb, "expand() with contained point on negative edge should return the expected AABB.")
-        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: 2.5, y: 3, z: 0)), aabb, "expand() with contained point on positive edge should return the expected AABB.")
-        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -20, y: 0, z: 0)), AABB (position: Vector3 (x: -20, y: 0, z: -2.5), size: Vector3 (x: 22.5, y: 7, z: 6)), "expand() with non-contained point should return the expected AABB.")
+
+    func testExpanding() {
+        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+        XCTAssertEqual(aabb.expand(toPoint: Vector3(x: -1, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
+        XCTAssertEqual(aabb.expand(toPoint: Vector3(x: 2, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
+        XCTAssertEqual(aabb.expand(toPoint: Vector3(x: -1.5, y: 3, z: 0)), aabb, "expand() with contained point on negative edge should return the expected AABB.")
+        XCTAssertEqual(aabb.expand(toPoint: Vector3(x: 2.5, y: 3, z: 0)), aabb, "expand() with contained point on positive edge should return the expected AABB.")
+        XCTAssertEqual(
+            aabb.expand(toPoint: Vector3(x: -20, y: 0, z: 0)), AABB(position: Vector3(x: -20, y: 0, z: -2.5), size: Vector3(x: 22.5, y: 7, z: 6)),
+            "expand() with non-contained point should return the expected AABB.")
     }
-    
-    func testFiniteNumberChecks () {
-        let x: Vector3 = Vector3 (x: 0, y: 1, z: 2)
-        let infinite: Vector3 = Vector3 (x: .nan, y: .nan, z: .nan)
-        XCTAssertTrue (AABB (position: x, size: x).isFinite (), "AABB with all components finite should be finite")
-        XCTAssertFalse (AABB (position: infinite, size: x).isFinite (), "AABB with one component infinite should not be finite.")
-        XCTAssertFalse (AABB (position: x, size: infinite).isFinite (), "AABB with one component infinite should not be finite.")
-        XCTAssertFalse (AABB (position: infinite, size: infinite).isFinite (), "AABB with two components infinite should not be finite.")
+
+    func testFiniteNumberChecks() {
+        let x: Vector3 = Vector3(x: 0, y: 1, z: 2)
+        let infinite: Vector3 = Vector3(x: .nan, y: .nan, z: .nan)
+        XCTAssertTrue(AABB(position: x, size: x).isFinite(), "AABB with all components finite should be finite")
+        XCTAssertFalse(AABB(position: infinite, size: x).isFinite(), "AABB with one component infinite should not be finite.")
+        XCTAssertFalse(AABB(position: x, size: infinite).isFinite(), "AABB with one component infinite should not be finite.")
+        XCTAssertFalse(AABB(position: infinite, size: infinite).isFinite(), "AABB with two components infinite should not be finite.")
     }
-    
+
 }

--- a/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/AABBTests.swift
@@ -1,235 +1,219 @@
 // Based on godot/tests/core/math/test_aabb.h
 
-import SwiftGodotTestability
 import XCTest
-
+import SwiftGodotTestability
 @testable import SwiftGodot
 
 final class AABBTests: GodotTestCase {
-
-    func testConstructorMethods() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        let aabbCopy: AABB = AABB(from: aabb)
-        XCTAssertEqual(aabb, aabbCopy, "AABBs created with the same dimensions but by different methods should be equal.")
+    
+    func testConstructorMethods () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        let aabbCopy: AABB = AABB (from: aabb)
+        XCTAssertEqual (aabb, aabbCopy, "AABBs created with the same dimensions but by different methods should be equal.")
     }
-
-    func testStringConversion() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertEqual(Variant(aabb).description, "[P: (-1.5, 2, -2.5), S: (4, 5, 6)]", "The string representation should match the expected value.")
+    
+    func testStringConversion () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (Variant (aabb).description, "[P: (-1.5, 2, -2.5), S: (4, 5, 6)]", "The string representation should match the expected value.")
     }
-
-    func testBasicGetters() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertEqual(aabb.position, Vector3(x: -1.5, y: 2, z: -2.5), "position getter should return the expected value.")
-        XCTAssertEqual(aabb.size, Vector3(x: 4, y: 5, z: 6), "size getter should return the expected value.")
-        XCTAssertEqual(aabb.end, Vector3(x: 2.5, y: 7, z: 3.5), "end getter should return the expected value.")
-        XCTAssertEqual(aabb.getCenter(), Vector3(x: 0.5, y: 4.5, z: 0.5), "getCenter() should return the expected value.")
+    
+    func testBasicGetters () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.position, Vector3 (x: -1.5, y: 2, z: -2.5), "position getter should return the expected value.")
+        XCTAssertEqual (aabb.size, Vector3 (x: 4, y: 5, z: 6), "size getter should return the expected value.")
+        XCTAssertEqual (aabb.end, Vector3 (x: 2.5, y: 7, z: 3.5), "end getter should return the expected value.")
+        XCTAssertEqual (aabb.getCenter (), Vector3 (x: 0.5, y: 4.5, z: 0.5), "getCenter() should return the expected value.")
     }
-
-    func testBasicSetters() {
+    
+    func testBasicSetters () {
         var aabb: AABB
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        aabb.end = Vector3 (x: 100, y: 0, z: 100)
+        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 101.5, y: -2, z: 102.5)), "Setting end should result in the expected AABB.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        aabb.position = Vector3 (x: -1000, y: -2000, z: -3000)
+        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1000, y: -2000, z: -3000), size: Vector3 (x: 4, y: 5, z: 6)), "Setting position should result in the expected AABB.")
 
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        aabb.end = Vector3(x: 100, y: 0, z: 100)
-        XCTAssertEqual(aabb, AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 101.5, y: -2, z: 102.5)), "Setting end should result in the expected AABB.")
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        aabb.position = Vector3(x: -1000, y: -2000, z: -3000)
-        XCTAssertEqual(aabb, AABB(position: Vector3(x: -1000, y: -2000, z: -3000), size: Vector3(x: 4, y: 5, z: 6)), "Setting position should result in the expected AABB.")
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        aabb.size = Vector3(x: 0, y: 0, z: -50)
-        XCTAssertEqual(aabb, AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 0, y: 0, z: -50)), "Setting position should result in the expected AABB.")
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        aabb.size = Vector3 (x: 0, y: 0, z: -50)
+        XCTAssertEqual (aabb, AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 0, y: 0, z: -50)), "Setting position should result in the expected AABB.")
     }
-
-    func testVolumeGetters() {
+    
+    func testVolumeGetters () {
         var aabb: AABB
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertEqual(aabb.getVolume(), 120, "getVolume() should return the expected value with positive size.")
-        XCTAssertTrue(aabb.hasVolume(), "Non-empty volumetric AABB should have a volume.")
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: -4, y: 5, z: 6))
-        XCTAssertEqual(aabb.getVolume(), -120, "getVolume() should return the expected value with negative size (1 component).")
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: -4, y: -5, z: 6))
-        XCTAssertEqual(aabb.getVolume(), 120, "getVolume() should return the expected value with positive size (2 components).")
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: -4, y: -5, z: -6))
-        XCTAssertEqual(aabb.getVolume(), -120, "getVolume() should return the expected value with negative size (3 components).")
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 0, z: 6))
-        XCTAssertFalse(aabb.hasVolume(), "Non-empty flat AABB should not have a volume.")
-
-        aabb = AABB()
-        XCTAssertFalse(aabb.hasVolume(), "Empty AABB should not have a volume.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getVolume (), 120, "getVolume() should return the expected value with positive size.")
+        XCTAssertTrue (aabb.hasVolume (), "Non-empty volumetric AABB should have a volume.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getVolume (), -120, "getVolume() should return the expected value with negative size (1 component).")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: -5, z: 6))
+        XCTAssertEqual (aabb.getVolume (), 120, "getVolume() should return the expected value with positive size (2 components).")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: -4, y: -5, z: -6))
+        XCTAssertEqual (aabb.getVolume (), -120, "getVolume() should return the expected value with negative size (3 components).")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 6))
+        XCTAssertFalse (aabb.hasVolume (), "Non-empty flat AABB should not have a volume.")
+        
+        aabb = AABB ()
+        XCTAssertFalse (aabb.hasVolume (), "Empty AABB should not have a volume.")
     }
-
-    func testSurfaceGetters() {
+    
+    func testSurfaceGetters () {
         var aabb: AABB
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertTrue(aabb.hasSurface(), "Non-empty volumetric AABB should have an surface.")
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 0, z: 6))
-        XCTAssertTrue(aabb.hasSurface(), "Non-empty flat AABB should have a surface.")
-
-        aabb = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 0, z: 0))
-        XCTAssertTrue(aabb.hasSurface(), "Non-empty linear AABB should have a surface.")
-
-        aabb = AABB()
-        XCTAssertFalse(aabb.hasSurface(), "Empty AABB should not have an surface.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertTrue (aabb.hasSurface (), "Non-empty volumetric AABB should have an surface.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 6))
+        XCTAssertTrue (aabb.hasSurface (), "Non-empty flat AABB should have a surface.")
+        
+        aabb = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 0, z: 0))
+        XCTAssertTrue (aabb.hasSurface (), "Non-empty linear AABB should have a surface.")
+        
+        aabb = AABB ()
+        XCTAssertFalse (aabb.hasSurface (), "Empty AABB should not have an surface.")
     }
-
-    func testIntersection() {
-        let aabbBig: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+    
+    func testIntersection () {
+        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
         var aabbSmall: AABB
-
-        aabbSmall = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertTrue(aabbBig.intersects(with: aabbSmall), "intersects() with fully contained AABB (touching the edge) should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: 0.5, y: 1.5, z: -2), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertTrue(aabbBig.intersects(with: aabbSmall), "intersects() with partially contained AABB (overflowing on Y axis) should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: 10, y: -10, z: -10), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertFalse(aabbBig.intersects(with: aabbSmall), "intersects() with non-contained AABB should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertEqual(aabbBig.intersection(with: aabbSmall), aabbSmall, "intersection() with fully contained AABB (touching the edge) should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: 0.5, y: 1.5, z: -2), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertEqual(
-            aabbBig.intersection(with: aabbSmall), AABB(position: Vector3(x: 0.5, y: 2, z: -2), size: Vector3(x: 1, y: 0.5, z: 1)),
-            "intersection() with partially contained AABB (overflowing on Y axis) should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: 10, y: -10, z: -10), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertEqual(aabbBig.intersection(with: aabbSmall), AABB(), "intersection() with non-contained AABB should return the expected result.")
-
-        XCTAssertTrue(aabbBig.intersectsPlane(Plane(normal: Vector3(x: 0, y: 1, z: 0), d: 4)), "intersectsPlane() should return the expected result.")
-        XCTAssertTrue(aabbBig.intersectsPlane(Plane(normal: Vector3(x: 0, y: -1, z: 0), d: -4)), "intersectsPlane() should return the expected result.")
-        XCTAssertFalse(aabbBig.intersectsPlane(Plane(normal: Vector3(x: 0, y: 1, z: 0), d: 200)), "intersectsPlane() should return the expected result.")
-
-        XCTAssertNotEqual(aabbBig.intersectsSegment(from: Vector3(x: 1, y: 3, z: 0), to: Vector3(x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
-        XCTAssertNotEqual(
-            aabbBig.intersectsSegment(from: Vector3(x: 0, y: 3, z: 0), to: Vector3(x: 0, y: -300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
-        XCTAssertNotEqual(
-            aabbBig.intersectsSegment(from: Vector3(x: -50, y: 3, z: -50), to: Vector3(x: 50, y: 3, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
-        XCTAssertEqual(
-            aabbBig.intersectsSegment(from: Vector3(x: -50, y: 25, z: -50), to: Vector3(x: 50, y: 25, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
-        XCTAssertNotEqual(
-            aabbBig.intersectsSegment(from: Vector3(x: 0, y: 3, z: 0), to: Vector3(x: 0, y: 3, z: 0)).gtype, Variant.GType.nil,
-            "intersectsSegment() should return the expected result with segment of length 0.")
-        XCTAssertEqual(
-            aabbBig.intersectsSegment(from: Vector3(x: 0, y: 300, z: 0), to: Vector3(x: 0, y: 300, z: 0)).gtype, Variant.GType.nil,
-            "intersectsSegment() should return the expected result with segment of length 0.")
+        
+        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertTrue (aabbBig.intersects (with: aabbSmall), "intersects() with fully contained AABB (touching the edge) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertTrue (aabbBig.intersects (with: aabbSmall), "intersects() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertFalse (aabbBig.intersects (with: aabbSmall), "intersects() with non-contained AABB should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), aabbSmall, "intersection() with fully contained AABB (touching the edge) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), AABB (position: Vector3 (x: 0.5, y: 2, z: -2), size: Vector3 (x: 1, y: 0.5, z: 1)), "intersection() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.intersection (with: aabbSmall), AABB (), "intersection() with non-contained AABB should return the expected result.")
+        
+        XCTAssertTrue (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 4)), "intersectsPlane() should return the expected result.")
+        XCTAssertTrue (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: -1, z: 0), d: -4)), "intersectsPlane() should return the expected result.")
+        XCTAssertFalse (aabbBig.intersectsPlane (Plane (normal: Vector3 (x: 0, y: 1, z: 0), d: 200)), "intersectsPlane() should return the expected result.")
+        
+        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 1, y: 3, z: 0), to: Vector3 (x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 3, z: 0), to: Vector3 (x: 0, y: -300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: -50, y: 3, z: -50), to: Vector3 (x: 50, y: 3, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertEqual (aabbBig.intersectsSegment (from: Vector3 (x: -50, y: 25, z: -50), to: Vector3 (x: 50, y: 25, z: 50)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result.")
+        XCTAssertNotEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 3, z: 0), to: Vector3 (x: 0, y: 3, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result with segment of length 0.")
+        XCTAssertEqual (aabbBig.intersectsSegment (from: Vector3 (x: 0, y: 300, z: 0), to: Vector3 (x: 0, y: 300, z: 0)).gtype, Variant.GType.nil, "intersectsSegment() should return the expected result with segment of length 0.")
     }
-
-    func testMerging() {
-        let aabbBig: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+    
+    func testMerging () {
+        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
         var aabbSmall: AABB
-
-        aabbSmall = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertEqual(aabbBig.merge(with: aabbSmall), aabbBig, "merge() with fully contained AABB (touching the edge) should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: 0.5, y: 1.5, z: -2), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertEqual(
-            aabbBig.merge(with: aabbSmall), AABB(position: Vector3(x: -1.5, y: 1.5, z: -2.5), size: Vector3(x: 4, y: 5.5, z: 6)),
-            "merge() with partially contained AABB (overflowing on Y axis) should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: 10, y: -10, z: -10), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertEqual(
-            aabbBig.merge(with: aabbSmall), AABB(position: Vector3(x: -1.5, y: -10, z: -10), size: Vector3(x: 12.5, y: 17, z: 13.5)),
-            "merge() with non-contained AABB should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.merge (with: aabbSmall), aabbBig, "merge() with fully contained AABB (touching the edge) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.merge (with: aabbSmall), AABB (position: Vector3 (x: -1.5, y: 1.5, z: -2.5), size: Vector3 (x: 4, y: 5.5, z: 6)), "merge() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertEqual (aabbBig.merge (with: aabbSmall), AABB (position: Vector3 (x: -1.5, y: -10, z: -10), size: Vector3 (x: 12.5, y: 17, z: 13.5)), "merge() with non-contained AABB should return the expected result.")
     }
-
-    func testEncloses() {
-        let aabbBig: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
+    
+    func testEncloses () {
+        let aabbBig: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
         var aabbSmall: AABB
-
-        aabbSmall = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertTrue(aabbBig.encloses(with: aabbSmall), "encloses() with fully contained AABB (touching the edge) should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: 0.5, y: 1.5, z: -2), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertFalse(aabbBig.encloses(with: aabbSmall), "encloses() with partially contained AABB (overflowing on Y axis) should return the expected result.")
-
-        aabbSmall = AABB(position: Vector3(x: 10, y: -10, z: -10), size: Vector3(x: 1, y: 1, z: 1))
-        XCTAssertFalse(aabbBig.encloses(with: aabbSmall), "encloses() with non-contained AABB should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertTrue (aabbBig.encloses (with: aabbSmall), "encloses() with fully contained AABB (touching the edge) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 0.5, y: 1.5, z: -2), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertFalse (aabbBig.encloses (with: aabbSmall), "encloses() with partially contained AABB (overflowing on Y axis) should return the expected result.")
+        
+        aabbSmall = AABB (position: Vector3 (x: 10, y: -10, z: -10), size: Vector3 (x: 1, y: 1, z: 1))
+        XCTAssertFalse (aabbBig.encloses (with: aabbSmall), "encloses() with non-contained AABB should return the expected result.")
     }
-
-    func testGetEndpoints() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertEqual(aabb.getEndpoint(idx: 0), Vector3(x: -1.5, y: 2, z: -2.5), "The endpoint at index 0 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: 1), Vector3(x: -1.5, y: 2, z: 3.5), "The endpoint at index 1 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: 2), Vector3(x: -1.5, y: 7, z: -2.5), "The endpoint at index 2 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: 3), Vector3(x: -1.5, y: 7, z: 3.5), "The endpoint at index 3 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: 4), Vector3(x: 2.5, y: 2, z: -2.5), "The endpoint at index 4 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: 5), Vector3(x: 2.5, y: 2, z: 3.5), "The endpoint at index 5 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: 6), Vector3(x: 2.5, y: 7, z: -2.5), "The endpoint at index 6 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: 7), Vector3(x: 2.5, y: 7, z: 3.5), "The endpoint at index 7 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: 8), Vector3(), "The endpoint at invalid index 8 should match the expected value.")
-        XCTAssertEqual(aabb.getEndpoint(idx: -1), Vector3(), "The endpoint at invalid index -1 should match the expected value.")
+    
+    func testGetEndpoints () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getEndpoint (idx: 0), Vector3 (x: -1.5, y: 2, z: -2.5), "The endpoint at index 0 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 1), Vector3 (x: -1.5, y: 2, z: 3.5), "The endpoint at index 1 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 2), Vector3 (x: -1.5, y: 7, z: -2.5), "The endpoint at index 2 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 3), Vector3 (x: -1.5, y: 7, z: 3.5), "The endpoint at index 3 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 4), Vector3 (x: 2.5, y: 2, z: -2.5), "The endpoint at index 4 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 5), Vector3 (x: 2.5, y: 2, z: 3.5), "The endpoint at index 5 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 6), Vector3 (x: 2.5, y: 7, z: -2.5), "The endpoint at index 6 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 7), Vector3 (x: 2.5, y: 7, z: 3.5), "The endpoint at index 7 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: 8), Vector3 (), "The endpoint at invalid index 8 should match the expected value.")
+        XCTAssertEqual (aabb.getEndpoint (idx: -1), Vector3 (), "The endpoint at invalid index -1 should match the expected value.")
     }
-
-    func testGetLongestShortestAxis() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertEqual(aabb.getLongestAxis(), Vector3(x: 0, y: 0, z: 1), "getLongestAxis() should return the expected value.")
-        XCTAssertEqual(aabb.getLongestAxisIndex(), Int64(Vector3.Axis.z.rawValue), "getLongestAxisIndex() should return the expected value.")
-        XCTAssertEqual(aabb.getLongestAxisSize(), 6, "getLongestAxisSize() should return the expected value.")
-        XCTAssertEqual(aabb.getShortestAxis(), Vector3(x: 1, y: 0, z: 0), "getShortestAxis() should return the expected value.")
-        XCTAssertEqual(aabb.getShortestAxisIndex(), Int64(Vector3.Axis.x.rawValue), "getShortestAxisIndex() should return the expected value.")
-        XCTAssertEqual(aabb.getShortestAxisSize(), 4, "getShortestAxisSize() should return the expected value.")
+    
+    func testGetLongestShortestAxis () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getLongestAxis (), Vector3 (x: 0, y: 0, z: 1), "getLongestAxis() should return the expected value.")
+        XCTAssertEqual (aabb.getLongestAxisIndex (), Int64 (Vector3.Axis.z.rawValue), "getLongestAxisIndex() should return the expected value.")
+        XCTAssertEqual (aabb.getLongestAxisSize (), 6, "getLongestAxisSize() should return the expected value.")
+        XCTAssertEqual (aabb.getShortestAxis (), Vector3 (x: 1, y: 0, z: 0), "getShortestAxis() should return the expected value.")
+        XCTAssertEqual (aabb.getShortestAxisIndex (), Int64 (Vector3.Axis.x.rawValue), "getShortestAxisIndex() should return the expected value.")
+        XCTAssertEqual (aabb.getShortestAxisSize (), 4, "getShortestAxisSize() should return the expected value.")
     }
-
-    func testGetSupport() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 1, y: 0, z: 0)), Vector3(x: 2.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 0.5, y: 1, z: 0)), Vector3(x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 0.5, y: 1, z: -400)), Vector3(x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 0, y: -1, z: 0)), Vector3(x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual(aabb.getSupport(dir: Vector3(x: 0, y: -0.1, z: 0)), Vector3(x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
-        XCTAssertEqual(aabb.getSupport(dir: Vector3()), Vector3(x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value with a null vector.")
+    
+    func testGetSupport () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 1, y: 0, z: 0)), Vector3 (x: 2.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0.5, y: 1, z: 0)), Vector3 (x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0.5, y: 1, z: -400)), Vector3 (x: 2.5, y: 7, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0, y: -1, z: 0)), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 (x: 0, y: -0.1, z: 0)), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value.")
+        XCTAssertEqual (aabb.getSupport (dir: Vector3 ()), Vector3 (x: -1.5, y: 2, z: -2.5), "getSupport() should return the expected value with a null vector.")
     }
-
-    func testGrow() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertEqual(aabb.grow(by: 0.25), AABB(position: Vector3(x: -1.75, y: 1.75, z: -2.75), size: Vector3(x: 4.5, y: 5.5, z: 6.5)), "grow() with positive value should return the expected AABB.")
-        XCTAssertEqual(aabb.grow(by: -0.25), AABB(position: Vector3(x: -1.25, y: 2.25, z: -2.25), size: Vector3(x: 3.5, y: 4.5, z: 5.5)), "grow() with negative value should return the expected AABB.")
-        XCTAssertEqual(aabb.grow(by: -10), AABB(position: Vector3(x: 8.5, y: 12, z: 7.5), size: Vector3(x: -16, y: -15, z: -14)), "grow() with large negative value should return the expected AABB.")
+    
+    func testGrow () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.grow (by: 0.25), AABB (position: Vector3 (x: -1.75, y: 1.75, z: -2.75), size: Vector3 (x: 4.5, y: 5.5, z: 6.5)), "grow() with positive value should return the expected AABB.")
+        XCTAssertEqual (aabb.grow (by: -0.25), AABB (position: Vector3 (x: -1.25, y: 2.25, z: -2.25), size: Vector3 (x: 3.5, y: 4.5, z: 5.5)), "grow() with negative value should return the expected AABB.")
+        XCTAssertEqual (aabb.grow (by: -10), AABB (position: Vector3 (x: 8.5, y: 12, z: 7.5), size: Vector3 (x: -16, y: -15, z: -14)), "grow() with large negative value should return the expected AABB.")
     }
-
-    func testHasPoint() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-
-        XCTAssertTrue(aabb.hasPoint(Vector3(x: -1, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
-        XCTAssertTrue(aabb.hasPoint(Vector3(x: 2, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
-        XCTAssertFalse(aabb.hasPoint(Vector3(x: -20, y: 0, z: 0)), "hasPoint() with non-contained point should return the expected value.")
-
-        XCTAssertTrue(aabb.hasPoint(Vector3(x: -1.5, y: 3, z: 0)), "hasPoint() with positive size should include point on near face (X axis).")
-        XCTAssertTrue(aabb.hasPoint(Vector3(x: 2.5, y: 3, z: 0)), "hasPoint() with positive size should include point on far face (X axis).")
-        XCTAssertTrue(aabb.hasPoint(Vector3(x: 0, y: 2, z: 0)), "hasPoint() with positive size should include point on near face (Y axis).")
-        XCTAssertTrue(aabb.hasPoint(Vector3(x: 0, y: 7, z: 0)), "hasPoint() with positive size should include point on far face (Y axis).")
-        XCTAssertTrue(aabb.hasPoint(Vector3(x: 0, y: 3, z: -2.5)), "hasPoint() with positive size should include point on near face (Z axis).")
-        XCTAssertTrue(aabb.hasPoint(Vector3(x: 0, y: 3, z: 3.5)), "hasPoint() with positive size should include point on far face (Z axis).")
+    
+    func testHasPoint () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: -1, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 2, y: 3, z: 0)), "hasPoint() with contained point should return the expected value.")
+        XCTAssertFalse (aabb.hasPoint (Vector3 (x: -20, y: 0, z: 0)), "hasPoint() with non-contained point should return the expected value.")
+        
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: -1.5, y: 3, z: 0)), "hasPoint() with positive size should include point on near face (X axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 2.5, y: 3, z: 0)), "hasPoint() with positive size should include point on far face (X axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 2, z: 0)), "hasPoint() with positive size should include point on near face (Y axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 7, z: 0)), "hasPoint() with positive size should include point on far face (Y axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 3, z: -2.5)), "hasPoint() with positive size should include point on near face (Z axis).")
+        XCTAssertTrue (aabb.hasPoint (Vector3 (x: 0, y: 3, z: 3.5)), "hasPoint() with positive size should include point on far face (Z axis).")
     }
-
-    func testExpanding() {
-        let aabb: AABB = AABB(position: Vector3(x: -1.5, y: 2, z: -2.5), size: Vector3(x: 4, y: 5, z: 6))
-        XCTAssertEqual(aabb.expand(toPoint: Vector3(x: -1, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
-        XCTAssertEqual(aabb.expand(toPoint: Vector3(x: 2, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
-        XCTAssertEqual(aabb.expand(toPoint: Vector3(x: -1.5, y: 3, z: 0)), aabb, "expand() with contained point on negative edge should return the expected AABB.")
-        XCTAssertEqual(aabb.expand(toPoint: Vector3(x: 2.5, y: 3, z: 0)), aabb, "expand() with contained point on positive edge should return the expected AABB.")
-        XCTAssertEqual(
-            aabb.expand(toPoint: Vector3(x: -20, y: 0, z: 0)), AABB(position: Vector3(x: -20, y: 0, z: -2.5), size: Vector3(x: 22.5, y: 7, z: 6)),
-            "expand() with non-contained point should return the expected AABB.")
+    
+    func testExpanding () {
+        let aabb: AABB = AABB (position: Vector3 (x: -1.5, y: 2, z: -2.5), size: Vector3 (x: 4, y: 5, z: 6))
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -1, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: 2, y: 3, z: 0)), aabb, "expand() with contained point should return the expected AABB.")
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -1.5, y: 3, z: 0)), aabb, "expand() with contained point on negative edge should return the expected AABB.")
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: 2.5, y: 3, z: 0)), aabb, "expand() with contained point on positive edge should return the expected AABB.")
+        XCTAssertEqual (aabb.expand (toPoint: Vector3 (x: -20, y: 0, z: 0)), AABB (position: Vector3 (x: -20, y: 0, z: -2.5), size: Vector3 (x: 22.5, y: 7, z: 6)), "expand() with non-contained point should return the expected AABB.")
     }
-
-    func testFiniteNumberChecks() {
-        let x: Vector3 = Vector3(x: 0, y: 1, z: 2)
-        let infinite: Vector3 = Vector3(x: .nan, y: .nan, z: .nan)
-        XCTAssertTrue(AABB(position: x, size: x).isFinite(), "AABB with all components finite should be finite")
-        XCTAssertFalse(AABB(position: infinite, size: x).isFinite(), "AABB with one component infinite should not be finite.")
-        XCTAssertFalse(AABB(position: x, size: infinite).isFinite(), "AABB with one component infinite should not be finite.")
-        XCTAssertFalse(AABB(position: infinite, size: infinite).isFinite(), "AABB with two components infinite should not be finite.")
+    
+    func testFiniteNumberChecks () {
+        let x: Vector3 = Vector3 (x: 0, y: 1, z: 2)
+        let infinite: Vector3 = Vector3 (x: .nan, y: .nan, z: .nan)
+        XCTAssertTrue (AABB (position: x, size: x).isFinite (), "AABB with all components finite should be finite")
+        XCTAssertFalse (AABB (position: infinite, size: x).isFinite (), "AABB with one component infinite should not be finite.")
+        XCTAssertFalse (AABB (position: x, size: infinite).isFinite (), "AABB with one component infinite should not be finite.")
+        XCTAssertFalse (AABB (position: infinite, size: infinite).isFinite (), "AABB with two components infinite should not be finite.")
     }
-
+    
 }


### PR DESCRIPTION
Currently, if the `swift build` or `swift test` commands fail, the GH action step will still be marked as succeeded.

This seems to be an artefact of the way we were re-running the tests from within the Godot engine; it resulted in the overall failure count being 0 even if there were actual failures.

This PR changes the way we run the tests, and should result in a non-zero exit status if a test does fail.

It also separates the XCTest run and the Swift testing run into two steps.

The default behaviour of `swift test` is to first run the XCTest engine, then run Swift testing engine. 

This results in the following confusing output at the end of the test run:

```
􀟈  Test run started.
􀄵  Testing Library Version: 102 (arm64e-apple-macos13.0)
􁁛  Test run with 0 tests passed after 0.001 seconds.
```

This is the output from the Swift testing engine. Because all our tests are using XCTest, and we have no Swift testing tests, it is saying that 0 tests passed. As it's the last thing in the report, it's a bit confusing and for a while I thought that this was why the exit status was 0.

To avoid this confusion, we can explicitly choose a test ending by passing `--disable-swift-testing` or `--disable-xctest`.

I have done this in two separate steps, so that the output from each testing engine is clearer. 

The Swift testing engine step is a null-op right now, so we could remove it, but at some point we might want to migrate some tests to the new testing framework, so I figured it was worth having it there to avoid later confusion.
