### PR TITLE
Cleaner Test Output

### DIFF
--- a/Sources/SwiftGodotTestability/GodotTestCase.swift
+++ b/Sources/SwiftGodotTestability/GodotTestCase.swift
@@ -11,6 +11,11 @@ import XCTest
 
 /// Base class for all test cases that run in the Godot runtime.
 open class GodotTestCase: XCTestCase {
+    open override var testRunClass: AnyClass? {
+        // use a dummy run if the engine isn't running to avoid generating output
+        !GodotRuntime.isRunning ? DummyTestRun.self : super.testRunClass
+    }
+
     override open func run() {
         // We will be run twice - once in the normal XCTest runtime,
         // and once in the Godot runtime. We only want to actually
@@ -19,7 +24,7 @@ open class GodotTestCase: XCTestCase {
             super.run()
         }
     }
-
+    
     override open class func setUp() {
         if GodotRuntime.isRunning {
             // register any types that are needed for the tests
@@ -71,6 +76,32 @@ open class GodotTestCase: XCTestCase {
 
 }
 
+/// Test run which does nothing.
+/// We return one of these when a Godot test is run
+/// without the test engine running. This avoids having
+/// duplicate runs of the test appear in the output.
+open class DummyTestRun: XCTestCaseRun {
+    override init(test: XCTest) {
+        super.init(test: XCTestCase())
+    }
+    open override func start() {
+    }
+    open override func stop() {
+    }
+    open override func record(_ issue: XCTIssue) {
+    }
+    open override var hasBeenSkipped: Bool { true }
+    open override var hasSucceeded: Bool { false }
+    open override var skipCount: Int { 0 }
+    open override var failureCount: Int { 0 }
+    open override var executionCount: Int { 0 }
+    open override var testCaseCount: Int { 0 }
+    open override var unexpectedExceptionCount: Int { 0 }
+    open override var totalFailureCount: Int { 0 }
+
+    open override var totalDuration: TimeInterval { 0 }
+    open override var testDuration: TimeInterval { 0 }
+}
 /// Godot testing support.
 
 public extension GodotTestCase {

--- a/Sources/SwiftGodotTestability/GodotTestRunner.swift
+++ b/Sources/SwiftGodotTestability/GodotTestRunner.swift
@@ -21,27 +21,131 @@ class __GodotTestRunner: XCTestCase {
         XCTAssert(Self.failureCount == 0, "Some tests failed when running in Godot")
     }
 
+    static let testNamePattern = #/-\[\w+ (?<name>\w+)\]/#
+
+    /// Print out the names of all the tests and suites in a suite.
+    static func describe(suiteOrTest: XCTest, indent: String = "") {
+        if let suite = suiteOrTest as? XCTestSuite {
+            if !indent.isEmpty { // skip printing top level suite
+                print("\(indent)\(suite.name)")
+            }
+            for test in suite.tests {
+                if test.name != "__GodotTestRunner" {
+                    describe(suiteOrTest: test, indent: indent + "  ")
+                }
+            }
+        } else if let test = suiteOrTest as? XCTestCase {
+            let shortName = try? testNamePattern.firstMatch(in: test.name)?.name
+            let testName = shortName.map { String($0) } ?? test.name
+            print("\(indent)- \(testName)")
+        }
+    }
+
+    /// Extract all the godot tests from a tree of XCTest objects.
+    /// This flattens the tree into a a suite containing only the suites
+    /// with tests that are subclasses of GodotTestCase.
+    /// Any suites that don't contain any Godot tests are skipped, since
+    /// they will be run in the normal XCTest runtime.
+    @discardableResult static func extractGodotTests(_ from: XCTest, into: XCTestSuite) -> Bool {
+        guard let suite = from as? XCTestSuite else { return false }
+        if suite.containsGodotTests {
+            into.addTest(suite)
+            return true
+        } else {
+            var hadTests = false
+            for test in suite.tests {
+                if !extractGodotTests(test, into: into) {
+                    #if DEBUG_SKIPPING
+                    print("Skipped \(test.name) as it has no Godot tests")
+                    #endif
+                } else {
+                    hadTests = true
+                }
+            }
+            return hadTests
+        }
+    }
+
     /// Set up the Godot runtime and run all the tests in it.
     override func run() {
         // this call will be re-entered inside the Godot runtime, so we
         // need to check if the runtime is already initialized.
         if !GodotRuntime.isInitialized {
+
+            // turn off buffering on stdout so that we see the output immediately
+            setbuf(__stdoutp, nil)
+
+            print("""
+                
+                Starting Godot Engine
+                =====================
+
+                """)
+
+            // run the engine
             GodotRuntime.run {
-                /// make a copy of all the tests and run them in Godot
+                /// make a copy of all the GodotTestCase tests and run them in Godot
                 let allTests = XCTestSuite.default
-                let suite = XCTestSuite(name: "All Tests In Godot")
+                let suite = XCTestSuite(name: "All Godot Tests")
                 for test in allTests.tests {
-                    suite.addTest(test)
+                    Self.extractGodotTests(test, into: suite)
                 }
+
+                print("""
+                    
+                    Running Tests in Godot Engine
+                    =============================
+
+                    """)
+
+                #if DEBUG_TEST_EXTRACTION // enable this to see the list of tests that will be run; useful for debugging
+                print("We will run the following tests:")
+                Self.describe(suiteOrTest: suite)
+                print("\n\n")
+                #endif
+
                 suite.run()
 
                 // record the failure count
-                Self.failureCount = suite.testRun!.totalFailureCount
+                let run = suite.testRun!
+                Self.failureCount = run.totalFailureCount
+
+                print("""
+                    
+                    Done Godot Engine Tests
+                    =======================
+                    \(run.testCaseCount) tests run, \(run.totalFailureCount) failures.
+
+
+                    Shutting Down Engine
+                    ====================
+
+                    """)
 
                 // shut down the Godot runtime
                 GodotRuntime.stop()
             }
+
+            print("""
+                
+                Engine Shut Down Done
+                =====================
+
+
+                """)
+
             super.run()
         }
+    }
+}
+
+extension XCTestSuite {
+    var containsGodotTests: Bool {
+        for test in tests {
+            if test is GodotTestCase {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Sources/SwiftGodotTestability/GodotTestRunner.swift
+++ b/Sources/SwiftGodotTestability/GodotTestRunner.swift
@@ -131,7 +131,7 @@ class __GodotTestRunner: XCTestCase {
 
             print("""
                 
-                
+
                 Engine Shut Down Done
                 =====================
 
@@ -144,6 +144,8 @@ class __GodotTestRunner: XCTestCase {
 }
 
 extension XCTestSuite {
+    /// Does this suite contain Godot tests?
+    /// (we deliberately don't recurse into sub-suites here)
     var containsGodotTests: Bool {
         for test in tests {
             if test is GodotTestCase {

--- a/Sources/SwiftGodotTestability/GodotTestRunner.swift
+++ b/Sources/SwiftGodotTestability/GodotTestRunner.swift
@@ -93,6 +93,7 @@ class __GodotTestRunner: XCTestCase {
 
                 print("""
                     
+
                     Running Tests in Godot Engine
                     =============================
 
@@ -112,8 +113,10 @@ class __GodotTestRunner: XCTestCase {
 
                 print("""
                     
+
                     Done Godot Engine Tests
                     =======================
+                    
                     \(run.testCaseCount) tests run, \(run.totalFailureCount) failures.
 
 
@@ -127,6 +130,7 @@ class __GodotTestRunner: XCTestCase {
             }
 
             print("""
+                
                 
                 Engine Shut Down Done
                 =====================

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -575,15 +575,17 @@ final class MemoryLeakTests: GodotTestCase {
     }
     
     func test_godot_string_description_leak() {
+        var buffer: String = ""
         checkLeaks {
             let string = GString("A")
-            for _ in 0 ..< 100 {
-                print(string.description)
+            for _ in 0..<100 {
+                buffer += string.description
             }
         }
     }
     
     func test_godot_string_from_variant_leak() {
+        var buffer: String = ""
         let variant = Variant("A")
         checkLeaks {
             for _ in 0 ..< 100 {
@@ -592,12 +594,13 @@ final class MemoryLeakTests: GodotTestCase {
                     break
                 }
                 
-                print(gstring.description)
+                buffer += gstring.description
             }
         }
     }
     
     func test_531_crash_or_leak() {
+        var buffer: String = ""
         checkLeaks {
             let g = GodotEncoder()
             let foon = FooN(myInt: 9, myText: "nine", myFoo: [
@@ -605,7 +608,7 @@ final class MemoryLeakTests: GodotTestCase {
                 Foo(myInt: 30, myText: "Nested2", myIntArray: [2,2,2])])
             try? foon.encode(to: g)
             
-            print(g.data.description)
+            buffer += g.data.description
         }
     }
     

--- a/Tests/SwiftGodotTests/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTests/MemoryLeakTests.swift
@@ -51,7 +51,7 @@ class GodotEncoder: Encoder {
 
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
 
-        var container = GodotKeyedContainer<Key>(codingPath: codingPath, userInfo: userInfo)
+        let container = GodotKeyedContainer<Key>(codingPath: codingPath, userInfo: userInfo)
         self.container = container
         return KeyedEncodingContainer(container)
     }
@@ -64,6 +64,7 @@ class GodotEncoder: Encoder {
         let key = codingKey.map { $0.stringValue }.joined(separator: ".")
         fatalError()
         //dict [key] = value
+        _ = key
     }
 
     func unkeyedContainer() -> any UnkeyedEncodingContainer {
@@ -80,9 +81,10 @@ class GodotEncoder: Encoder {
 
     class GodotKeyedContainer<Key:CodingKey>: KeyedEncodingContainerProtocol, GodotEncodingContainer {
         func encodeNil(forKey key: Key) throws {
-            var container = self.nestedSingleValueContainer(forKey: key)
+            let container = self.nestedSingleValueContainer(forKey: key)
             fatalError()
             //try container.encode(Variant())
+            _ = container
         }
 
         var codingPath: [any CodingKey] = []
@@ -103,7 +105,7 @@ class GodotEncoder: Encoder {
         }
 
         func encode(_ value: String, forKey key: Key) throws {
-            var container = self.nestedSingleValueContainer(forKey: key)
+            let container = self.nestedSingleValueContainer(forKey: key)
             try container.encode(value)
             self.storage[key.stringValue] = container
         }
@@ -279,7 +281,7 @@ class GodotEncoder: Encoder {
     class GodotSingleValueContainer: SingleValueEncodingContainer, GodotEncodingContainer {
         func encode<T>(_ value: T) throws where T : Encodable {
             if value is Array<Any> {
-                var container = GodotUnkeyedContainer (codingPath: codingPath, userInfo: userInfo)
+                let container = GodotUnkeyedContainer (codingPath: codingPath, userInfo: userInfo)
                 try container.encode(value)
                 self.value = container.data
             } else if let i = value as? Int {
@@ -287,7 +289,7 @@ class GodotEncoder: Encoder {
             } else if let str = value as? String {
                 try self.encode(str)
             } else {
-                var nested = GodotEncoder()
+                let nested = GodotEncoder()
                 try value.encode(to: nested)
                 self.value = nested.container?.data
             }
@@ -533,6 +535,7 @@ final class MemoryLeakTests: GodotTestCase {
                     return
                 }
                 let strFoo1 = String(gstrFoo0)
+                _ = [strFoo, strFoo0, strFoo1] // suppress unused warnings
             }
         }
         
@@ -549,6 +552,7 @@ final class MemoryLeakTests: GodotTestCase {
                     return
                 }
                 let strBar1 = String(gstrBar0)
+                _ = [strBar, strBar0, strBar1] // suppress unused warnings
             }
         }
     }
@@ -569,7 +573,7 @@ final class MemoryLeakTests: GodotTestCase {
             for _ in 0 ..< 200 {
                 let object = Object()
                 let methodName = StringName("get_method_list")
-                let methodList = object.call(method: methodName)
+                _ = object.call(method: methodName)
             }
         }
     }


### PR DESCRIPTION
This change does a few things:

- Uses a dummy test run class for tests when the Godot runtime isn't running.
- Adds some logging to clearly delineate the time when the tests are running in the engine
- Filters out non-engine tests when running in the engine (previously tests that just inherit from XCTestCase were running twice)

Using the dummy run class makes the test suites appear to contain no tests when they are run outside the engine:

```
Test Suite 'AABBTests' started at 2024-11-01 12:30:53.297.
Test Suite 'AABBTests' passed at 2024-11-01 12:30:53.297.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
```

Later when they run in the engine, the tests will show up:

```
Test Suite 'AABBTests' started at 2024-11-01 12:30:56.593.
Test Case '-[SwiftGodotEngineTests.AABBTests testBasicGetters]' started.
Test Case '-[SwiftGodotEngineTests.AABBTests testBasicGetters]' passed (0.016 seconds).
Test Case '-[SwiftGodotEngineTests.AABBTests testBasicSetters]' started.
Test Case '-[SwiftGodotEngineTests.AABBTests testBasicSetters]' passed (0.013 seconds).
... etc
```

This is marginally less confusing as you can search for the name of a specific test like `testBasicGetters` and find it in just one place.

The logging I've added around the initialisation and shutdown of the engine itself makes it a little clearer what's going on:

```
Starting Godot Engine
=====================

LibGodot initialization
Godot Engine v4.3.1.rc.custom_build.7e451cc34 (2024-10-05 04:48:09 UTC) - https://godotengine.org
TextServer: Added interface "Dummy"
TextServer: Added interface "ICU / HarfBuzz / Graphite (Built-in)"
Using "default" pen tablet driver...

TextServer: Primary interface set to: "ICU / HarfBuzz / Graphite (Built-in)".
CameraServer: Registered camera Razer Kiyo Pro with ID 1 and position 0 at index 0
[1;31mERROR:[0;91m Could not load global script cache.
[0;90m   at: get_global_class_list (core/config/project_settings.cpp:1231)[0m
CORE API HASH: 2488069049
EDITOR API HASH: 1114809042

Running Tests in Godot Engine
=============================

Test Suite 'All Godot Tests' started at 2024-11-01 12:30:56.593.
Test Suite 'AABBTests' started at 2024-11-01 12:30:56.593.
Test Case '-[SwiftGodotEngineTests.AABBTests testBasicGetters]' started.
...etc
Test Suite 'WrappedTests' passed at 2024-11-01 12:31:28.200.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.055 (0.055) seconds
Test Suite 'All Godot Tests' passed at 2024-11-01 12:31:28.200.
	 Executed 258 tests, with 0 failures (0 unexpected) in 31.565 (31.607) seconds

Done Godot Engine Tests
=======================
258 tests run, 0 failures.


Shutting Down Engine
====================

Loaded system CA certificates
XR: Clearing primary interface
XR: Removed interface "Native mobile"
XR: Removed interface "OpenXR"
[1;33mWARNING:[0;93m 1 RID of type "CanvasItem" was leaked.
[0;90m     at: _free_rids (servers/rendering/renderer_canvas_cull.cpp:2511)[0m
[1;33mWARNING:[0;93m ObjectDB instances leaked at exit (run with --verbose for details).
[0;90m     at: cleanup (core/object/object.cpp:2291)[0m
Leaked instance: GridMap:26809992446 - Node name: 
Leaked instance: GridMap:26843546881 - Node name: 
Leaked instance: Node:64491619586 - Node name: 
Leaked instance: Node:64458065155 - Node name: 
Leaked instance: Node:64525174020 - Node name: 
Leaked instance: Node:64541951237 - Node name: 
Leaked instance: Node:64575505670 - Node name: 
Leaked instance: GridMap:64659391751 - Node name: 
Leaked instance: GridMap:64692946184 - Node name: 
Leaked instance: GridMap:64726500617 - Node name: 
Leaked instance: GridMap:64760055050 - Node name: 
Leaked instance: Sprite2D:65984791819 - Node name: 
Leaked instance: Node:66018346252 - Node name: 
Leaked instance: Node:66035123469 - Node name: 
Hint: Leaked instances typically happen when nodes are removed from the scene tree (with `remove_child()`) but not freed (with `free()` or `queue_free()`).
Orphan StringName: _enter_tree (static: 0, total: 14)
Orphan StringName: name (static: 0, total: 1)
Orphan StringName: _unhandled_input (static: 0, total: 14)
Orphan StringName: _ready (static: 0, total: 14)
Orphan StringName: _exit_tree (static: 0, total: 14)
Orphan StringName: RandomNumberGenerator (static: 1, total: 2)
Orphan StringName: proxy (static: 0, total: 1)
Orphan StringName: mySignal (static: 0, total: 1)
Orphan StringName: DuplicateClassTestNode (static: 0, total: 1)
Orphan StringName: UndoRedo (static: 1, total: 2)
Orphan StringName: Sprite2D (static: 1, total: 3)
Orphan StringName: age (static: 0, total: 1)
Orphan StringName: _input (static: 0, total: 14)
Orphan StringName: Image (static: 1, total: 2004)
Orphan StringName: AStar3D (static: 1, total: 104)
Orphan StringName: _shortcut_input (static: 0, total: 14)
Orphan StringName: _process (static: 0, total: 14)
Orphan StringName: Node (static: 1, total: 20)
Orphan StringName: _unhandled_key_input (static: 0, total: 14)
Orphan StringName: GridMap (static: 1, total: 10)
Orphan StringName: Object (static: 1, total: 463)
Orphan StringName: _get_configuration_warnings (static: 0, total: 14)
Orphan StringName: _draw (static: 0, total: 1)
Orphan StringName: _physics_process (static: 0, total: 14)
StringName: 24 unclaimed string names at exit.

Engine Shut Down Done
=====================


Test Case '-[SwiftGodotTestability.__GodotTestRunner testRunEverythingInGodot]' started.
Test Case '-[SwiftGodotTestability.__GodotTestRunner testRunEverythingInGodot]' passed (0.001 seconds).
Test Suite '__GodotTestRunner' passed at 2024-11-01 12:31:28.954.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.001 (32.658) seconds
Test Suite 'SwiftGodotPackageTests.xctest' passed at 2024-11-01 12:31:28.954.
	 Executed 84 tests, with 0 failures (0 unexpected) in 2.995 (35.657) seconds
Test Suite 'All tests' passed at 2024-11-01 12:31:28.954.
	 Executed 84 tests, with 0 failures (0 unexpected) in 2.995 (35.658) seconds
```


