### PR TITLE
Adopt Swift 6.0 Tools Version

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -39,8 +39,8 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.0.2-release
-          tag: 6.0.2-RELEASE
+          branch: swift-6.0.3-release
+          tag: 6.0.3-RELEASE
       - uses: actions/checkout@v4
       - name: Build
         run: swift build --build-tests --quiet

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,8 +34,7 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
-
-    timeout-minutes: 10
+    timeout-minutes: 15
     
     steps:
       - uses: compnerd/gha-setup-swift@main

--- a/Package.swift
+++ b/Package.swift
@@ -1,22 +1,13 @@
-// swift-tools-version: 5.10
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 6.0
 
-import PackageDescription
 import CompilerPluginSupport
-
-//var linkerSettings: [LinkerSetting] = []
-//#if os(macOS)
-//linkerSettings.append(.unsafeFlags([
-//    "-Xlinker", "-undefined",
-//    "-Xlinker", "dynamic_lookup",
-//]))
-//#endif
+import PackageDescription
 
 var libraryType: Product.Library.LibraryType
 #if os(Windows)
-libraryType = .static
+    libraryType = .static
 #else
-libraryType = .dynamic
+    libraryType = .dynamic
 #endif
 
 // Products define the executables and libraries a package produces, and make them visible to other packages.
@@ -24,36 +15,38 @@ var products: [Product] = [
     .library(
         name: "SwiftGodot",
         type: libraryType,
-        targets: ["SwiftGodot"]),
+        targets: ["SwiftGodot"]
+    ),
+
     .library(
         name: "SwiftGodotStatic",
-        targets: ["SwiftGodot"]),
+        targets: ["SwiftGodot"]
+    ),
+
     .library(
         name: "ExtensionApi",
         targets: [
             "ExtensionApi",
-            "ExtensionApiJson"
-        ]),
-    .plugin(name: "CodeGeneratorPlugin", targets: ["CodeGeneratorPlugin"]),
-    .plugin(name: "EntryPointGeneratorPlugin", targets: ["EntryPointGeneratorPlugin"])
-]
+            "ExtensionApiJson",
+        ]
+    ),
 
-// Macros aren't supported on Windows before 5.9.1 and this sample uses them
-#if !(os(Windows) && swift(<5.9.1))
-products.append(
+    .plugin(
+        name: "CodeGeneratorPlugin",
+        targets: ["CodeGeneratorPlugin"]
+    ),
+
+    .plugin(
+        name: "EntryPointGeneratorPlugin",
+        targets: ["EntryPointGeneratorPlugin"]
+    ),
+
     .library(
         name: "SimpleExtension",
         type: libraryType,
-        targets: ["SimpleExtension"]))
-#endif
-
-// libgodot is only available for macOS and testability runtime depends on it
-#if os(macOS)
-products.append(
-    .library(
-        name: "SwiftGodotTestability",
-        targets: ["SwiftGodotTestability"]))
-#endif
+        targets: ["SimpleExtension"]
+    ),
+]
 
 var targets: [Target] = [
     .executableTarget(
@@ -62,20 +55,27 @@ var targets: [Target] = [
             .product(name: "SwiftSyntax", package: "swift-syntax"),
             .product(name: "SwiftParser", package: "swift-syntax"),
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        ]
+        ],
+        swiftSettings: [.swiftLanguageMode(.v5)]
     ),
+
     // This contains GDExtension's JSON API data models
     .target(
         name: "ExtensionApi",
-        exclude: ["ExtensionApiJson.swift", "extension_api.json"]),
+        exclude: ["ExtensionApiJson.swift", "extension_api.json"],
+        swiftSettings: [.swiftLanguageMode(.v5)]
+    ),
+
     // This contains a resource bundle with extension_api.json
     .target(
         name: "ExtensionApiJson",
         path: "Sources/ExtensionApi",
         exclude: ["ApiJsonModel.swift", "ApiJsonModel+Extra.swift"],
         sources: ["ExtensionApiJson.swift"],
-        resources: [.process("extension_api.json")]),
-    
+        resources: [.process("extension_api.json")],
+        swiftSettings: [.swiftLanguageMode(.v5)]
+    ),
+
     // The generator takes Godot's JSON-based API description as input and
     // produces Swift API bindings that can be used to call into Godot.
     .executableTarget(
@@ -83,127 +83,58 @@ var targets: [Target] = [
         dependencies: [
             "ExtensionApi",
             .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxBuilder", package: "swift-syntax")
+            .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
         ],
         path: "Generator",
         exclude: ["README.md"],
         swiftSettings: [
+            .swiftLanguageMode(.v5)
             // Uncomment for using legacy array-based marshalling
             //.define("LEGACY_MARSHALING")
         ]
     ),
-    
+
     // This is a build-time plugin that invokes the generator and produces
     // the bindings that are compiled into SwiftGodot
-        .plugin(
-            name: "CodeGeneratorPlugin",
-            capability: .buildTool(),
-            dependencies: ["Generator"]
-        ),
-    
-        .plugin(
-            name: "EntryPointGeneratorPlugin",
-            capability: .buildTool(),
-            dependencies: ["EntryPointGenerator"]
-        ),
-    
+    .plugin(
+        name: "CodeGeneratorPlugin",
+        capability: .buildTool(),
+        dependencies: ["Generator"]
+    ),
+
+    .plugin(
+        name: "EntryPointGeneratorPlugin",
+        capability: .buildTool(),
+        dependencies: ["EntryPointGenerator"]
+    ),
+
     // This allows the Swift code to call into the Godot bridge API (GDExtension)
     .target(
-        name: "GDExtension"),
-]
+        name: "GDExtension",
+        swiftSettings: [.swiftLanguageMode(.v5)]
+    ),
 
-var swiftGodotPlugins: [Target.PluginUsage] = ["CodeGeneratorPlugin"]
-
-// Macros aren't supported on Windows before 5.9.1
-#if !(os(Windows) && swift(<5.9.1))
-targets.append(contentsOf: [
     // These are macros that can be used by third parties to simplify their
     // SwiftGodot development experience, these are used at compile time by
     // third party projects
-    .macro(name: "SwiftGodotMacroLibrary",
-           dependencies: [
+    .macro(
+        name: "SwiftGodotMacroLibrary",
+        dependencies: [
             .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
             .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
-           ]),
+            .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        ],
+        swiftSettings: [.swiftLanguageMode(.v5)]
+    ),
     // This contains sample code showing how to use the SwiftGodot API
     .target(
         name: "SimpleExtension",
         dependencies: ["SwiftGodot"],
-        exclude: ["SwiftSprite.gdextension", "README.md"]),
-        //linkerSettings: linkerSettings),
-])
-swiftGodotPlugins.append("SwiftGodotMacroLibrary")
-#endif
-
-// Macro tests don't work on Windows yet
-#if !os(Windows)
-// Idea: -mark_dead_strippable_dylib
-targets.append(
-    .testTarget(name: "SwiftGodotMacrosTests",
-            dependencies: [
-                "SwiftGodotMacroLibrary",
-                "SwiftGodot",
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
-            ]))
-#endif
-
-// libgodot is only available for macOS
-#if os(macOS)
-
-/// You might want to build your own libgodot, so you can step into it in the debugger when fixing failing tests. Here's how:
-///
-/// 1. Check out the appropriate branch of https://github.com/migueldeicaza/libgodot
-/// 2. Build with `scons platform=macos target=template_debug dev_build=yes library_type=shared_library`. The `target=template_debug` is important, because `target=editor` will get you a `TOOLS_ENABLED` build that breaks some test cases.
-/// 3. Use `scripts/make-libgodot.framework` to build an `xcframework` and put it at the root of your SwiftGodot work tree.
-/// 4. Change `#if true` to `#if false` below.
-///
-#if true
-let libgodot_tests = Target.binaryTarget(
-    name: "libgodot_tests",
-    url: "https://github.com/migueldeicaza/SwiftGodotKit/releases/download/4.3.5/libgodot.xcframework.zip",
-    checksum: "865ea17ad3e20caab05b3beda35061f57143c4acf0e4ad2684ddafdcc6c4f199"
-)
-#else
-let libgodot_tests = Target .binaryTarget(
-    name: "libgodot_tests",
-    path: "libgodot.xcframework"
-)
-#endif
-
-targets.append(contentsOf: [
-    // Godot runtime as a library
-
-    libgodot_tests,
-
-    // Base functionality for Godot runtime dependant tests
-    .target(
-        name: "SwiftGodotTestability",
-        dependencies: [            
-            "SwiftGodot",
-            "libgodot_tests",
-            "GDExtension"
-        ]),
-    
-    // General purpose runtime dependant tests
-    .testTarget(
-        name: "SwiftGodotTests",
-        dependencies: [
-            "SwiftGodotTestability",
-        ]
+        exclude: ["SwiftSprite.gdextension", "README.md"],
+        swiftSettings: [.swiftLanguageMode(.v5)]
     ),
-    
-    // Runtime dependant tests based on the engine tests from Godot's repository
-    .testTarget(
-        name: "SwiftGodotEngineTests",
-        dependencies: [
-            "SwiftGodotTestability",
-        ]
-    ),
-])
-#endif
+    //linkerSettings: linkerSettings),
 
-targets.append(contentsOf: [
     // This is the binding itself, it is made up of our generated code for the
     // Godot API, supporting infrastructure and extensions to the API to provide
     // a better Swift experience
@@ -212,11 +143,12 @@ targets.append(contentsOf: [
         dependencies: ["GDExtension"],
         //linkerSettings: linkerSettings,
         swiftSettings: [
-            .define("CUSTOM_BUILTIN_IMPLEMENTATIONS")
+            .swiftLanguageMode(.v5),
+            .define("CUSTOM_BUILTIN_IMPLEMENTATIONS"),
         ],
-        plugins: swiftGodotPlugins
+        plugins: ["CodeGeneratorPlugin", "SwiftGodotMacroLibrary"]
     ),
-    
+
     // General purpose cross-platform tests
     .testTarget(
         name: "SwiftGodotUniversalTests",
@@ -224,9 +156,10 @@ targets.append(contentsOf: [
             "SwiftGodot",
             "ExtensionApi",
             "ExtensionApiJson",
-        ]
+        ],
+        swiftSettings: [.swiftLanguageMode(.v5)]
     ),
-])
+]
 
 let package = Package(
     name: "SwiftGodot",

--- a/Package.swift
+++ b/Package.swift
@@ -250,7 +250,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "510.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.1"),
     ],
     targets: targets
 )

--- a/Plugins/CodeGeneratorPlugin/plugin.swift
+++ b/Plugins/CodeGeneratorPlugin/plugin.swift
@@ -25,8 +25,8 @@ import PackagePlugin
         var outputFiles: [URL] = []
         #if os(Windows)
             // Windows has 32K limit on CreateProcess argument length, SPM currently doesn't handle it well
-            outputFiles.append(genSourcesDir.appending(subpath: "Generated.swift"))
-            arguments.append(context.package.directory.appending(subpath: "doc"))
+            outputFiles.append(genSourcesDir.appending(path: "Generated.swift"))
+            arguments.append(context.package.directoryURL.appending(path: "doc").path)
             arguments.append("--singlefile")
             commands.append(
                 Command.prebuildCommand(

--- a/Plugins/CodeGeneratorPlugin/plugin.swift
+++ b/Plugins/CodeGeneratorPlugin/plugin.swift
@@ -1,6 +1,6 @@
 //
 // Generator's Plugin definition.swift
-//  
+//
 //
 //  Created by Miguel de Icaza on 4/4/23.
 //
@@ -13,40 +13,40 @@ import PackagePlugin
     func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
         var commands: [Command] = []
         // Configure the commands to write to a "GeneratedSources" directory.
-        let genSourcesDir = context.pluginWorkDirectory.appending("GeneratedSources")
+        let genSourcesDir = context.pluginWorkDirectoryURL.appending(path: "GeneratedSources")
 
         // We only generate commands for source targets.
-        let generator: Path = try context.tool(named: "Generator").path
+        let generator = try context.tool(named: "Generator").url
 
-        let api = context.package.directory.appending(["Sources", "ExtensionApi", "extension_api.json"])
-        
-        var arguments: [CustomStringConvertible] = [ api, genSourcesDir ]
-        var outputFiles: [Path] = []
+        let api = context.package.directoryURL
+            .appending(["Sources", "ExtensionApi", "extension_api.json"])
+
+        var arguments = [api.path, genSourcesDir.path]
+        var outputFiles: [URL] = []
         #if os(Windows)
-        // Windows has 32K limit on CreateProcess argument length, SPM currently doesn't handle it well
-        outputFiles.append(genSourcesDir.appending(subpath: "Generated.swift"))
-        arguments.append(context.package.directory.appending(subpath: "doc"))
-        arguments.append("--singlefile")
-        commands.append(Command.prebuildCommand(
-            displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
-            executable: generator,
-            arguments: arguments,
-            outputFilesDirectory: genSourcesDir))
+            // Windows has 32K limit on CreateProcess argument length, SPM currently doesn't handle it well
+            outputFiles.append(genSourcesDir.appending(subpath: "Generated.swift"))
+            arguments.append(context.package.directory.appending(subpath: "doc"))
+            arguments.append("--singlefile")
+            commands.append(
+                Command.prebuildCommand(
+                    displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
+                    executable: generator,
+                    arguments: arguments,
+                    outputFilesDirectory: genSourcesDir))
         #else
-        outputFiles.append (contentsOf: knownBuiltin.map { genSourcesDir.appending(["generated-builtin", $0])})
-        outputFiles.append (contentsOf: known.map { genSourcesDir.appending(["generated", $0])})
+            outputFiles.append(contentsOf: knownBuiltin.map { genSourcesDir.appending(["generated-builtin", $0]) })
+            outputFiles.append(contentsOf: known.map { genSourcesDir.appending(["generated", $0]) })
         #endif
 
-        // For Windows with Swift 5.10 both prebuildCommand and buildCommand are needed
-        #if !os(Windows) || swift(>=5.10)
-        commands.append(Command.buildCommand(
-            displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
-            executable: generator,
-            arguments: arguments,
-            inputFiles: [api],
-            outputFiles: outputFiles))
-        #endif
-        
+        commands.append(
+            Command.buildCommand(
+                displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
+                executable: generator,
+                arguments: arguments,
+                inputFiles: [api],
+                outputFiles: outputFiles))
+
         return commands
     }
 }
@@ -1013,3 +1013,9 @@ let known = [
     "ZIPReader.swift",
 
 ]
+
+extension URL {
+    func appending(_ paths: [String]) -> URL {
+        return paths.reduce(self) { $0.appending(path: $1) }
+    }
+}

--- a/Plugins/EntryPointGeneratorPlugin/EntryPointGeneratorPlugin.swift
+++ b/Plugins/EntryPointGeneratorPlugin/EntryPointGeneratorPlugin.swift
@@ -13,18 +13,19 @@ import PackagePlugin
         guard let sourceFiles = target.sourceModule?.sourceFiles else {
             return []
         }
-        
-        let generatorPath = try context.tool(named: "EntryPointGenerator").path
-        
-        let output = context.pluginWorkDirectory.appending("GeneratedSources", "EntryPoint.generated.swift")
-        
-        let inputFiles = sourceFiles.map(\.path)
-        
-        let arguments = [
-           "-o",
-           output.string
-        ] + inputFiles.map(\.string)
-        
+
+        let generatorPath = try context.tool(named: "EntryPointGenerator").url
+
+        let output = context.pluginWorkDirectoryURL.appending(path: "GeneratedSources").appending(path: "EntryPoint.generated.swift")
+
+        let inputFiles = sourceFiles.map(\.url)
+
+        let arguments =
+            [
+                "-o",
+                output.path,
+            ] + inputFiles.map(\.path)
+
         return [
             Command.buildCommand(
                 displayName: "Generating Godot entry point",

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -18,7 +18,7 @@ public struct GodotCallable: PeerMacro {
         
         if let effects = funcDecl.signature.effectSpecifiers,
            effects.asyncSpecifier?.presence == .present ||
-            effects.throwsSpecifier?.presence == .present {
+            effects.throwsClause?.throwsSpecifier.presence == .present {
             throw GodotMacroError.unsupportedCallableEffect
         }
         

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
@@ -37,7 +37,7 @@ class MacroGodotTestCase: XCTestCase {
                 sourceFiles: [file: .init(moduleName: "test", fullFilePath: "test.swift")]
             )
 
-            let expandedSourceFile = file.expand(macros: Self.macros, in: context, indentationWidth: .spaces(4))
+            let expandedSourceFile = file.expand(macros: Self.macros, contextGenerator: { _ in context }, indentationWidth: .spaces(4))
             
             let testBody = """
             assertExpansion(

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -326,7 +326,8 @@ final class MacroGodotTests: MacroGodotTestCase {
                     let className = StringName("MyData")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<MyData> (name: className)
-                } ()}
+                } ()
+            }
             final class MyClass: Node {
                 var data: MyData = .init()
             


### PR DESCRIPTION
~~This is an experiment.~~

This changes swift-tools-version to 6.0, but then opts out all of the non-plugin targets from the Swift 6.0 language mode (for now).

There is no way to opt out for plugins, so they are updated (the updates are fairly trivial).

Partly I did this to see whether forcing the tools version to 6.0 helped with any of the Windows build problems.

It does also have the advantage that we can migrate targets to Swift 6.0 one at a time, when the time comes.

Obviously this change would force a dependency on the Swift 6.x toolchain. That may be a good thing, if it reduces the need to cope with legacy compiler weirdness (eg windows compiler features lagging behind).