### PR TITLE
Refactor Extension Interface

### DIFF
--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -53,7 +53,7 @@ public class ClassInfo<T:Object> {
             propPtr [i] = prop.makeNativeStruct()
             i += 1
         }
-        gi.classdb_register_extension_class_signal (library, &self.name.content, &name.content, propPtr, GDExtensionInt(propInfo.count))
+        gi.classdb_register_extension_class_signal (extensionInterface.getLibrary(), &self.name.content, &name.content, propPtr, GDExtensionInt(propInfo.count))
         propPtr.deallocate()
     }
     
@@ -153,7 +153,7 @@ public class ClassInfo<T:Object> {
                 default_argument_count: 0,
                 default_arguments: nil) // GDExtensionVariantPtr)
                 withUnsafePointer(to: &self.name.content) { namePtr in
-                    gi.classdb_register_extension_class_method (library, namePtr, &info)
+                    gi.classdb_register_extension_class_method (extensionInterface.getLibrary(), namePtr, &info)
                 }
             }
         }
@@ -166,7 +166,7 @@ public class ClassInfo<T:Object> {
         let gname = GString(stringLiteral: name)
         let gprefix = GString(stringLiteral: prefix)
         
-        gi.classdb_register_extension_class_property_group (library, &self.name.content, &gname.content, &gprefix.content)
+        gi.classdb_register_extension_class_property_group (extensionInterface.getLibrary(), &self.name.content, &gname.content, &gprefix.content)
     }
     
     /// Starts a new property sub-group, all the properties declared after calling this method
@@ -175,7 +175,7 @@ public class ClassInfo<T:Object> {
         let gname = GString(stringLiteral: name)
         let gprefix = GString(stringLiteral: prefix)
         
-        gi.classdb_register_extension_class_property_subgroup (library, &self.name.content, &gname.content, &gprefix.content)
+        gi.classdb_register_extension_class_property_subgroup (extensionInterface.getLibrary(), &self.name.content, &gname.content, &gprefix.content)
     }
     
     /// Registers the property in the class with the information provided in `info`.
@@ -190,7 +190,7 @@ public class ClassInfo<T:Object> {
         var pinfo = GDExtensionPropertyInfo ()
         pinfo = info.makeNativeStruct()
         
-        gi.classdb_register_extension_class_property (library, &self.name.content, &pinfo, &setter.content, &getter.content)
+        gi.classdb_register_extension_class_property (extensionInterface.getLibrary(), &self.name.content, &pinfo, &setter.content, &getter.content)
     }
 }
 

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -123,6 +123,7 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     deinit {
         if ownsHandle {
             if let handle {
+                guard extensionInterface.objectShouldDeinit(handle: handle) else { return }
 #if DEBUG_INSTANCES
                 let type = xmap[handle] ?? "unknown"
                 let txt = "DEINIT for object=\(type) handle=\(handle)"
@@ -169,6 +170,7 @@ open class Wrapped: Equatable, Identifiable, Hashable {
             print ("deinit: we do not own this object, nothing to do: object=\(txt) handle=\(handle)")
 #endif
         }
+        extensionInterface.objectDeinited(object: self)
     }
     static var userTypeBindingCallback = GDExtensionInstanceBindingCallbacks(
         create_callback: userTypeBindingCreate,
@@ -185,7 +187,7 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     public var godotClassName: StringName {
         var sc: StringName.ContentType = StringName.zero
         
-        if gi.object_get_class_name (handle, library, &sc) != 0 {
+        if gi.object_get_class_name (handle, extensionInterface.getLibrary(), &sc) != 0 {
             let sn = StringName(content: sc)
             return sn
         }
@@ -227,6 +229,7 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     public required init (nativeHandle: UnsafeRawPointer) {
         handle = nativeHandle
         ownsHandle = false
+        extensionInterface.objectInited(object: self)
 #if DEBUG_INSTANCES
         xmap [nativeHandle] = "\(self)"
         print ("Init Object From Handle: \(nativeHandle) -> \(self)")
@@ -258,6 +261,7 @@ open class Wrapped: Equatable, Identifiable, Hashable {
 #endif
         bindGodotInstance(instance: self, handle: handle)
         let _ = Self.classInitializer
+        extensionInterface.objectInited(object: self)
     }
     
     open class var godotClassName: StringName {
@@ -299,7 +303,7 @@ func bindGodotInstance(instance: some Wrapped, handle: UnsafeRawPointer) {
         }
     }
     
-    gi.object_set_instance_binding(UnsafeMutableRawPointer (mutating: handle), token, retain.toOpaque(), &callbacks)
+    gi.object_set_instance_binding(UnsafeMutableRawPointer (mutating: handle),  extensionInterface.getLibrary(), retain.toOpaque(), &callbacks)
 }
 
 var userTypes: [String:(UnsafeRawPointer)->Wrapped] = [:]
@@ -347,7 +351,7 @@ func register<T:Wrapped> (type name: StringName, parent: StringName, type: T.Typ
     info.class_userdata = retained.toOpaque()
     
     withUnsafePointer(to: &parent.content) { parentPtr in
-        gi.classdb_register_extension_class (library, &nameContent, parentPtr, &info)
+        gi.classdb_register_extension_class (extensionInterface.getLibrary(), &nameContent, parentPtr, &info)
     }
 }
 
@@ -369,7 +373,7 @@ public func unregister<T:Wrapped> (type: T.Type) {
     let name = StringName (typeStr)
     pd ("Unregistering \(typeStr)")
     withUnsafePointer (to: &name.content) { namePtr in
-        gi.classdb_unregister_extension_class (library, namePtr)
+        gi.classdb_unregister_extension_class (extensionInterface.getLibrary(), namePtr)
     }
 }
 
@@ -429,7 +433,7 @@ func lookupObject<T: Object> (nativeHandle: UnsafeRawPointer) -> T? {
     }
     var className: String = ""
     var sc: StringName.ContentType = StringName.zero
-    if gi.object_get_class_name (nativeHandle, library, &sc) != 0 {
+    if gi.object_get_class_name (nativeHandle, extensionInterface.getLibrary(), &sc) != 0 {
         let sn = StringName(content: sc)
         className = String(sn)
     } else {
@@ -614,7 +618,7 @@ struct CallableWrapper {
         
         var cci = GDExtensionCallableCustomInfo(
             callable_userdata: wrapperPtr,
-            token: token,
+            token: extensionInterface.getLibrary(),
             object_id: 0,
             call_func: invokeWrappedCallable,
             is_valid_func: nil,

--- a/Sources/SwiftGodot/EntryPoint.swift
+++ b/Sources/SwiftGodot/EntryPoint.swift
@@ -5,14 +5,63 @@
 //
 //
 
-@_implementationOnly import GDExtension
+import GDExtension
+
+public protocol ExtensionInterface {
+
+    func variantShouldDeinit(content: GDExtensionVariantPtr) -> Bool
+
+    func objectShouldDeinit(handle: UnsafeRawPointer) -> Bool
+
+    func objectInited(object: Wrapped)
+
+    func objectDeinited(object: Wrapped)
+
+    func getLibrary() -> GDExtensionClassLibraryPtr
+
+    func getProcAddr() -> GDExtensionInterfaceGetProcAddress
+
+}
+
+public class LibGodotExtensionInterface : ExtensionInterface {
+
+    /// If your application is crashing due to the Variant leak fixes, please
+    /// enable this flag, and provide me with a test case, so I can find that
+    /// pesky scenario.
+    public let experimentalDisableVariantUnref = false
+
+    private let library: GDExtensionClassLibraryPtr
+    private let getProcAddrFun: GDExtensionInterfaceGetProcAddress
+
+    public init(library: GDExtensionClassLibraryPtr, getProcAddrFun: GDExtensionInterfaceGetProcAddress) {
+        self.library = library
+        self.getProcAddrFun = getProcAddrFun
+    }
+
+    public func variantShouldDeinit(content: GDExtensionVariantPtr) -> Bool {
+        return !experimentalDisableVariantUnref
+    }
+
+    public func objectShouldDeinit(handle: UnsafeRawPointer) -> Bool {
+        return true
+    }
+
+    public func objectInited(object: Wrapped) {}
+
+    public func objectDeinited(object: Wrapped) {}
+
+    public func getLibrary() -> GDExtensionClassLibraryPtr {
+        return library
+    }
+
+    public func getProcAddr() -> GDExtensionInterfaceGetProcAddress {
+        return getProcAddrFun
+    }
+
+}
 
 /// The pointer to the Godot Extension Interface
-/// The library pointer we received at startup
-var library: GDExtensionClassLibraryPtr!
-var token: GDExtensionClassLibraryPtr! {
-    return library
-}
+var extensionInterface: ExtensionInterface!
 
 /// This variable is used to trigger a reloading of the method definitions in Godot, this is only needed
 /// for scenarios where SwiftGodot is being used with multiple active Godot runtimes in the same process
@@ -30,13 +79,9 @@ func loadFunctions (loader: GDExtensionInterfaceGetProcAddress) {
 /// operate.   It is only used when you use SwiftGodot embedded into an
 /// application - as opposed to using SwiftGodot purely as an extension
 ///
-public func setExtensionInterface (to: OpaquePointer?, library lib: OpaquePointer?) {
-    guard let to else {
-        print ("Expected a pointer to a GDExtensionInterfaceGetProcAddress")
-        return
-    }
-    loadGodotInterface(unsafeBitCast(to, to: GDExtensionInterfaceGetProcAddress.self))
-    library = GDExtensionClassLibraryPtr (lib)
+public func setExtensionInterface (interface: ExtensionInterface) {
+    extensionInterface = interface
+    loadGodotInterface(interface.getProcAddr())
 }
 
 // Extension initialization callback
@@ -372,15 +417,15 @@ public func initializeSwiftModule (
     initHook: @escaping (GDExtension.InitializationLevel)->(),
     deInitHook: @escaping (GDExtension.InitializationLevel)->())
 {
-    loadGodotInterface (unsafeBitCast(godotGetProcAddrPtr, to: GDExtensionInterfaceGetProcAddress.self)
-    )
+    let getProcAddrFun = unsafeBitCast(godotGetProcAddrPtr, to: GDExtensionInterfaceGetProcAddress.self)
+    loadGodotInterface (getProcAddrFun)
 
     // For now, we will only initialize the library once, so all of the SwiftGodot
     // modules are bundled together.   This is not optimal, see this bug 
     // with a description of what we should be doing:
     // https://github.com/migueldeicaza/SwiftGodot/issues/72
-    if library == nil {
-        library = GDExtensionClassLibraryPtr(libraryPtr)
+    if extensionInterface == nil {
+        extensionInterface = LibGodotExtensionInterface(library: GDExtensionClassLibraryPtr(libraryPtr), getProcAddrFun: getProcAddrFun)
     }
     extensionInitCallbacks [libraryPtr] = initHook
     extensionDeInitCallbacks [libraryPtr] = deInitHook

--- a/Sources/SwiftGodot/Export.swift
+++ b/Sources/SwiftGodot/Export.swift
@@ -39,7 +39,7 @@ func additionalRegistations (name: StringName) {
 //                minfo.arguments_metadata = UnsafeMutablePointer (mutating: argMetaPtr.baseAddress)
 //                minfo.arguments_info = UnsafeMutablePointer (mutating: argInfoPtr.baseAddress)
 //                
-//                gi.classdb_register_extension_class_method (library, UnsafePointer(&name.content), &minfo)
+//                gi.classdb_register_extension_class_method (extensionInterface.getLibrary(), UnsafePointer(&name.content), &minfo)
 //            }
 //        }
 //    }

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -7,11 +7,6 @@
 
 @_implementationOnly import GDExtension
 
-/// If your application is crashing due to the Variant leak fixes, please
-/// enable this flag, and provide me with a test case, so I can find that
-/// pesky scenario.
-public var experimentalDisableVariantUnref = false
-
 /// Variant objects box various Godot Objects, you create them with one of the
 /// constructors, and you can retrieve the contents using the various extension
 /// constructors that are declared on the various types that are wrapped.
@@ -80,7 +75,7 @@ public class Variant: Hashable, Equatable, CustomDebugStringConvertible {
     }
 
     deinit {
-        if experimentalDisableVariantUnref { return }
+        if !extensionInterface.variantShouldDeinit(content: &content) { return }
         gi.variant_destroy (&content)
     }
     

--- a/Sources/SwiftGodotTestability/GodotRuntime.swift
+++ b/Sources/SwiftGodotTestability/GodotRuntime.swift
@@ -59,8 +59,8 @@ private extension GodotRuntime {
                 guard let godotGetProcAddr else {
                     return 0
                 }
-                let bit = unsafeBitCast (godotGetProcAddr, to: OpaquePointer.self)
-                setExtensionInterface (to: bit, library: OpaquePointer (libraryPtr!))
+                let interface = LibGodotExtensionInterface(library: libraryPtr, getProcAddrFun: godotGetProcAddr)
+                setExtensionInterface(interface: interface)
                 godotLibrary = OpaquePointer (libraryPtr)!
                 extensionInit?.pointee = GDExtensionInitialization (
                     minimum_initialization_level: GDEXTENSION_INITIALIZATION_CORE,


### PR DESCRIPTION
These changes refactor the extension interface into a single protocol that provides access to the library handle and the getProcAddr function, giving the implementation more flexibility in providing these to the bindings.