### PR TITLE
clean up Generator top-level and use ArgumentParser

### DIFF
--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -26,166 +26,168 @@ func isSmallInt(_ arg: JGodotArgument) -> Bool {
     }
 }
 
-func getArgumentDeclaration(_ argument: JGodotArgument, omitLabel: Bool, kind: ArgumentKind = .classes, isOptional: Bool) -> String {
-    //let optNeedInOut = isCoreType(name: argument.type) ? "inout " : ""
-    let optNeedInOut = ""
-    
-    var def: String = ""
-    if var dv = argument.defaultValue, dv != "" {
-        func dvMissing(_ kind: String) {
-            #if WARN_MISSING
-                print("Generator/default_value: no support for [\(kind)] = \(dv)")
-            #endif
-        }
-        
-        let argumentType = argument.type
-        
-        // This method is useful to customize the output of a call to a constructor
-        // it splits out the arguments into an array of strings, calls the constructor
-        // and then puts together the constructor invocation
-        func makeWith (_ callback: ([String]) -> String) -> String {
-            if #available(iOS 16.0, *) {
-                let values = String (dv [dv.firstIndex(of: "(")!...].dropFirst ().dropLast()).split (separator: ", ").map { String ($0) }
-                let res = callback (values)
-                return " = \(argumentType) (\(res))"
-            } else {
-                fatalError("You need a modern MacOS to build this")
+extension Generator {
+    func getArgumentDeclaration(_ argument: JGodotArgument, omitLabel: Bool, kind: ArgumentKind = .classes, isOptional: Bool) -> String {
+        //let optNeedInOut = isCoreType(name: argument.type) ? "inout " : ""
+        let optNeedInOut = ""
+
+        var def: String = ""
+        if var dv = argument.defaultValue, dv != "" {
+            func dvMissing(_ kind: String) {
+                #if WARN_MISSING
+                    print("Generator/default_value: no support for [\(kind)] = \(dv)")
+                #endif
             }
-        }
-        // Given a dv of "Vector (1,0)" returns a SwiftGodot suitable "Vector(x: 1, y: 0)" based on the
-        // args value that contains the desired labels
-        func makeDef (_ args: [String]) -> String {
-            // Turn a string like 'Vector2(0, 1)' into the array of values ["0", "1"]
-            makeWith { values in
-                return zip (args, values).map { v in String ("\(v.0): \(v.1)") }.joined (separator: ", ")
-            }
-        }
-        
-        // TODO:
-        //  - handle creating initializers from enums (builtint)
-        //  - empty arrays
-        //  - Structure with initialized values (Color (1,1,1,1))
-        //  - NodePath ("") ctor
-        //  - nil values (needs to both turn the value nullable and handle that in the marshal code
-        //  - typedarrays, the default values need to be handled one by one, or a general conversion
-        // system needs to be implemented
-        if !argumentType.starts(with: "Array") && !argumentType.starts(with: "bitfield::") && (!isStruct(argumentType) || isPrimitiveType(name: argumentType)) && argumentType != "NodePath" && !argumentType.starts(with: "typedarray::") && !argumentType.starts (with: "Dictionary") && dv != "null" {
-            if argument.type == "String" {
-                def = " = \(dv)"
-            } else if argument.type == "StringName" {
-                // GDScript has StringName literals, e.g. &"example" == StringName("example")
-                // Some of the default values are marked as such literals in extension_api.json
-                if dv.starts(with: "&") {
-                    dv = String(dv.dropFirst())
-                }
-                def = " = StringName (\(dv))"
-            } else if argument.type.starts(with: "enum::"){
-                if let ev = mapEnumValue (enumDef: argument.type, value: dv) {
-                    def = " = \(ev)"
-                }
-            } else if argumentType == "Variant" {
-                dvMissing ("Variant")
-            } else {
-                def = " = \(dv)"
-            }
-        } else {
-            // Here we add the new conversions, will eventually replace everything
-            // above, as the do-not-run conditions are becoming large and difficult
-            // to parse - they were fine to bootstrap, but not for the long term.
-            
-            switch argumentType {
-                // Handle empty type arrays
-            case let at where at.hasPrefix("typedarray::"):
-                // We can not generate an array value for RDPipelineSpecializationConstant because it has no public constructor
-                if dv == "[]" || dv.hasSuffix("]([])") && !dv.contains("RDPipelineSpecializationConstant"){
-                    def = " = \(getGodotType(argument, kind: kind)) ()"
+
+            let argumentType = argument.type
+
+            // This method is useful to customize the output of a call to a constructor
+            // it splits out the arguments into an array of strings, calls the constructor
+            // and then puts together the constructor invocation
+            func makeWith (_ callback: ([String]) -> String) -> String {
+                if #available(iOS 16.0, *) {
+                    let values = String (dv [dv.firstIndex(of: "(")!...].dropFirst ().dropLast()).split (separator: ", ").map { String ($0) }
+                    let res = callback (values)
+                    return " = \(argumentType) (\(res))"
                 } else {
-                    dvMissing (argumentType)
+                    fatalError("You need a modern MacOS to build this")
                 }
-            case "Dictionary":
-                if dv == "{}" {
-                    def = " = GDictionary ()"
+            }
+            // Given a dv of "Vector (1,0)" returns a SwiftGodot suitable "Vector(x: 1, y: 0)" based on the
+            // args value that contains the desired labels
+            func makeDef (_ args: [String]) -> String {
+                // Turn a string like 'Vector2(0, 1)' into the array of values ["0", "1"]
+                makeWith { values in
+                    return zip (args, values).map { v in String ("\(v.0): \(v.1)") }.joined (separator: ", ")
+                }
+            }
+
+            // TODO:
+            //  - handle creating initializers from enums (builtint)
+            //  - empty arrays
+            //  - Structure with initialized values (Color (1,1,1,1))
+            //  - NodePath ("") ctor
+            //  - nil values (needs to both turn the value nullable and handle that in the marshal code
+            //  - typedarrays, the default values need to be handled one by one, or a general conversion
+            // system needs to be implemented
+            if !argumentType.starts(with: "Array") && !argumentType.starts(with: "bitfield::") && (!isStruct(argumentType) || isPrimitiveType(name: argumentType)) && argumentType != "NodePath" && !argumentType.starts(with: "typedarray::") && !argumentType.starts (with: "Dictionary") && dv != "null" {
+                if argument.type == "String" {
+                    def = " = \(dv)"
+                } else if argument.type == "StringName" {
+                    // GDScript has StringName literals, e.g. &"example" == StringName("example")
+                    // Some of the default values are marked as such literals in extension_api.json
+                    if dv.starts(with: "&") {
+                        dv = String(dv.dropFirst())
+                    }
+                    def = " = StringName (\(dv))"
+                } else if argument.type.starts(with: "enum::"){
+                    if let ev = mapEnumValue (enumDef: argument.type, value: dv) {
+                        def = " = \(ev)"
+                    }
+                } else if argumentType == "Variant" {
+                    dvMissing ("Variant")
                 } else {
-                    dvMissing (argumentType)
+                    def = " = \(dv)"
                 }
-            case let bt where bt.hasPrefix("bitfield::"):
-                if let defIntValue = Int (dv) {
-                    if defIntValue == 0 {
-                        def = " = []"
+            } else {
+                // Here we add the new conversions, will eventually replace everything
+                // above, as the do-not-run conditions are becoming large and difficult
+                // to parse - they were fine to bootstrap, but not for the long term.
+
+                switch argumentType {
+                    // Handle empty type arrays
+                case let at where at.hasPrefix("typedarray::"):
+                    // We can not generate an array value for RDPipelineSpecializationConstant because it has no public constructor
+                    if dv == "[]" || dv.hasSuffix("]([])") && !dv.contains("RDPipelineSpecializationConstant"){
+                        def = " = \(getGodotType(argument, kind: kind)) ()"
                     } else {
-                        // Need to look it up
-                        if let optionType = findEnumDef(name: argumentType) {
-                            let prefix = optionType.values.commonPrefix()
-                            var setValues = ""
-                            
-                            for value in optionType.values {
-                                if (defIntValue & value.value) != 0 {
-                                    let name = snakeToCamel(value.name.dropPrefix(prefix))
-                                    if setValues != "" {
-                                        setValues += ", "
-                                    }
-                                    setValues += ".\(name)"
-                                }
-                            }
-                            def = " = [\(setValues)]"
+                        dvMissing (argumentType)
+                    }
+                case "Dictionary":
+                    if dv == "{}" {
+                        def = " = GDictionary ()"
+                    } else {
+                        dvMissing (argumentType)
+                    }
+                case let bt where bt.hasPrefix("bitfield::"):
+                    if let defIntValue = Int (dv) {
+                        if defIntValue == 0 {
+                            def = " = []"
                         } else {
-                            dvMissing ("\(argumentType) due to not being able to lookup the type")
+                            // Need to look it up
+                            if let optionType = findEnumDef(name: argumentType) {
+                                let prefix = optionType.values.commonPrefix()
+                                var setValues = ""
+
+                                for value in optionType.values {
+                                    if (defIntValue & value.value) != 0 {
+                                        let name = snakeToCamel(value.name.dropPrefix(prefix))
+                                        if setValues != "" {
+                                            setValues += ", "
+                                        }
+                                        setValues += ".\(name)"
+                                    }
+                                }
+                                def = " = [\(setValues)]"
+                            } else {
+                                dvMissing ("\(argumentType) due to not being able to lookup the type")
+                            }
                         }
-                    }
-                } else {
-                    dvMissing ("bitfield:: with a non-integer default value")
-                }
-            case "Array":
-                if dv == "[]" {
-                    def = " = GArray ()"
-                } else {
-                    // Tracked: https://github.com/migueldeicaza/SwiftGodot/issues/7
-                    dvMissing ("arrays with values")
-                    print ("Generator: no support for arrays with values: \(dv)")
-                }
-            case "Vector2":
-                def = makeDef (["x", "y"])
-            case "Vector2i":
-                def = makeDef (["x", "y"])
-            case "Vector3":
-                def = makeDef (["x", "y", "z"])
-            case "Color":
-                def = makeDef (["r", "g", "b", "a"])
-            case "Rect2":
-                def = makeDef (["x", "y", "width", "height"])
-            case "Rect2i":
-                def = makeDef (["x", "y", "width", "height"])
-            case "Transform2D":
-                def = makeWith { a in
-                    return "xAxis: Vector2 (x: \(a[0]), y: \(a[1])), yAxis: Vector2 (x: \(a[2]), y: \(a[3])), origin: Vector2 (x: \(a[4]), y: \(a[5]))"
-                }
-            case "NodePath":
-                def = " = \(dv)"
-            case "Transform3D":
-                def = makeWith { a in
-                    return "xAxis: Vector3 (x: \(a[0]), y: \(a[1]), z: \(a[2])), yAxis: Vector3 (x: \(a[3]), y: \(a[4]), z: \(a[5])), zAxis: Vector3(x: \(a[6]), y: \(a[7]), z: \(a[8])), origin: Vector3 (x: \(a[9]), y: \(a[10]), z: \(a[11]))"
-                }
-            case "Variant":
-                if dv == "0" {
-                    def = "Variant (0)"
-                }
-            default:
-                if dv == "null" {
-                    if argumentType == "Variant" {
-                        def = " = Variant ()"
                     } else {
-                        def = " = nil"
+                        dvMissing ("bitfield:: with a non-integer default value")
                     }
-                } else {
-                    dvMissing ("General \(argumentType)")
+                case "Array":
+                    if dv == "[]" {
+                        def = " = GArray ()"
+                    } else {
+                        // Tracked: https://github.com/migueldeicaza/SwiftGodot/issues/7
+                        dvMissing ("arrays with values")
+                        print ("Generator: no support for arrays with values: \(dv)")
+                    }
+                case "Vector2":
+                    def = makeDef (["x", "y"])
+                case "Vector2i":
+                    def = makeDef (["x", "y"])
+                case "Vector3":
+                    def = makeDef (["x", "y", "z"])
+                case "Color":
+                    def = makeDef (["r", "g", "b", "a"])
+                case "Rect2":
+                    def = makeDef (["x", "y", "width", "height"])
+                case "Rect2i":
+                    def = makeDef (["x", "y", "width", "height"])
+                case "Transform2D":
+                    def = makeWith { a in
+                        return "xAxis: Vector2 (x: \(a[0]), y: \(a[1])), yAxis: Vector2 (x: \(a[2]), y: \(a[3])), origin: Vector2 (x: \(a[4]), y: \(a[5]))"
+                    }
+                case "NodePath":
+                    def = " = \(dv)"
+                case "Transform3D":
+                    def = makeWith { a in
+                        return "xAxis: Vector3 (x: \(a[0]), y: \(a[1]), z: \(a[2])), yAxis: Vector3 (x: \(a[3]), y: \(a[4]), z: \(a[5])), zAxis: Vector3(x: \(a[6]), y: \(a[7]), z: \(a[8])), origin: Vector3 (x: \(a[9]), y: \(a[10]), z: \(a[11]))"
+                    }
+                case "Variant":
+                    if dv == "0" {
+                        def = "Variant (0)"
+                    }
+                default:
+                    if dv == "null" {
+                        if argumentType == "Variant" {
+                            def = " = Variant ()"
+                        } else {
+                            def = " = nil"
+                        }
+                    } else {
+                        dvMissing ("General \(argumentType)")
+                    }
                 }
             }
         }
+
+        let prefix = omitLabel ? "_ " : ""
+
+        return "\(prefix)\(godotArgumentToSwift (argument.name)): \(optNeedInOut)\(getGodotType(argument, kind: kind))\(isOptional ? "?" : "")\(def)"
     }
-    
-    let prefix = omitLabel ? "_ " : ""
-    
-    return "\(prefix)\(godotArgumentToSwift (argument.name)): \(optNeedInOut)\(getGodotType(argument, kind: kind))\(isOptional ? "?" : "")\(def)"
 }
 
 // The name of the form 'bitfield::'

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -176,33 +176,33 @@ extension Generator {
 
         return "\(prefix)\(godotArgumentToSwift (argument.name)): \(optNeedInOut)\(getGodotType(argument, kind: kind))\(isOptional ? "?" : "")\(def)"
     }
-}
 
-// The name of the form 'bitfield::'
-private func findEnumDef (name: String) -> JGodotGlobalEnumElement? {
-    guard name.starts(with: "bitfield::") else {
-        return nil
-    }
-
-    let full = name.dropFirst(10)
-    guard let split = full.firstIndex(of: ".") else {
-        print ("No support for global bitfields for \(name)")
-        return nil
-    }
-    let type = full [full.startIndex..<split]
-    guard let cdef = classMap [String (type)] else {
-        print ("Could not find class \(type) for \(name)")
-        return nil
-    }
-    let enumName = full [full.index(split, offsetBy: 1)...]
-    guard let enums = cdef.enums else {
-        print ("Could not find an enum \(enumName) in \(type)")
-        return nil
-    }
-    for x in enums {
-        if x.name == enumName {
-            return x
+    // The name of the form 'bitfield::'
+    private func findEnumDef (name: String) -> JGodotGlobalEnumElement? {
+        guard name.starts(with: "bitfield::") else {
+            return nil
         }
+
+        let full = name.dropFirst(10)
+        guard let split = full.firstIndex(of: ".") else {
+            print ("No support for global bitfields for \(name)")
+            return nil
+        }
+        let type = full [full.startIndex..<split]
+        guard let cdef = classMap [String (type)] else {
+            print ("Could not find class \(type) for \(name)")
+            return nil
+        }
+        let enumName = full [full.index(split, offsetBy: 1)...]
+        guard let enums = cdef.enums else {
+            print ("Could not find an enum \(enumName) in \(type)")
+            return nil
+        }
+        for x in enums {
+            if x.name == enumName {
+                return x
+            }
+        }
+        return nil
     }
-    return nil
 }

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -216,28 +216,3 @@ private func findEnumDef (name: String) -> JGodotGlobalEnumElement? {
     }
     return nil
 }
-
-func getArgRef (arg: JGodotArgument) -> String {
-    var argref: String
-    var optstorage: String
-    var needAddress = "&"
-    if !isStruct(arg.type) { // { ) isCoreType(name: arg.type){
-        argref = godotArgumentToSwift (arg.name)
-        if arg.type == "String" && mapStringToSwift {
-            argref = "gstr_\(arg.name)"
-            optstorage = ".content"
-        } else {
-            if builtinSizes [arg.type] != nil && arg.type != "Object" {
-                optstorage = ".content"
-            } else {
-                needAddress = "&"
-                optstorage = ".handle"
-            }
-        }
-        return "\(needAddress)\(escapeSwift(argref))\(optstorage)"
-    } else {
-        argref = "copy_\(arg.name)"
-        optstorage = ""
-        return "\(needAddress)\(escapeSwift(argref))\(optstorage)"
-    }
-}

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -188,6 +188,35 @@ func getArgumentDeclaration(_ argument: JGodotArgument, omitLabel: Bool, kind: A
     return "\(prefix)\(godotArgumentToSwift (argument.name)): \(optNeedInOut)\(getGodotType(argument, kind: kind))\(isOptional ? "?" : "")\(def)"
 }
 
+// The name of the form 'bitfield::'
+private func findEnumDef (name: String) -> JGodotGlobalEnumElement? {
+    guard name.starts(with: "bitfield::") else {
+        return nil
+    }
+
+    let full = name.dropFirst(10)
+    guard let split = full.firstIndex(of: ".") else {
+        print ("No support for global bitfields for \(name)")
+        return nil
+    }
+    let type = full [full.startIndex..<split]
+    guard let cdef = classMap [String (type)] else {
+        print ("Could not find class \(type) for \(name)")
+        return nil
+    }
+    let enumName = full [full.index(split, offsetBy: 1)...]
+    guard let enums = cdef.enums else {
+        print ("Could not find an enum \(enumName) in \(type)")
+        return nil
+    }
+    for x in enums {
+        if x.name == enumName {
+            return x
+        }
+    }
+    return nil
+}
+
 func getArgRef (arg: JGodotArgument) -> String {
     var argref: String
     var optstorage: String

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -14,18 +14,6 @@ func godotArgumentToSwift (_ name: String) -> String {
     return escapeSwift (snakeToCamel (name))
 }
 
-func isSmallInt(_ arg: JGodotArgument) -> Bool {
-    if arg.type != "int" {
-        return false
-    }
-    switch getGodotType(arg, kind: .classes) {
-    case "Int32", "UInt32", "Int16", "UInt16", "Int8", "UInt8":
-        return true
-    default:
-        return false
-    }
-}
-
 extension Generator {
     func getArgumentDeclaration(_ argument: JGodotArgument, omitLabel: Bool, kind: ArgumentKind = .classes, isOptional: Bool) -> String {
         //let optNeedInOut = isCoreType(name: argument.type) ? "inout " : ""

--- a/Generator/Generator/Arguments.swift
+++ b/Generator/Generator/Arguments.swift
@@ -69,7 +69,7 @@ func getArgumentDeclaration(_ argument: JGodotArgument, omitLabel: Bool, kind: A
         //  - nil values (needs to both turn the value nullable and handle that in the marshal code
         //  - typedarrays, the default values need to be handled one by one, or a general conversion
         // system needs to be implemented
-        if !argumentType.starts(with: "Array") && !argumentType.starts(with: "bitfield::") && (!(isStructMap [argumentType] ?? false) || isPrimitiveType(name: argumentType)) && argumentType != "NodePath" && !argumentType.starts(with: "typedarray::") && !argumentType.starts (with: "Dictionary") && dv != "null" {
+        if !argumentType.starts(with: "Array") && !argumentType.starts(with: "bitfield::") && (!isStruct(argumentType) || isPrimitiveType(name: argumentType)) && argumentType != "NodePath" && !argumentType.starts(with: "typedarray::") && !argumentType.starts (with: "Dictionary") && dv != "null" {
             if argument.type == "String" {
                 def = " = \(dv)"
             } else if argument.type == "StringName" {
@@ -192,11 +192,9 @@ func getArgRef (arg: JGodotArgument) -> String {
     var argref: String
     var optstorage: String
     var needAddress = "&"
-    if !(isStructMap [arg.type] ?? false) { // { ) isCoreType(name: arg.type){
+    if !isStruct(arg.type) { // { ) isCoreType(name: arg.type){
         argref = godotArgumentToSwift (arg.name)
-        if isStructMap [arg.type] ?? false {
-            optstorage = ""
-        } else if arg.type == "String" && mapStringToSwift {
+        if arg.type == "String" && mapStringToSwift {
             argref = "gstr_\(arg.name)"
             optstorage = ".content"
         } else {
@@ -207,13 +205,10 @@ func getArgRef (arg: JGodotArgument) -> String {
                 optstorage = ".handle"
             }
         }
+        return "\(needAddress)\(escapeSwift(argref))\(optstorage)"
     } else {
         argref = "copy_\(arg.name)"
         optstorage = ""
-    }
-    if (isStructMap [arg.type] ?? false) {
-        return "\(needAddress)\(escapeSwift(argref))\(optstorage)"
-    } else {
         return "\(needAddress)\(escapeSwift(argref))\(optstorage)"
     }
 }

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -91,8 +91,8 @@ func generateBuiltinCtors (_ p: Printer,
                            typeEnum: String,
                            members: [JGodotArgument]?)
 {
-    let isStruct = isStructMap [typeName] ?? false
-    
+    let isStruct = isStruct(typeName)
+
     for m in ctors {
         var args = ""
         var visibility = "public"
@@ -229,7 +229,7 @@ func generateMethodCall (_ p: Printer,
         if godotReturnType == "Variant" {
             ptrResult = "&result"
         } else {
-            let isStruct = isStructMap [godotReturnType ?? ""] ?? false
+            let isStruct = isStruct(godotReturnType ?? "")
             if isStruct {
                 ptrResult = "&result"
             } else {
@@ -253,7 +253,7 @@ func generateMethodCall (_ p: Printer,
         if isStatic {
             return "\(typeName).\(methodToCall)(nil, \(argsRef), \(ptrResult), \(countArg))"
         } else {
-            if isStructMap [typeName] ?? false {
+            if isStruct(typeName) {
                 return """
                 var mutSelfCopy = self
                 withUnsafeMutablePointer (to: &mutSelfCopy) { ptr in
@@ -381,8 +381,7 @@ func generateBuiltinOperators (_ p: Printer,
                     }
                     p ("\(declType) result: \(retType) = \(retType)()")
                 }
-                let isStruct = isStructMap [op.returnType] ?? false
-                if isStruct {
+                if isStruct(op.returnType) {
                     ptrResult = "&result"
                 } else {
                     ptrResult = "&result.content"

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -876,9 +876,9 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
         default:
             let p: Printer = await PrinterFactory.shared.initPrinter(bc.name)
             p.preamble()
-            mapStringToSwift = bc.name != "String"
-            generateBuiltinClass (p: p, bc)
-            mapStringToSwift = true
+            $mapStringToSwift.withValue(bc.name != "String") {
+                generateBuiltinClass (p: p, bc)
+            }
             if let outputDir {
                 p.save(outputDir + "/\(bc.name).swift")
             }

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -186,7 +186,7 @@ extension Generator {
 
                 let arguments = (m.arguments ?? []).map {
                     // must not fail
-                    try! MethodArgument(from: $0, typeName: typeName, methodName: "#constructor\(m.index)", options: .builtInClassOptions)
+                    try! methodArgument(from: $0, typeName: typeName, methodName: "#constructor\(m.index)", options: .builtInClassOptions)
                 }
 
                 if arguments.isEmpty {
@@ -230,7 +230,7 @@ extension Generator {
 
         let methodArguments = arguments.map { argument in
             // must never fail
-            try! MethodArgument(from: argument, typeName: typeName, methodName: methodToCall, options: .builtInClassOptions)
+            try! methodArgument(from: argument, typeName: typeName, methodName: methodToCall, options: .builtInClassOptions)
         }
 
         let ptrResult: String
@@ -395,14 +395,14 @@ extension Generator {
                     } else {
                         ptrResult = "&result.content"
                     }
-                    let lhsa = try! MethodArgument(
+                    let lhsa = try! methodArgument(
                         from: JGodotArgument(name: "lhs", type: godotTypeName, defaultValue: nil, meta: nil),
                         typeName: godotTypeName,
                         methodName: "#operator\(swiftOperator)",
                         options: .builtInClassOptions
                     )
 
-                    let rhsa = try! MethodArgument(
+                    let rhsa = try! methodArgument(
                         from: JGodotArgument(name: "rhs", type: right, defaultValue: nil, meta: nil),
                         typeName: godotTypeName,
                         methodName: "#operator\(swiftOperator)",

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -8,408 +8,511 @@
 import Foundation
 import ExtensionApi
 
-/// Given an initializer of the form "Vector (0, 1, 0)" returns a proper Swift "Vector (x: 0, y: 1, z: 0)" value
-///
-func getInitializer (_ bc: JGodotBuiltinClass, _ val: String) -> String? {
-    if let pstart = val.firstIndex(of: "("), let pend = val.lastIndex(of: ")"){
-        let va = val [val.index(pstart, offsetBy: 1)..<pend]
-        let splitArgs: [Substring.SubSequence]
-        if #available(iOS 16.0, *) {
-            splitArgs = va.split(separator: ", ")
-        } else {
-            fatalError ("This requires a modern MacOS to build")
-        }
-        // Find a constructor with that number of arguments
-        for constructor in bc.constructors {
-            
-            if constructor.arguments?.count ?? -1 == splitArgs.count {
-                // Found
-                var prefixedArgs = ""
-                for i in 0..<splitArgs.count {
-                    if prefixedArgs.count != 0 { prefixedArgs += ", "}
-                    let name = constructor.arguments! [i].name
-                    var pval = splitArgs [i]
-
-                    // Some Godot constants leak into the initializers
-                    if pval.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) == "inf" {
-                        pval = "Float.infinity"[...]
-                    }
-
-                    prefixedArgs = prefixedArgs + name + ": " + pval
-                }
-                return String (val [val.startIndex..<pstart]) + " (" + prefixedArgs + ")"
-            }
-        }
-        
-        // Fallback for missing constructors
-        let format: String?
-        switch (bc.name, splitArgs.count) {
-        case ("Transform2D", 6):
-            format = "Transform2D (xAxis: Vector2 (x: %@, y: %@), yAxis: Vector2 (x: %@, y: %@), origin: Vector2 (x: %@, y: %@))"
-        case ("Basis", 9):
-            format = "Basis (xAxis: Vector3 (x: %@, y: %@, z: %@), yAxis: Vector3 (x: %@, y: %@, z: %@), zAxis: Vector3 (x: %@, y: %@, z: %@))"
-        case ("Transform3D", 12):
-            format = "Transform3D (basis: Basis (xAxis: Vector3 (x: %@, y: %@, z: %@), yAxis: Vector3 (x: %@, y: %@, z: %@), zAxis: Vector3 (x: %@, y: %@, z: %@)), origin: Vector3(x: %@, y: %@, z: %@))"
-        case ("Projection", 16):
-            format = "Projection (xAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), yAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), zAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), wAxis: Vector4 (x: %@, y: %@, z: %@, w: %@))"
-        default:
-            format = nil
-        }
-        if let format {
-            return String (format: format, arguments: splitArgs.map (String.init))
-        }
-        return nil
-    }
-    return val
+enum BKind {
+    case isStruct
+    case isClass
 }
+var builtinGodotTypeNames: [String:BKind] = ["Variant": .isClass]
+var builtinClassStorage: [String:String] = [:]
 
-func generateBuiltinConstants (_ p: Printer,
-                               _ bc: JGodotBuiltinClass,
-                               typeName: String) {
-        
-    guard let constants = bc.constants else { return }
-    
-    for constant in constants {
-        // Check if we need to inject parameter names
-        guard let val = getInitializer (bc, constant.value) else {
-            print ("Generator: no constructor matching constant \(bc.name).\(constant.name) = \(constant.value)")
-            continue
-        }
-        
-        if constant.description != "" {
-            doc (p, bc, constant.description)
-        }
-        p ("public static let \(snakeToCamel (constant.name)) = \(val)")
-    }
-}
+extension Generator {
 
-func generateBuiltinCtors (_ p: Printer,
-                           _ bc: JGodotBuiltinClass,
-                           _ ctors: [JGodotConstructor],
-                           godotTypeName: String,
-                           typeName: String,
-                           typeEnum: String,
-                           members: [JGodotArgument]?)
-{
-    let isStruct = isStruct(typeName)
-
-    for m in ctors {
-        var args = ""
-        var visibility = "public"
-        
-        let ptrName = "constructor\(m.index)"
-        p ("static var \(ptrName): GDExtensionPtrConstructor = gi.variant_get_ptr_constructor (\(typeEnum), \(m.index))!\n")
-        
-        for arg in m.arguments ?? [] {
-            if args != "" { args += ", " }
-            args += getArgumentDeclaration(arg, omitLabel: false, kind: .builtInField, isOptional: arg.type == "Variant")
-        }
-        
-        if let desc = m.description, desc != "" {
-            doc (p, bc, desc)
-        }
-        if args == "" {
-            if !isStruct {
-                visibility.append(" required")
-            }
-        }
-        
-        p ("\(visibility) init (\(args))") {
-            // Determine if we have a constructors whose sole job is to initialize the members
-            // of the struct, in that case, just do that, do not call into Godot.
-            if let margs = m.arguments, let members, margs.count == members.count {
-                var constructorMatchesFields = true
-                for x in 0..<margs.count {
-                    // This is so that we can match field `x` with `xAxis` in a few cases
-                    if !(margs [x].name.starts (with: members [x].name) && margs [x].type == members [x].type) {
-                        constructorMatchesFields = false
-                        break
-                    }
-                }
-                if constructorMatchesFields {
-                    for x in 0..<margs.count {
-                        p ("self.\(members [x].name) = \(escapeSwift (snakeToCamel (margs [x].name)))")
-                    }
-                    return
-                }
-            }
-                        
-            // I used to have a nicer model, rather than everything having a
-            // handle, I had a named handle, like "_godot_string"
-            let ptr = isStruct ? "self" : "content"
-            
-            // We need to initialize some variables before we call
-            if let members {
-                if bc.name == "Color" {
-                    p ("self.red = 0")
-                    p ("self.green = 0")
-                    p ("self.blue = 0")
-                    p ("self.alpha = 1")
-                } else if bc.name == "Quaternion" && m.arguments == nil {
-                    p ("self.x = 0")
-                    p ("self.y = 0")
-                    p ("self.z = 0")
-                    p ("self.w = 1")
-                } else if bc.name == "Transform2D" && m.arguments == nil {
-                    p ("self.x = Vector2 (x: 1, y: 0)")
-                    p ("self.y = Vector2 (x: 0, y: 1)")
-                    p ("self.origin = Vector2 ()")
-                } else if bc.name == "Basis" && m.arguments == nil {
-                    p ("self.x = Vector3 (x: 1, y: 0, z: 0)")
-                    p ("self.y = Vector3 (x: 0, y: 1, z: 0)")
-                    p ("self.z = Vector3 (x: 0, y: 0, z: 1)")
-                } else if bc.name == "Projection" && m.arguments == nil {
-                    p ("self.x = Vector4 (x: 1, y: 0, z: 0, w: 0)")
-                    p ("self.y = Vector4 (x: 0, y: 1, z: 0, w: 0)")
-                    p ("self.z = Vector4 (x: 0, y: 0, z: 1, w: 0)")
-                    p ("self.w = Vector4 (x: 0, y: 0, z: 0, w: 1)")
-                } else {
-                    for x in members {
-                        p ("self.\(x.name) = \(MemberBuiltinJsonTypeToSwift(x.type)) ()")
-                    }
-                }
-                // Another special case: empty constructors in generated structs (those we added fields for)
-                // we just keep the manual initialization and do not call the constructor
-                if m.arguments == nil {
-                    return
-                }
-            }
-            
-            let arguments = (m.arguments ?? []).map {
-                // must not fail
-                try! MethodArgument(from: $0, typeName: typeName, methodName: "#constructor\(m.index)", options: .builtInClassOptions)
-            }
-            
-            if arguments.isEmpty {
-                preparingArguments(p, arguments: arguments) {
-                    p ("\(typeName).\(ptrName)(&\(ptr), nil)")
-                }
+    /// Given an initializer of the form "Vector (0, 1, 0)" returns a proper Swift "Vector (x: 0, y: 1, z: 0)" value
+    ///
+    private func getInitializer (_ bc: JGodotBuiltinClass, _ val: String) -> String? {
+        if let pstart = val.firstIndex(of: "("), let pend = val.lastIndex(of: ")"){
+            let va = val [val.index(pstart, offsetBy: 1)..<pend]
+            let splitArgs: [Substring.SubSequence]
+            if #available(iOS 16.0, *) {
+                splitArgs = va.split(separator: ", ")
             } else {
-                preparingArguments(p, arguments: arguments) {
-                    aggregatingPreparedArguments(p, argumentsCount: arguments.count) {
-                        p("\(typeName).\(ptrName)(&\(ptr), pArgs)")
+                fatalError ("This requires a modern MacOS to build")
+            }
+            // Find a constructor with that number of arguments
+            for constructor in bc.constructors {
+
+                if constructor.arguments?.count ?? -1 == splitArgs.count {
+                    // Found
+                    var prefixedArgs = ""
+                    for i in 0..<splitArgs.count {
+                        if prefixedArgs.count != 0 { prefixedArgs += ", "}
+                        let name = constructor.arguments! [i].name
+                        var pval = splitArgs [i]
+
+                        // Some Godot constants leak into the initializers
+                        if pval.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) == "inf" {
+                            pval = "Float.infinity"[...]
+                        }
+
+                        prefixedArgs = prefixedArgs + name + ": " + pval
+                    }
+                    return String (val [val.startIndex..<pstart]) + " (" + prefixedArgs + ")"
+                }
+            }
+
+            // Fallback for missing constructors
+            let format: String?
+            switch (bc.name, splitArgs.count) {
+            case ("Transform2D", 6):
+                format = "Transform2D (xAxis: Vector2 (x: %@, y: %@), yAxis: Vector2 (x: %@, y: %@), origin: Vector2 (x: %@, y: %@))"
+            case ("Basis", 9):
+                format = "Basis (xAxis: Vector3 (x: %@, y: %@, z: %@), yAxis: Vector3 (x: %@, y: %@, z: %@), zAxis: Vector3 (x: %@, y: %@, z: %@))"
+            case ("Transform3D", 12):
+                format = "Transform3D (basis: Basis (xAxis: Vector3 (x: %@, y: %@, z: %@), yAxis: Vector3 (x: %@, y: %@, z: %@), zAxis: Vector3 (x: %@, y: %@, z: %@)), origin: Vector3(x: %@, y: %@, z: %@))"
+            case ("Projection", 16):
+                format = "Projection (xAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), yAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), zAxis: Vector4 (x: %@, y: %@, z: %@, w: %@), wAxis: Vector4 (x: %@, y: %@, z: %@, w: %@))"
+            default:
+                format = nil
+            }
+            if let format {
+                return String (format: format, arguments: splitArgs.map (String.init))
+            }
+            return nil
+        }
+        return val
+    }
+
+    private func generateBuiltinConstants (_ p: Printer,
+                                   _ bc: JGodotBuiltinClass,
+                                   typeName: String) {
+
+        guard let constants = bc.constants else { return }
+
+        for constant in constants {
+            // Check if we need to inject parameter names
+            guard let val = getInitializer (bc, constant.value) else {
+                print ("Generator: no constructor matching constant \(bc.name).\(constant.name) = \(constant.value)")
+                continue
+            }
+
+            if constant.description != "" {
+                doc (p, bc, constant.description)
+            }
+            p ("public static let \(snakeToCamel (constant.name)) = \(val)")
+        }
+    }
+
+    private func generateBuiltinCtors (_ p: Printer,
+                               _ bc: JGodotBuiltinClass,
+                               _ ctors: [JGodotConstructor],
+                               godotTypeName: String,
+                               typeName: String,
+                               typeEnum: String,
+                               members: [JGodotArgument]?)
+    {
+        let isStruct = isStruct(typeName)
+
+        for m in ctors {
+            var args = ""
+            var visibility = "public"
+
+            let ptrName = "constructor\(m.index)"
+            p ("static var \(ptrName): GDExtensionPtrConstructor = gi.variant_get_ptr_constructor (\(typeEnum), \(m.index))!\n")
+
+            for arg in m.arguments ?? [] {
+                if args != "" { args += ", " }
+                args += getArgumentDeclaration(arg, omitLabel: false, kind: .builtInField, isOptional: arg.type == "Variant")
+            }
+
+            if let desc = m.description, desc != "" {
+                doc (p, bc, desc)
+            }
+            if args == "" {
+                if !isStruct {
+                    visibility.append(" required")
+                }
+            }
+
+            p ("\(visibility) init (\(args))") {
+                // Determine if we have a constructors whose sole job is to initialize the members
+                // of the struct, in that case, just do that, do not call into Godot.
+                if let margs = m.arguments, let members, margs.count == members.count {
+                    var constructorMatchesFields = true
+                    for x in 0..<margs.count {
+                        // This is so that we can match field `x` with `xAxis` in a few cases
+                        if !(margs [x].name.starts (with: members [x].name) && margs [x].type == members [x].type) {
+                            constructorMatchesFields = false
+                            break
+                        }
+                    }
+                    if constructorMatchesFields {
+                        for x in 0..<margs.count {
+                            p ("self.\(members [x].name) = \(escapeSwift (snakeToCamel (margs [x].name)))")
+                        }
+                        return
+                    }
+                }
+
+                // I used to have a nicer model, rather than everything having a
+                // handle, I had a named handle, like "_godot_string"
+                let ptr = isStruct ? "self" : "content"
+
+                // We need to initialize some variables before we call
+                if let members {
+                    if bc.name == "Color" {
+                        p ("self.red = 0")
+                        p ("self.green = 0")
+                        p ("self.blue = 0")
+                        p ("self.alpha = 1")
+                    } else if bc.name == "Quaternion" && m.arguments == nil {
+                        p ("self.x = 0")
+                        p ("self.y = 0")
+                        p ("self.z = 0")
+                        p ("self.w = 1")
+                    } else if bc.name == "Transform2D" && m.arguments == nil {
+                        p ("self.x = Vector2 (x: 1, y: 0)")
+                        p ("self.y = Vector2 (x: 0, y: 1)")
+                        p ("self.origin = Vector2 ()")
+                    } else if bc.name == "Basis" && m.arguments == nil {
+                        p ("self.x = Vector3 (x: 1, y: 0, z: 0)")
+                        p ("self.y = Vector3 (x: 0, y: 1, z: 0)")
+                        p ("self.z = Vector3 (x: 0, y: 0, z: 1)")
+                    } else if bc.name == "Projection" && m.arguments == nil {
+                        p ("self.x = Vector4 (x: 1, y: 0, z: 0, w: 0)")
+                        p ("self.y = Vector4 (x: 0, y: 1, z: 0, w: 0)")
+                        p ("self.z = Vector4 (x: 0, y: 0, z: 1, w: 0)")
+                        p ("self.w = Vector4 (x: 0, y: 0, z: 0, w: 1)")
+                    } else {
+                        for x in members {
+                            p ("self.\(x.name) = \(MemberBuiltinJsonTypeToSwift(x.type)) ()")
+                        }
+                    }
+                    // Another special case: empty constructors in generated structs (those we added fields for)
+                    // we just keep the manual initialization and do not call the constructor
+                    if m.arguments == nil {
+                        return
+                    }
+                }
+
+                let arguments = (m.arguments ?? []).map {
+                    // must not fail
+                    try! MethodArgument(from: $0, typeName: typeName, methodName: "#constructor\(m.index)", options: .builtInClassOptions)
+                }
+
+                if arguments.isEmpty {
+                    preparingArguments(p, arguments: arguments) {
+                        p ("\(typeName).\(ptrName)(&\(ptr), nil)")
+                    }
+                } else {
+                    preparingArguments(p, arguments: arguments) {
+                        aggregatingPreparedArguments(p, argumentsCount: arguments.count) {
+                            p("\(typeName).\(ptrName)(&\(ptr), pArgs)")
+                        }
                     }
                 }
             }
         }
     }
-}
 
-func generateMethodCall (_ p: Printer,
-                         typeName: String,
-                         methodToCall: String,
-                         godotReturnType: String?,
-                         isStatic: Bool,
-                         isVararg: Bool,
-                         arguments: [JGodotArgument]) {
-    let hasReturnStatement = godotReturnType != nil
-    
-    let resultTypeName = "\(getGodotType (SimpleType (type: godotReturnType ?? ""), kind: .builtIn))"
-    if hasReturnStatement {
-        if godotReturnType == "String" && mapStringToSwift {
-            p ("let result = GString ()")
-        } else if godotReturnType == "Variant" {
-            p("var result = Variant.zero")
-        } else {
-            var declType = "var"
-            if builtinGodotTypeNames [godotReturnType ?? ""] == .isClass {
-                declType = "let"
+    private func generateMethodCallForBuiltin (_ p: Printer,
+                             typeName: String,
+                             methodToCall: String,
+                             godotReturnType: String?,
+                             isStatic: Bool,
+                             isVararg: Bool,
+                             arguments: [JGodotArgument]) {
+        let hasReturnStatement = godotReturnType != nil
+
+        let resultTypeName = "\(getGodotType (SimpleType (type: godotReturnType ?? ""), kind: .builtIn))"
+        if hasReturnStatement {
+            if godotReturnType == "String" && mapStringToSwift {
+                p ("let result = GString ()")
+            } else if godotReturnType == "Variant" {
+                p("var result = Variant.zero")
+            } else {
+                var declType = "var"
+                if builtinGodotTypeNames [godotReturnType ?? ""] == .isClass {
+                    declType = "let"
+                }
+                p ("\(declType) result: \(resultTypeName) = \(resultTypeName)()")
             }
-            p ("\(declType) result: \(resultTypeName) = \(resultTypeName)()")
         }
-    }
-    
-    let methodArguments = arguments.map { argument in
-        // must never fail
-        try! MethodArgument(from: argument, typeName: typeName, methodName: methodToCall, options: .builtInClassOptions)
-    }
-        
-    let ptrResult: String
-    if hasReturnStatement {
-        if godotReturnType == "Variant" {
-            ptrResult = "&result"
-        } else {
-            let isStruct = isStruct(godotReturnType ?? "")
-            if isStruct {
+
+        let methodArguments = arguments.map { argument in
+            // must never fail
+            try! MethodArgument(from: argument, typeName: typeName, methodName: methodToCall, options: .builtInClassOptions)
+        }
+
+        let ptrResult: String
+        if hasReturnStatement {
+            if godotReturnType == "Variant" {
                 ptrResult = "&result"
             } else {
-                ptrResult = "&result.content"
+                let isStruct = isStruct(godotReturnType ?? "")
+                if isStruct {
+                    ptrResult = "&result"
+                } else {
+                    ptrResult = "&result.content"
+                }
             }
-        }
-    } else {
-        ptrResult = "nil"
-    }
-    
-    generateMethodCall(p, isVariadic: isVararg, arguments: arguments, methodArguments: methodArguments) { argsRef, count in
-        let countArg: String
-        
-        switch count {
-        case .literal(let literal):
-            countArg = "\(literal)"
-        case .expression(let expr):
-            countArg = "Int32(\(expr))"
-        }
-        
-        if isStatic {
-            return "\(typeName).\(methodToCall)(nil, \(argsRef), \(ptrResult), \(countArg))"
         } else {
-            if isStruct(typeName) {
-                return """
+            ptrResult = "nil"
+        }
+
+        generateMethodCall(p, isVariadic: isVararg, arguments: arguments, methodArguments: methodArguments) { argsRef, count in
+            let countArg: String
+
+            switch count {
+            case .literal(let literal):
+                countArg = "\(literal)"
+            case .expression(let expr):
+                countArg = "Int32(\(expr))"
+            }
+
+            if isStatic {
+                return "\(typeName).\(methodToCall)(nil, \(argsRef), \(ptrResult), \(countArg))"
+            } else {
+                if isStruct(typeName) {
+                    return """
                 var mutSelfCopy = self
                 withUnsafeMutablePointer (to: &mutSelfCopy) { ptr in
                    \(typeName).\(methodToCall)(ptr, \(argsRef), \(ptrResult), \(countArg))
                 }
                 """
-            } else {
-                return "\(typeName).\(methodToCall)(&content, \(argsRef), \(ptrResult), \(countArg))"
-            }
-        }
-    }
-    
-    if hasReturnStatement {
-        if godotReturnType == "Variant" {
-            p("return Variant(takingOver: result)")
-        } else if godotReturnType == "String" && mapStringToSwift {
-            p("return result.description")
-        } else {
-            p("return result")
-        }
-    }
-}
-
-// List of operators we do not want to generate, as we have custom versions
-let skipOperators: [String:[(String,String)]] = [
-    "StringName": [("==", "StringName")]
-]
-
-private struct OperatorSignature: Hashable, ExpressibleByStringLiteral {
-    let name: String
-    let lhs: String
-    let rhs: String
-    
-    init(name: String, lhs: String, rhs: String) {
-        self.name = name
-        self.lhs = lhs
-        self.rhs = rhs
-    }
-    
-    init(stringLiteral value: StringLiteralType) {
-        let components = value.split(separator: " ")
-        
-        precondition(components.count == 3)
-        
-        lhs = String(components[0])
-        name = String(components[1])
-        rhs = String(components[2])
-    }
-}
-
-private struct MethodSignature: Hashable, ExpressibleByStringLiteral {
-    let typeName: String
-    let methodName: String
-    
-    init(typeName: String, methodName: String) {
-        self.typeName = typeName
-        self.methodName = methodName
-    }
-    
-    init(stringLiteral value: StringLiteralType) {
-        let components = value.split(separator: ".")
-        
-        precondition(components.count == 2)
-        typeName = String(components[0])
-        methodName = String(components[1])
-    }
-}
-
-/// - Parameters:
-///   - operators: the array of operators
-///   - godotTypeName: the type for which we are generating operators
-///   - typeName: the type name above, but in Swift
-func generateBuiltinOperators (_ p: Printer,
-                               _ bc: JGodotBuiltinClass,
-                               typeName: String) {
-    let operators = bc.operators
-    let godotTypeName = bc.name
-    var n = 0
-    
-    for op in operators {
-        let ptrName = "operator_\(n)"
-        n += 1
-        
-        if let right = op.rightType {
-            guard right != "Variant" else { continue }
-
-            
-            if let skippable = skipOperators [godotTypeName] {
-                if skippable.contains (where: { $0.0 == op.name && $0.1 == op.rightType }) {
-                    continue
+                } else {
+                    return "\(typeName).\(methodToCall)(&content, \(argsRef), \(ptrResult), \(countArg))"
                 }
             }
-            guard let (operatorCode, swiftOperator) = infixOperatorMap (op.name) else {
+        }
+
+        if hasReturnStatement {
+            if godotReturnType == "Variant" {
+                p("return Variant(takingOver: result)")
+            } else if godotReturnType == "String" && mapStringToSwift {
+                p("return result.description")
+            } else {
+                p("return result")
+            }
+        }
+    }
+
+    // List of operators we do not want to generate, as we have custom versions
+    private static let skipOperators: [String:[(String,String)]] = [
+        "StringName": [("==", "StringName")]
+    ]
+
+    private struct OperatorSignature: Hashable, ExpressibleByStringLiteral {
+        let name: String
+        let lhs: String
+        let rhs: String
+
+        init(name: String, lhs: String, rhs: String) {
+            self.name = name
+            self.lhs = lhs
+            self.rhs = rhs
+        }
+
+        init(stringLiteral value: StringLiteralType) {
+            let components = value.split(separator: " ")
+
+            precondition(components.count == 3)
+
+            lhs = String(components[0])
+            name = String(components[1])
+            rhs = String(components[2])
+        }
+    }
+
+    private struct MethodSignature: Hashable, ExpressibleByStringLiteral {
+        let typeName: String
+        let methodName: String
+
+        init(typeName: String, methodName: String) {
+            self.typeName = typeName
+            self.methodName = methodName
+        }
+
+        init(stringLiteral value: StringLiteralType) {
+            let components = value.split(separator: ".")
+
+            precondition(components.count == 2)
+            typeName = String(components[0])
+            methodName = String(components[1])
+        }
+    }
+
+    /// - Parameters:
+    ///   - operators: the array of operators
+    ///   - godotTypeName: the type for which we are generating operators
+    ///   - typeName: the type name above, but in Swift
+    private func generateBuiltinOperators (_ p: Printer,
+                                   _ bc: JGodotBuiltinClass,
+                                   typeName: String) {
+        let operators = bc.operators
+        let godotTypeName = bc.name
+        var n = 0
+
+        for op in operators {
+            let ptrName = "operator_\(n)"
+            n += 1
+
+            if let right = op.rightType {
+                guard right != "Variant" else { continue }
+
+
+                if let skippable = Self.skipOperators [godotTypeName] {
+                    if skippable.contains (where: { $0.0 == op.name && $0.1 == op.rightType }) {
+                        continue
+                    }
+                }
+                guard let (operatorCode, swiftOperator) = infixOperatorMap (op.name) else {
+                    continue
+                }
+                p.staticVar (name: ptrName, type: "GDExtensionPtrOperatorEvaluator") {
+                    let rightTypeCode = builtinTypecode (right)
+                    let leftTypeCode = builtinTypecode (godotTypeName)
+                    p ("return gi.variant_get_ptr_operator_evaluator (\(operatorCode), \(leftTypeCode), \(rightTypeCode))!")
+                }
+
+                let retType = getGodotType(SimpleType (type: op.returnType), kind: .builtIn)
+
+                let lhsTypeName = typeName
+                let rhsTypeName = getGodotType(SimpleType(type: right), kind: .builtIn)
+
+                let customImplementation = Self.customBuiltinOperatorImplementations[OperatorSignature(name: swiftOperator, lhs: lhsTypeName, rhs: rhsTypeName)]
+
+                if let desc = op.description, desc != "" {
+                    doc (p, bc, desc)
+                }
+
+                p ("public static func \(swiftOperator) (lhs: \(lhsTypeName), rhs: \(rhsTypeName)) -> \(retType) "){
+                    if customImplementation != nil {
+                        p("#if !CUSTOM_BUILTIN_IMPLEMENTATIONS")
+                    }
+
+                    let ptrResult: String
+                    if op.returnType == "String" && mapStringToSwift {
+                        p ("let result = GString ()")
+                    } else {
+                        var declType: String = "var"
+                        if builtinGodotTypeNames [op.returnType] == .isClass {
+                            declType = "let"
+                        }
+                        p ("\(declType) result: \(retType) = \(retType)()")
+                    }
+                    if isStruct(op.returnType) {
+                        ptrResult = "&result"
+                    } else {
+                        ptrResult = "&result.content"
+                    }
+                    let lhsa = try! MethodArgument(
+                        from: JGodotArgument(name: "lhs", type: godotTypeName, defaultValue: nil, meta: nil),
+                        typeName: godotTypeName,
+                        methodName: "#operator\(swiftOperator)",
+                        options: .builtInClassOptions
+                    )
+
+                    let rhsa = try! MethodArgument(
+                        from: JGodotArgument(name: "rhs", type: right, defaultValue: nil, meta: nil),
+                        typeName: godotTypeName,
+                        methodName: "#operator\(swiftOperator)",
+                        options: .builtInClassOptions
+                    )
+
+                    preparingArguments(p, arguments: [lhsa, rhsa]) {
+                        p("\(typeName).\(ptrName)(pArg0, pArg1, \(ptrResult))")
+                    }
+
+                    if op.returnType == "String" && mapStringToSwift {
+                        p ("return result.description")
+                    } else {
+                        p ("return result")
+                    }
+
+                    if let customImplementation {
+                        p("#else // CUSTOM_BUILTIN_IMPLEMENTATIONS")
+                        p(customImplementation)
+                        p("#endif")
+                    }
+                }
+            }
+        }
+    }
+
+
+
+    private func generateBuiltinMethods (_ p: Printer,
+                                 _ bc: JGodotBuiltinClass,
+                                 _ methods: [JGodotBuiltinClassMethod],
+                                 _ typeName: String,
+                                 _ typeEnum: String,
+                                 isStruct: Bool)
+    {
+        if methods.count > 0 {
+            p ("\n/* Methods */\n")
+        }
+        for m in methods {
+            if m.name == "repeat" {
+                // TODO: Avoid clash for now
                 continue
             }
-            p.staticVar (name: ptrName, type: "GDExtensionPtrOperatorEvaluator") {
-                let rightTypeCode = builtinTypecode (right)
-                let leftTypeCode = builtinTypecode (godotTypeName)
-                p ("return gi.variant_get_ptr_operator_evaluator (\(operatorCode), \(leftTypeCode), \(rightTypeCode))!")
+
+            if omittedMethodsList[typeName]?.contains(m.name) == true {
+                continue
             }
-            
-            let retType = getGodotType(SimpleType (type: op.returnType), kind: .builtIn)
-            
-            let lhsTypeName = typeName
-            let rhsTypeName = getGodotType(SimpleType(type: right), kind: .builtIn)
-                        
-            let customImplementation = customBuiltinOperatorImplementations[OperatorSignature(name: swiftOperator, lhs: lhsTypeName, rhs: rhsTypeName)]
-            
-            if let desc = op.description, desc != "" {
-                doc (p, bc, desc)
+
+
+            let ret: String
+            if m.returnType == "Variant" {
+                ret = "Variant?"
+            } else {
+                ret = getGodotType(SimpleType (type: m.returnType ?? ""), kind: .builtIn)
             }
-            
-            p ("public static func \(swiftOperator) (lhs: \(lhsTypeName), rhs: \(rhsTypeName)) -> \(retType) "){
+
+            // TODO: problem caused by gobject_object being defined as "void", so it is not possible to create storage to that.
+            if ret == "Object" {
+                continue
+            }
+            let retSig = ret == "" ? "" : "-> \(ret)"
+            var args = ""
+
+            let ptrName = "method_\(m.name)"
+
+            p.staticVar (name: ptrName, type: "GDExtensionPtrBuiltInMethod") {
+                p ("let name = StringName (\"\(m.name)\")")
+                p ("return gi.variant_get_ptr_builtin_method (\(typeEnum), &name.content, \(m.hash))!")
+            }
+
+            for arg in m.arguments ?? [] {
+                let omitFirstLabel: Bool
+                // Omit first argument label, if necessary
+                if args.isEmpty, shouldOmitFirstArgLabel(typeName: typeName, methodName: m.name, argName: arg.name) {
+                    omitFirstLabel = true
+                } else {
+                    omitFirstLabel = false
+                }
+                if args != "" { args += ", " }
+                args += getArgumentDeclaration(arg, omitLabel: omitFirstLabel, isOptional: arg.type == "Variant")
+            }
+            if m.isVararg {
+                if args != "" { args += ", " }
+                args += "_ arguments: Variant?..."
+            }
+            doc (p, bc, m.description)
+            // Generate the method entry point
+            if discardableResultList [bc.name]?.contains(m.name) ?? false && m.returnType != "" {
+                p ("@discardableResult /* 1: \(m.name) */ ")
+            }
+
+            let keyword: String
+            if m.isStatic {
+                keyword = " static"
+            } else if !isStruct {
+                keyword = " final"
+            } else {
+                keyword = ""
+            }
+
+            let methodName = escapeSwift(snakeToCamel(m.name))
+            let customImplementation = Self.customBuiltinMethodImplementations[MethodSignature(typeName: bc.name, methodName: methodName)]
+
+            p ("public\(keyword) func \(methodName)(\(args))\(retSig)") {
                 if customImplementation != nil {
                     p("#if !CUSTOM_BUILTIN_IMPLEMENTATIONS")
                 }
-                
-                let ptrResult: String
-                if op.returnType == "String" && mapStringToSwift {
-                    p ("let result = GString ()")
-                } else {
-                    var declType: String = "var"
-                    if builtinGodotTypeNames [op.returnType] == .isClass {
-                        declType = "let"
-                    }
-                    p ("\(declType) result: \(retType) = \(retType)()")
-                }
-                if isStruct(op.returnType) {
-                    ptrResult = "&result"
-                } else {
-                    ptrResult = "&result.content"
-                }
-                let lhsa = try! MethodArgument(
-                    from: JGodotArgument(name: "lhs", type: godotTypeName, defaultValue: nil, meta: nil),
-                    typeName: godotTypeName,
-                    methodName: "#operator\(swiftOperator)",
-                    options: .builtInClassOptions
-                )
-                
-                let rhsa = try! MethodArgument(
-                    from: JGodotArgument(name: "rhs", type: right, defaultValue: nil, meta: nil),
-                    typeName: godotTypeName,
-                    methodName: "#operator\(swiftOperator)",
-                    options: .builtInClassOptions
-                )
-                    
-                preparingArguments(p, arguments: [lhsa, rhsa]) {
-                    p("\(typeName).\(ptrName)(pArg0, pArg1, \(ptrResult))")
-                }
-                
-                if op.returnType == "String" && mapStringToSwift {
-                    p ("return result.description")
-                } else {
-                    p ("return result")
-                }
-                
+
+                generateMethodCallForBuiltin (p, typeName: typeName, methodToCall: ptrName, godotReturnType: m.returnType, isStatic: m.isStatic, isVararg: m.isVararg, arguments: m.arguments ?? [])
+
                 if let customImplementation {
                     p("#else // CUSTOM_BUILTIN_IMPLEMENTATIONS")
                     p(customImplementation)
@@ -417,112 +520,18 @@ func generateBuiltinOperators (_ p: Printer,
                 }
             }
         }
-    }
-}
-    
-
-
-func generateBuiltinMethods (_ p: Printer,
-                             _ bc: JGodotBuiltinClass,
-                             _ methods: [JGodotBuiltinClassMethod],
-                             _ typeName: String,
-                             _ typeEnum: String,
-                             isStruct: Bool)
-{
-    if methods.count > 0 {
-        p ("\n/* Methods */\n")
-    }
-    for m in methods {
-        if m.name == "repeat" {
-            // TODO: Avoid clash for now
-            continue
-        }
-        
-        if omittedMethodsList[typeName]?.contains(m.name) == true {
-            continue
-        }
-        
-        
-        let ret: String
-        if m.returnType == "Variant" {
-            ret = "Variant?"
-        } else {
-            ret = getGodotType(SimpleType (type: m.returnType ?? ""), kind: .builtIn)
-        }
-        
-        // TODO: problem caused by gobject_object being defined as "void", so it is not possible to create storage to that.
-        if ret == "Object" {
-            continue
-        }
-        let retSig = ret == "" ? "" : "-> \(ret)"
-        var args = ""
-    
-        let ptrName = "method_\(m.name)"
-        
-        p.staticVar (name: ptrName, type: "GDExtensionPtrBuiltInMethod") {
-            p ("let name = StringName (\"\(m.name)\")")
-            p ("return gi.variant_get_ptr_builtin_method (\(typeEnum), &name.content, \(m.hash))!")
-        }
-        
-        for arg in m.arguments ?? [] {
-            let omitFirstLabel: Bool
-            // Omit first argument label, if necessary
-            if args.isEmpty, shouldOmitFirstArgLabel(typeName: typeName, methodName: m.name, argName: arg.name) {
-                omitFirstLabel = true
-            } else {
-                omitFirstLabel = false
+        if bc.isKeyed {
+            let variantType = builtinTypecode(bc.name)
+            p.staticVar (visibility: "private ", name: "keyed_getter", type: "GDExtensionPtrKeyedGetter") {
+                p ("return gi.variant_get_ptr_keyed_getter (\(variantType))!")
             }
-            if args != "" { args += ", " }
-            args += getArgumentDeclaration(arg, omitLabel: omitFirstLabel, isOptional: arg.type == "Variant")
-        }
-        if m.isVararg {
-            if args != "" { args += ", " }
-            args += "_ arguments: Variant?..."
-        }
-        doc (p, bc, m.description)
-        // Generate the method entry point
-        if discardableResultList [bc.name]?.contains(m.name) ?? false && m.returnType != "" {
-            p ("@discardableResult /* 1: \(m.name) */ ")
-        }
-
-        let keyword: String
-        if m.isStatic {
-            keyword = " static"
-        } else if !isStruct {
-            keyword = " final"
-        } else {
-            keyword = ""
-        }
-        
-        let methodName = escapeSwift(snakeToCamel(m.name))
-        let customImplementation = customBuiltinMethodImplementations[MethodSignature(typeName: bc.name, methodName: methodName)]
-        
-        p ("public\(keyword) func \(methodName)(\(args))\(retSig)") {
-            if customImplementation != nil {
-                p("#if !CUSTOM_BUILTIN_IMPLEMENTATIONS")
+            p.staticVar (visibility: "private ", name: "keyed_setter", type: "GDExtensionPtrKeyedSetter") {
+                p ("return gi.variant_get_ptr_keyed_setter (\(variantType))!")
             }
-            
-            generateMethodCall (p, typeName: typeName, methodToCall: ptrName, godotReturnType: m.returnType, isStatic: m.isStatic, isVararg: m.isVararg, arguments: m.arguments ?? [])
-            
-            if let customImplementation {
-                p("#else // CUSTOM_BUILTIN_IMPLEMENTATIONS")
-                p(customImplementation)
-                p("#endif")
+            p.staticVar (visibility: "private ", name: "keyed_checker", type: "GDExtensionPtrKeyedChecker") {
+                p ("return gi.variant_get_ptr_keyed_checker (\(variantType))!")
             }
-        }
-    }
-    if bc.isKeyed {
-        let variantType = builtinTypecode(bc.name)
-        p.staticVar (visibility: "private ", name: "keyed_getter", type: "GDExtensionPtrKeyedGetter") {
-            p ("return gi.variant_get_ptr_keyed_getter (\(variantType))!")
-        }
-        p.staticVar (visibility: "private ", name: "keyed_setter", type: "GDExtensionPtrKeyedSetter") {
-            p ("return gi.variant_get_ptr_keyed_setter (\(variantType))!")
-        }
-        p.staticVar (visibility: "private ", name: "keyed_checker", type: "GDExtensionPtrKeyedChecker") {
-            p ("return gi.variant_get_ptr_keyed_checker (\(variantType))!")
-        }
-        p("""
+            p("""
         public subscript(key: Variant?) -> Variant? {
             get {                            
                 withUnsafePointer(to: key.content) { pKeyContent in
@@ -548,97 +557,90 @@ func generateBuiltinMethods (_ p: Printer,
                 }                                
             }
         }
-        """)        
-    }
-    if let returnType = bc.indexingReturnType, !bc.isKeyed, !bc.name.hasSuffix ("Array"), bc.name != "String" {
-        let godotType = getGodotType (JGodotReturnValue (type: returnType, meta: nil))
-        let variantType = builtinTypecode (bc.name)
-        p.staticVar (visibility: "private ", name: "indexed_getter", type: "GDExtensionPtrIndexedGetter") {
-            p ("return gi.variant_get_ptr_indexed_getter (\(variantType))!")
+        """)
         }
-        p.staticVar (visibility: "private ", name: "indexed_setter", type: "GDExtensionPtrIndexedSetter") {
-            p ("return gi.variant_get_ptr_indexed_setter (\(variantType))!")
-        }
-        p (" public subscript (index: Int64) -> \(godotType)") {
-            p ("mutating get") {
-                p ("var result = \(godotType) ()")
-                p ("Self.indexed_getter (&self, index, &result)")
-                p ("return result")
+        if let returnType = bc.indexingReturnType, !bc.isKeyed, !bc.name.hasSuffix ("Array"), bc.name != "String" {
+            let godotType = getGodotType (JGodotReturnValue (type: returnType, meta: nil))
+            let variantType = builtinTypecode (bc.name)
+            p.staticVar (visibility: "private ", name: "indexed_getter", type: "GDExtensionPtrIndexedGetter") {
+                p ("return gi.variant_get_ptr_indexed_getter (\(variantType))!")
             }
-            p ("set") {
-                p ("var value = newValue")
-                p ("Self.indexed_setter (&self, index, &value)")
+            p.staticVar (visibility: "private ", name: "indexed_setter", type: "GDExtensionPtrIndexedSetter") {
+                p ("return gi.variant_get_ptr_indexed_setter (\(variantType))!")
+            }
+            p (" public subscript (index: Int64) -> \(godotType)") {
+                p ("mutating get") {
+                    p ("var result = \(godotType) ()")
+                    p ("Self.indexed_getter (&self, index, &result)")
+                    p ("return result")
+                }
+                p ("set") {
+                    p ("var value = newValue")
+                    p ("Self.indexed_setter (&self, index, &value)")
+                }
             }
         }
     }
-}
 
-enum BKind {
-    case isStruct
-    case isClass
-}
-var builtinGodotTypeNames: [String:BKind] = ["Variant": .isClass]
-var builtinClassStorage: [String:String] = [:]
+    func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) async {
 
-func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) async {
+        func generateBuiltinClass (p: Printer, _ bc: JGodotBuiltinClass) {
+            // TODO: isKeyed, hasDestrcturo,
+            let kind: BKind = builtinGodotTypeNames[bc.name]!
 
-    func generateBuiltinClass (p: Printer, _ bc: JGodotBuiltinClass) {
-        // TODO: isKeyed, hasDestrcturo,
-        let kind: BKind = builtinGodotTypeNames[bc.name]!
-        
-        let typeName = mapTypeName (bc.name)
-        let typeEnum = "GDEXTENSION_VARIANT_TYPE_" + camelToSnake(bc.name).uppercased()
-        
-        
-        var conformances: [String] = []
-        if kind == .isStruct {
-            conformances.append ("Equatable")
-            conformances.append ("Hashable")
-        } else {
-            if bc.operators.contains(where: { op in op.name == "==" && op.rightType == bc.name }) {
+            let typeName = mapTypeName (bc.name)
+            let typeEnum = "GDEXTENSION_VARIANT_TYPE_" + camelToSnake(bc.name).uppercased()
+
+
+            var conformances: [String] = []
+            if kind == .isStruct {
                 conformances.append ("Equatable")
+                conformances.append ("Hashable")
+            } else {
+                if bc.operators.contains(where: { op in op.name == "==" && op.rightType == bc.name }) {
+                    conformances.append ("Equatable")
+                }
             }
-        }
 
-        if bc.name == "String" || bc.name == "StringName" || bc.name == "NodePath" {
-            conformances.append ("ExpressibleByStringLiteral")
-            conformances.append ("ExpressibleByStringInterpolation")
-            conformances.append ("LosslessStringConvertible")
-        }
-        if bc.name.hasSuffix ("Array") {
-            conformances.append ("Collection")
-            conformances.append ("RandomAccessCollection")
-        }
-        var proto = ""
-        if conformances.count > 0 {
-            proto = ": " + conformances.joined(separator: ", ")
-        } else {
-            proto = ""
-        }
-        
-        doc (p, bc, bc.brief_description)
-        if (bc.description ?? "") != "" {
-            doc (p, bc, "")      // Add a newline before the fuller description
-            doc (p, bc, bc.description)
-        }
-        
-        p ("public \(kind == .isStruct ? "struct" : "class") \(typeName)\(proto)") {
-            if bc.name == "String" {
-                p("""
+            if bc.name == "String" || bc.name == "StringName" || bc.name == "NodePath" {
+                conformances.append ("ExpressibleByStringLiteral")
+                conformances.append ("ExpressibleByStringInterpolation")
+                conformances.append ("LosslessStringConvertible")
+            }
+            if bc.name.hasSuffix ("Array") {
+                conformances.append ("Collection")
+                conformances.append ("RandomAccessCollection")
+            }
+            var proto = ""
+            if conformances.count > 0 {
+                proto = ": " + conformances.joined(separator: ", ")
+            } else {
+                proto = ""
+            }
+
+            doc (p, bc, bc.brief_description)
+            if (bc.description ?? "") != "" {
+                doc (p, bc, "")      // Add a newline before the fuller description
+                doc (p, bc, bc.description)
+            }
+
+            p ("public \(kind == .isStruct ? "struct" : "class") \(typeName)\(proto)") {
+                if bc.name == "String" {
+                    p("""
                 public required init(_ string: String) {
                     gi.string_new_with_utf8_chars(&content, string)
                 }
                 """)
-                
-                p("""
+
+                    p("""
                 // ExpressibleByStringLiteral conformance
                 public required init(stringLiteral value: String) {
                     gi.string_new_with_utf8_chars(&content, value)
                 }
                 """)
-            }
-            if bc.name == "NodePath"  {
-                p("""
+                }
+                if bc.name == "NodePath"  {
+                    p("""
                 /// ExpressibleByStringLiteral conformance
                 public required init(stringLiteral value: String) {
                     let gstring = GString(value)
@@ -649,8 +651,8 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                     }
                 }
                 """)
-                
-                p("""
+
+                    p("""
                 /// LosslessStringConvertible conformance
                 public required init(_ value: String) {
                     let gstring = GString(value)
@@ -661,28 +663,28 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                     }
                 }
                 """)
-                
-                p ("/// Produces a string representation of this NodePath")
-                p ("public var description: String") {
-                    p ("let sub = getSubnameCount () > 0 ? getConcatenatedSubnames ().description : \"\"")
-                    p ("return (isAbsolute() ? \"/\" : \"\") + (getNameCount () > 0 ? getConcatenatedNames ().description : \"\") + (sub == \"\" ? sub : \":\\(sub)\")")
+
+                    p ("/// Produces a string representation of this NodePath")
+                    p ("public var description: String") {
+                        p ("let sub = getSubnameCount () > 0 ? getConcatenatedSubnames ().description : \"\"")
+                        p ("return (isAbsolute() ? \"/\" : \"\") + (getNameCount () > 0 ? getConcatenatedNames ().description : \"\") + (sub == \"\" ? sub : \":\\(sub)\")")
+                    }
                 }
-            }
-            if bc.name == "StringName" {
-                // TODO: This is a little brittle, because I am
-                // hardcoding the constructor1 here, it should
-                // really produce this when it matches the kind
-                // directly to be the one that takes a StringName
-                // parameter
-                p("""
+                if bc.name == "StringName" {
+                    // TODO: This is a little brittle, because I am
+                    // hardcoding the constructor1 here, it should
+                    // really produce this when it matches the kind
+                    // directly to be the one that takes a StringName
+                    // parameter
+                    p("""
                 public init(fromPtr ptr: UnsafeRawPointer?) {
                     withUnsafePointer(to: ptr) { pArgs in
                         StringName.constructor1(&content, pArgs) 
                     }
                 }
                 """)
-                
-                p("""
+
+                    p("""
                 /// ExpressibleByStringLiteral conformace
                 public required init(stringLiteral value: String) {
                     let gstring = GString(value)
@@ -693,8 +695,8 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                     }
                 }
                 """)
-                
-                p("""
+
+                    p("""
                 /// LosslessStringConvertible conformance 
                 public required init(_ value: String) {
                     let gstring = GString(value)
@@ -705,55 +707,55 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                     }
                 }
                 """)
-            }
-            if bc.name == "Callable" {
-                p ("/// Creates a Callable instance from a Swift function")
-                p ("/// - Parameter callback: the swift function that receives `Arguments`, and returns a `Variant`")
-                p ("public init(_ callback: @escaping (borrowing Arguments) -> Variant?)") {
-                    p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
                 }
+                if bc.name == "Callable" {
+                    p ("/// Creates a Callable instance from a Swift function")
+                    p ("/// - Parameter callback: the swift function that receives `Arguments`, and returns a `Variant`")
+                    p ("public init(_ callback: @escaping (borrowing Arguments) -> Variant?)") {
+                        p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
+                    }
 
-#if false 
-                p ("/// Creates a Callable instance from a Swift function")
-                p ("/// - Parameter callback: the swift function that receives an array of Variant arguments, and returns an optional Variant")
-                p("""
+#if false
+                    p ("/// Creates a Callable instance from a Swift function")
+                    p ("/// - Parameter callback: the swift function that receives an array of Variant arguments, and returns an optional Variant")
+                    p("""
                 @available(*, deprecated, message: "Use `init(_ callback: @escaping (borrowing Arguments) -> Variant)` instead.")
                 """)
-                p ("public init (_ callback: @escaping ([Variant])->Variant?)") {
-                    p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
-                }
+                    p ("public init (_ callback: @escaping ([Variant])->Variant?)") {
+                        p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
+                    }
 #endif
-            }
-            if bc.hasDestructor {
-                p.staticVar (name: "destructor", type: "GDExtensionPtrDestructor") {
-                    p ("return gi.variant_get_ptr_destructor (\(typeEnum))!")
                 }
-                
-                p ("deinit"){
-                    p ("if content != \(typeName).zero") {
-                        p ("\(typeName).destructor (&content)")
+                if bc.hasDestructor {
+                    p.staticVar (name: "destructor", type: "GDExtensionPtrDestructor") {
+                        p ("return gi.variant_get_ptr_destructor (\(typeEnum))!")
+                    }
+
+                    p ("deinit"){
+                        p ("if content != \(typeName).zero") {
+                            p ("\(typeName).destructor (&content)")
+                        }
                     }
                 }
-            }
-            if bc.name.hasPrefix("Packed") && bc.name.hasSuffix("Array") {
-                p ("/// The number of elements in the array")
-                p ("public var count: Int { Int (size()) }")
-            }
-            if kind == .isClass {
-                let (storage, initialize) = getBuiltinStorage (bc.name)
-                p ("// Contains a binary blob where this type information is stored")
-                p ("public var content: ContentType\(initialize)")
-                p ("// Used to initialize empty types")
-                p ("public static let zero: ContentType \(initialize)")
-                p ("// Convenience type that matches the build configuration storage needs")
-                p ("public typealias ContentType = \(storage)")
-                builtinClassStorage [bc.name] = storage
-                // TODO: This is a little brittle, because I am
-                // hardcoding the constructor1 here, it should
-                // really produce this when it matches the kind
-                // directly to be the one that takes the same
-                // parameter                
-                p("""
+                if bc.name.hasPrefix("Packed") && bc.name.hasSuffix("Array") {
+                    p ("/// The number of elements in the array")
+                    p ("public var count: Int { Int (size()) }")
+                }
+                if kind == .isClass {
+                    let (storage, initialize) = getBuiltinStorage (bc.name)
+                    p ("// Contains a binary blob where this type information is stored")
+                    p ("public var content: ContentType\(initialize)")
+                    p ("// Used to initialize empty types")
+                    p ("public static let zero: ContentType \(initialize)")
+                    p ("// Convenience type that matches the build configuration storage needs")
+                    p ("public typealias ContentType = \(storage)")
+                    builtinClassStorage [bc.name] = storage
+                    // TODO: This is a little brittle, because I am
+                    // hardcoding the constructor1 here, it should
+                    // really produce this when it matches the kind
+                    // directly to be the one that takes the same
+                    // parameter
+                    p("""
                 // Used to construct objects on virtual proxies
                 public required init(content proxyContent: ContentType) {
                     withUnsafePointer(to: proxyContent) { pContent in
@@ -763,188 +765,191 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
                     }
                 }
                 """)
-                
-                p ("// Used to construct objects when the underlying built-in's ref count has already been incremented for me")
-                p ("public required init(alreadyOwnedContent content: ContentType)") {
-                    p ("self.content = content")
-                }
-            }
-           
-            func memberDoc (_ name: String) {
-                guard let members = bc.members else { return }
-                for m in members {
-                    if m.name == name {
-                        doc (p, bc, m.description)
+
+                    p ("// Used to construct objects when the underlying built-in's ref count has already been incremented for me")
+                    p ("public required init(alreadyOwnedContent content: ContentType)") {
+                        p ("self.content = content")
                     }
                 }
-            }
-            let storedMembers: [JGodotArgument]?
-            if bc.name == "Color" {
-                memberDoc ("r")
-                p ("public var red: Float")
-                memberDoc ("g")
-                p ("public var green: Float")
-                memberDoc ("b")
-                p ("public var blue: Float")
-                memberDoc ("a")
-                p ("public var alpha: Float")
-                storedMembers = bc.members
-            } else {
-                if kind == .isStruct, let memberOffsets = builtinMemberOffsets [bc.name] {
-                    storedMembers = memberOffsets.compactMap({ m in
-                        return bc.members?.first(where: { $0.name == m.member })
-                    })
-                } else {
+
+                func memberDoc (_ name: String) {
+                    guard let members = bc.members else { return }
+                    for m in members {
+                        if m.name == name {
+                            doc (p, bc, m.description)
+                        }
+                    }
+                }
+                let storedMembers: [JGodotArgument]?
+                if bc.name == "Color" {
+                    memberDoc ("r")
+                    p ("public var red: Float")
+                    memberDoc ("g")
+                    p ("public var green: Float")
+                    memberDoc ("b")
+                    p ("public var blue: Float")
+                    memberDoc ("a")
+                    p ("public var alpha: Float")
                     storedMembers = bc.members
-                }
-                if let members = storedMembers {
-                    for x in members {
-                        memberDoc (x.name)
-                        p ("public var \(x.name): \(MemberBuiltinJsonTypeToSwift (x.type))")
+                } else {
+                    if kind == .isStruct, let memberOffsets = builtinMemberOffsets [bc.name] {
+                        storedMembers = memberOffsets.compactMap({ m in
+                            return bc.members?.first(where: { $0.name == m.member })
+                        })
+                    } else {
+                        storedMembers = bc.members
                     }
-                }
-            }
-                
-            if let enums = bc.enums {
-                generateEnums(p, cdef: bc, values: enums, prefix: bc.name + ".")
-            }
-            generateBuiltinCtors (p, bc, bc.constructors, godotTypeName: bc.name, typeName: typeName, typeEnum: typeEnum, members: storedMembers)
-            
-            generateBuiltinMethods(p, bc, bc.methods ?? [], typeName, typeEnum, isStruct: kind == .isStruct)
-            generateBuiltinOperators (p, bc, typeName: typeName)
-            generateBuiltinConstants (p, bc, typeName: typeName)
-            
-            // Generate the synthetic `end` property
-            if bc.name == "Rect2" || bc.name == "Rect2i" || bc.name == "AABB" {
-                let retType: String
-                memberDoc("end")
-                switch bc.name {
-                case "Rect2": retType = "Vector2"
-                case "Rect2i": retType = "Vector2i"
-                case "AABB": retType = "Vector3"
-                default:
-                    fatalError("Should never happen")
-                }
-                p ("public var end: \(retType)") {
-                    p ("set") {
-                        p ("size = newValue - position")
+                    if let members = storedMembers {
+                        for x in members {
+                            memberDoc (x.name)
+                            p ("public var \(x.name): \(MemberBuiltinJsonTypeToSwift (x.type))")
+                        }
                     }
-                    p ("get") {
-                        p ("position + size")
-                    }
-                }
-            }
-            if bc.name.hasSuffix ("Array") {
-                p ("public var startIndex: Int") {
-                    p ("0")
-                }
-                p ("public var endIndex: Int") {
-                    p ("Int (size ())")
                 }
 
-                p ("public func index(after i: Int) -> Int") {
-                    p ("i+1")
+                if let enums = bc.enums {
+                    generateEnums(p, cdef: bc, values: enums, prefix: bc.name + ".")
                 }
+                generateBuiltinCtors (p, bc, bc.constructors, godotTypeName: bc.name, typeName: typeName, typeEnum: typeEnum, members: storedMembers)
 
-                p ("public func index(before i: Int) -> Int") {
-                    p ("return i-1")
+                generateBuiltinMethods(p, bc, bc.methods ?? [], typeName, typeEnum, isStruct: kind == .isStruct)
+                generateBuiltinOperators (p, bc, typeName: typeName)
+                generateBuiltinConstants (p, bc, typeName: typeName)
+
+                // Generate the synthetic `end` property
+                if bc.name == "Rect2" || bc.name == "Rect2i" || bc.name == "AABB" {
+                    let retType: String
+                    memberDoc("end")
+                    switch bc.name {
+                    case "Rect2": retType = "Vector2"
+                    case "Rect2i": retType = "Vector2i"
+                    case "AABB": retType = "Vector3"
+                    default:
+                        fatalError("Should never happen")
+                    }
+                    p ("public var end: \(retType)") {
+                        p ("set") {
+                            p ("size = newValue - position")
+                        }
+                        p ("get") {
+                            p ("position + size")
+                        }
+                    }
+                }
+                if bc.name.hasSuffix ("Array") {
+                    p ("public var startIndex: Int") {
+                        p ("0")
+                    }
+                    p ("public var endIndex: Int") {
+                        p ("Int (size ())")
+                    }
+
+                    p ("public func index(after i: Int) -> Int") {
+                        p ("i+1")
+                    }
+
+                    p ("public func index(before i: Int) -> Int") {
+                        p ("return i-1")
+                    }
+                }
+            }
+        }
+
+        // First map structs and classes from the builtins
+        for bc in values {
+            if bc.name == "Nil" { continue }
+            switch bc.name {
+                // We do not generate code for a few types, we will bridge those instead
+            case "int", "float", "bool":
+                break
+            default:
+                builtinGodotTypeNames [bc.name] = bc.members != nil ? .isStruct : .isClass
+            }
+        }
+
+        for bc in values {
+            switch bc.name {
+                // This one is ignored altogether. We've got `Optional` in Swift
+            case "Nil":
+                break
+                // We do not generate code for a few types, we will bridge those instead
+            case "int", "float", "bool":
+                break
+            default:
+                let p: Printer = await PrinterFactory.shared.initPrinter(bc.name)
+                p.preamble()
+                $mapStringToSwift.withValue(bc.name != "String") {
+                    generateBuiltinClass (p: p, bc)
+                }
+                if let outputDir {
+                    p.save(outputDir + "/\(bc.name).swift")
                 }
             }
         }
     }
-    
-    // First map structs and classes from the builtins
-    for bc in values {
-        if bc.name == "Nil" { continue }
-        switch bc.name {
-            // We do not generate code for a few types, we will bridge those instead
-        case "int", "float", "bool":
-            break
-        default:
-            builtinGodotTypeNames [bc.name] = bc.members != nil ? .isStruct : .isClass
-        }
-    }
-    
-    for bc in values {
-        switch bc.name {
-            // This one is ignored altogether. We've got `Optional` in Swift
-        case "Nil":
-            break
-            // We do not generate code for a few types, we will bridge those instead
-        case "int", "float", "bool":
-            break
-        default:
-            let p: Printer = await PrinterFactory.shared.initPrinter(bc.name)
-            p.preamble()
-            $mapStringToSwift.withValue(bc.name != "String") {
-                generateBuiltinClass (p: p, bc)
-            }
-            if let outputDir {
-                p.save(outputDir + "/\(bc.name).swift")
-            }
-        }
-    }
+
+    // MARK: - Custom operators impl
+    private static let customBuiltinOperatorImplementations: [OperatorSignature: String] = [
+        // MARK: Vector3
+        "Vector3 * Vector3": """
+        return Vector3(x: lhs.x * rhs.x, y: lhs.y * rhs.y, z: lhs.z * rhs.z)
+        """,
+
+        "Vector3 / Vector3": """
+        return Vector3(x: lhs.x / rhs.x, y: lhs.y / rhs.y, z: lhs.z / rhs.z)
+        """,
+
+        "Vector3 + Vector3": """
+        return Vector3(x: lhs.x + rhs.x, y: lhs.y + rhs.y, z: lhs.z + rhs.z)
+        """,
+
+        "Vector3 - Vector3": """
+        return Vector3(x: lhs.x - rhs.x, y: lhs.y - rhs.y, z: lhs.z - rhs.z)
+        """,
+
+        "Vector3 * Double": """
+        let rhs = Float(rhs)
+        return Vector3(x: lhs.x * rhs, y: lhs.y * rhs, z: lhs.z * rhs)
+        """,
+
+        "Vector3 / Double": """
+        let rhs = Float(rhs)
+        return Vector3(x: lhs.x / rhs, y: lhs.y / rhs, z: lhs.z / rhs)
+        """,
+    ]
+
+    // MARK: - Custom methods impl
+    private static let customBuiltinMethodImplementations: [MethodSignature: String] = [
+        // MARK: Vector3
+        "Vector3.dot": """
+        // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L206-L208
+        return Double(x * with.x + y * with.y + z * with.z)        
+        """,
+
+        "Vector3.cross": """
+        // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L197-L204
+        return Vector3(
+            x: (y * with.z) - (z * with.y),
+            y: (z * with.x) - (x * with.z),
+            z: (x * with.y) - (y * with.x)
+        )
+        """,
+
+        "Vector3.length": """
+        // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L476-L481
+        return sqrt(Double(x * x + y * y + z * z))   
+        """,
+
+        "Vector3.lengthSquared": """
+        // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L484-L489
+        return Double(x * x + y * y + z * z)
+        """,
+
+        "Vector3.distance": """
+        // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L292-L295
+        return Double((to - self).length())
+        """,
+    ]
+
 }
 
-// MARK: - Custom operators impl
-private let customBuiltinOperatorImplementations: [OperatorSignature: String] = [
-    // MARK: Vector3
-    "Vector3 * Vector3": """
-    return Vector3(x: lhs.x * rhs.x, y: lhs.y * rhs.y, z: lhs.z * rhs.z)
-    """,
-    
-    "Vector3 / Vector3": """
-    return Vector3(x: lhs.x / rhs.x, y: lhs.y / rhs.y, z: lhs.z / rhs.z)
-    """,
-    
-    "Vector3 + Vector3": """
-    return Vector3(x: lhs.x + rhs.x, y: lhs.y + rhs.y, z: lhs.z + rhs.z)
-    """,
-    
-    "Vector3 - Vector3": """
-    return Vector3(x: lhs.x - rhs.x, y: lhs.y - rhs.y, z: lhs.z - rhs.z)
-    """,
-        
-    "Vector3 * Double": """
-    let rhs = Float(rhs)
-    return Vector3(x: lhs.x * rhs, y: lhs.y * rhs, z: lhs.z * rhs)
-    """,
-    
-    "Vector3 / Double": """
-    let rhs = Float(rhs)
-    return Vector3(x: lhs.x / rhs, y: lhs.y / rhs, z: lhs.z / rhs)
-    """,
-]
-
-// MARK: - Custom methods impl
-private let customBuiltinMethodImplementations: [MethodSignature: String] = [
-    // MARK: Vector3
-    "Vector3.dot": """
-    // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L206-L208
-    return Double(x * with.x + y * with.y + z * with.z)        
-    """,
-    
-    "Vector3.cross": """
-    // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L197-L204
-    return Vector3(
-        x: (y * with.z) - (z * with.y),
-        y: (z * with.x) - (x * with.z),
-        z: (x * with.y) - (y * with.x)
-    )
-    """,
-    
-    "Vector3.length": """
-    // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L476-L481
-    return sqrt(Double(x * x + y * y + z * z))   
-    """,
-    
-    "Vector3.lengthSquared": """
-    // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L484-L489
-    return Double(x * x + y * y + z * z)
-    """,
-    
-    "Vector3.distance": """
-    // https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/core/math/vector3.h#L292-L295
-    return Double((to - self).length())
-    """,
-]

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -808,7 +808,7 @@ extension Generator {
                 }
 
                 if let enums = bc.enums {
-                    generateEnums(p, cdef: bc, values: enums, prefix: bc.name + ".")
+                    generateEnums(p, cdef: bc, values: enums)
                 }
                 generateBuiltinCtors (p, bc, bc.constructors, godotTypeName: bc.name, typeName: typeName, typeEnum: typeEnum, members: storedMembers)
 

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -8,10 +8,6 @@
 import Foundation
 import ExtensionApi
 
-// Populated with the types loaded from the api.json, we assume they are all reference types
-// anything else is not
-var referenceTypes: [String:Bool] = [:]
-
 // Maps a typename to its toplevel Json element
 var tree: [String: JGodotExtensionAPIClass] = [:]
 
@@ -477,11 +473,6 @@ var skipList = Set<String>()
 #endif
 
 func generateClasses (values: [JGodotExtensionAPIClass], outputDir: String?) async {
-    // TODO: duplicate, we can remove this and use classMap
-    // Assemble all the reference types, we use to test later
-    for cdef in values {
-        referenceTypes[cdef.name] = true
-    }
     // TODO: no longer used, probably can remove
     // Also a convenient hash to go from name to json
     // And track which types must be opened up
@@ -760,7 +751,7 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
 
 func generateCtorPointers (_ p: Printer) {
     p ("var godotFrameworkCtors = [")
-    for x in referenceTypes.keys.sorted() {
+    for x in classMap.keys.sorted() {
         p ("    \"\(x)\": \(x).self, //(nativeHandle:),")
     }
     p ("]")

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -8,9 +8,6 @@
 import Foundation
 import ExtensionApi
 
-// Maps a typename to its toplevel Json element
-var tree: [String: JGodotExtensionAPIClass] = [:]
-
 var typeToChildren: [String:[String]] = [:]
 
 func makeDefaultInit (godotType: String, initCollection: String = "") -> String {
@@ -477,8 +474,6 @@ func generateClasses (values: [JGodotExtensionAPIClass], outputDir: String?) asy
     // Also a convenient hash to go from name to json
     // And track which types must be opened up
     for cdef in values {
-        tree [cdef.name] = cdef
-        
         let base = cdef.inherits ?? ""
         if base != "" {
             if var v = typeToChildren [cdef.name] {

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -8,8 +8,6 @@
 import Foundation
 import ExtensionApi
 
-var typeToChildren: [String:[String]] = [:]
-
 func makeDefaultInit (godotType: String, initCollection: String = "") -> String {
     switch godotType {
     case "Variant":
@@ -470,31 +468,6 @@ var skipList = Set<String>()
 #endif
 
 func generateClasses (values: [JGodotExtensionAPIClass], outputDir: String?) async {
-    // TODO: no longer used, probably can remove
-    // Also a convenient hash to go from name to json
-    // And track which types must be opened up
-    for cdef in values {
-        let base = cdef.inherits ?? ""
-        if base != "" {
-            if var v = typeToChildren [cdef.name] {
-                v.append(cdef.inherits ?? "")
-            } else {
-                typeToChildren [cdef.name] = [cdef.inherits ?? ""]
-            }
-        }
-    }
-    
-    // Collect all the signals
-//    for cdef in values {
-//        if let signals = cdef.signals {
-//            for signal in signals {
-//                if signal.arguments! [0] == signal.arguments! [1] {
-//
-//                }
-//            }
-//        }
-//    }
-    
     await withTaskGroup(of: Void.self) { group in
         for cdef in values {
             group.addTask {

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -65,7 +65,7 @@ func makeDefaultReturn (godotType: String) -> String {
 }
 
 func argTypeNeedsCopy (godotType: String) -> Bool {
-    if isStructMap [godotType] ?? false {
+    if isStruct(godotType) {
         return true
     }
     if godotType.starts(with: "enum::") {
@@ -161,7 +161,7 @@ func generateVirtualProxy (_ p: Printer,
                 retPtr!.storeBytes(of: ret.content, as: Variant.ContentType.self)
                 ret?.content = Variant.zero
                 """)
-            } else if isStructMap [ret.type] ?? false || isStructMap [virtRet ?? "NON_EXIDTENT"] ?? false || ret.type.starts(with: "bitfield::"){
+            } else if isStruct(ret.type) || isStruct(virtRet ?? "NON_EXISTENT") || ret.type.starts(with: "bitfield::"){
                 p ("retPtr!.storeBytes (of: ret, as: \(virtRet!).self)")
             } else if ret.type.starts(with: "enum::") {
                 p ("retPtr!.storeBytes (of: Int32 (ret.rawValue), as: Int32.self)")

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -619,7 +619,7 @@ extension Generator {
             var referencedMethods = Set<String>()
 
             if let enums = cdef.enums {
-                generateEnums (p, cdef: cdef, values: enums, prefix: nil)
+                generateEnums (p, cdef: cdef, values: enums)
             }
 
             let oResult = p.result

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -749,10 +749,12 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
     }
 }
 
-func generateCtorPointers (_ p: Printer) {
-    p ("var godotFrameworkCtors = [")
-    for x in classMap.keys.sorted() {
-        p ("    \"\(x)\": \(x).self, //(nativeHandle:),")
+extension Generator {
+    func generateCtorPointers (_ p: Printer) {
+        p ("var godotFrameworkCtors = [")
+        for x in classMap.keys.sorted() {
+            p ("    \"\(x)\": \(x).self, //(nativeHandle:),")
+        }
+        p ("]")
     }
-    p ("]")
 }

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -8,6 +8,14 @@
 import Foundation
 import ExtensionApi
 
+#if false
+var okList: Set<String> = [ "RefCounted", "Node", "Sprite2D", "Node2D", "CanvasItem", "Object", "String", "StringName", "AStar2D", "Material", "Camera3D", "Node3D", "ProjectSettings", "MeshInstance3D", "BoxMesh", "SceneTree", "Window", "Label", "Timer", "AudioStreamPlayer", "PackedScene", "PathFollow2D", "InputEvent", "ClassDB", "AnimatedSprite2D", "Input", "CollisionShape2D", "SpriteFrames", "RigidBody2D" ]
+var skipList = Set<String>()
+#else
+var okList = Set<String>()
+var skipList = Set<String>()
+#endif
+
 func makeDefaultInit (godotType: String, initCollection: String = "") -> String {
     switch godotType {
     case "Variant":
@@ -68,137 +76,6 @@ func argTypeNeedsCopy (godotType: String) -> Bool {
     return false
 }
 
-func generateVirtualProxy (_ p: Printer,
-                           cdef: JGodotExtensionAPIClass,
-                           methodName: String,
-                           method: JGodotClassMethod) {
-    // Generate the glue for the virtual methods (those that start with an underscore in Godot
-    guard method.isVirtual else {
-        print ("ERROR: internally, we passed methods that are not virtual")
-        return
-    }
-    let virtRet: String?
-    var returnOptional = false
-    if let ret = method.returnValue {
-        let godotReturnType = ret.type
-        let godotReturnTypeIsReferenceType = classMap [godotReturnType] != nil
-        returnOptional = godotReturnTypeIsReferenceType && isReturnOptional(className: cdef.name, method: methodName)
-
-        virtRet = getGodotType(ret)
-    } else {
-        virtRet = nil
-    }
-    p ("func _\(cdef.name)_proxy\(method.name) (instance: UnsafeMutableRawPointer?, args: UnsafePointer<UnsafeRawPointer?>?, retPtr: UnsafeMutableRawPointer?)") {
-        p ("guard let instance else { return }")
-        if let arguments = method.arguments, arguments.count > 0 {
-            p ("guard let args else { return }")
-        }
-        p ("let swiftObject = Unmanaged<\(cdef.name)>.fromOpaque(instance).takeUnretainedValue()")
-        
-        var argCall = ""
-        var argPrep = ""
-        var i = 0
-        for arg in method.arguments ?? [] {
-            if argCall != "" { argCall += ", " }
-            let argName = escapeSwift (snakeToCamel (arg.name))
-            
-            // Drop the first argument name for methods whose name already include the argument
-            // name, like 'setMultiplayerPeer (peer: ..)' becomes 'setMultiplayerPeer (_ peer: ...)'
-            if i > 0 || !method.name.hasSuffix("_\(arg.name)") {
-                argCall += "\(argName): "
-            }
-            if arg.type == "String" {
-                argCall += "GString.stringFromGStringPtr (ptr: args [\(i)]!) ?? \"\""
-            } else if classMap [arg.type] != nil {
-                //
-                // This idiom guarantees that: if this is a known object, we surface this
-                // object, but if it is not known, then we create the instance
-                //
-                argPrep += "let resolved_\(i) = args [\(i)]!.load (as: UnsafeRawPointer.self)\n"
-                let handleResolver: String
-                if hasSubclasses.contains(cdef.name) {
-                    // If the type we are bubbling up has subclasses, we want to create the most
-                    // derived type if possible, so we perform the longer lookup
-                    handleResolver = "lookupObject (nativeHandle: resolved_\(i))!"
-                } else {
-                    // There are no subclasses, so we can create the object right away
-                    handleResolver = "\(arg.type) (nativeHandle: resolved_\(i))"
-                }
-                argCall += "lookupLiveObject (handleAddress: resolved_\(i)) as? \(arg.type) ?? \(handleResolver)"
-            } else if let storage = builtinClassStorage [arg.type] {
-                argCall += "\(mapTypeName (arg.type)) (content: args [\(i)]!.assumingMemoryBound (to: \(storage).self).pointee)"
-            } else {
-                let gt = getGodotType(arg)
-                argCall += "args [\(i)]!.assumingMemoryBound (to: \(gt).self).pointee"
-            }
-            i += 1
-        }
-        let hasReturn = method.returnValue != nil
-        if argPrep != "" {
-            p (argPrep)
-        }
-        var call = "swiftObject.\(methodName) (\(argCall))"
-        if method.returnValue?.type == "String" {
-            call = "GString (\(call))"
-        }
-        if hasReturn {
-            p ("let ret = \(call)")
-        } else {
-            p ("\(call)")
-        }
-        if let ret = method.returnValue {
-            if ret.type == "Variant" {
-                p("""
-                retPtr!.storeBytes(of: ret.content, as: Variant.ContentType.self)
-                ret?.content = Variant.zero
-                """)
-            } else if isStruct(ret.type) || isStruct(virtRet ?? "NON_EXISTENT") || ret.type.starts(with: "bitfield::"){
-                p ("retPtr!.storeBytes (of: ret, as: \(virtRet!).self)")
-            } else if ret.type.starts(with: "enum::") {
-                p ("retPtr!.storeBytes (of: Int32 (ret.rawValue), as: Int32.self)")
-            } else if ret.type.contains("*") {
-                p ("retPtr!.storeBytes (of: ret, as: OpaquePointer?.self)")
-            } else {
-                let derefField: String
-                let derefType: String
-                if ret.type.starts(with: "typedarray::") {
-                    derefField = "array.content"
-                    derefType = "type (of: ret.array.content)"
-                } else if classMap [ret.type] != nil {
-                    derefField = "handle"
-                    derefType = "UnsafeRawPointer?.self"
-                } else {
-                    derefField = "content"
-                    derefType = "type (of: ret.content)"
-                }
-                
-                let target: String
-                if ret.type.starts (with: "typedarray::") {
-                    target = "array.content"
-                } else {
-                    target = classMap [ret.type] != nil ? "handle" : "content"
-                }
-                p ("retPtr!.storeBytes (of: ret\(returnOptional ? "?" : "").\(derefField), as: \(derefType)) // \(ret.type)")
-                
-                // Poor man's transfer the ownership: we clear the content
-                // so the destructor has nothing to act on, because we are
-                // returning the reference to the other side.
-                if target == "content" {
-                    let type = getGodotType(SimpleType(type: ret.type))
-                    switch type {
-                    case "String":
-                        p ("ret.content = GString.zero")
-                    case "Array":
-                        p ("ret.content = GArray.zero")
-                    default:
-                        p ("ret.content = \(type).zero")
-                    }
-                }
-            }
-        }
-    }
-}
-
 // Dictioanry of Godot Type Name to array of method names that can get a @discardableResult
 // Notice that the type is looked up as the original Godot name, not
 // the mapped name (it is "Array", not "GArray"):
@@ -239,7 +116,7 @@ let omittedMethodsList: [String: Set<String>] = [
 ]
 
 // Dictionary used to explicitly tell the generator to replace the first argument label with "_ "
-let omittedFirstArgLabelList: [String: Set<String>] = [
+private let omittedFirstArgLabelList: [String: Set<String>] = [
     "GArray": ["append"],
     "PackedColorArray": ["append"],
     "PackedFloat64Array": ["append"],
@@ -247,7 +124,6 @@ let omittedFirstArgLabelList: [String: Set<String>] = [
     "PackedStringArray": ["append"],
     "PackedVector2Array": ["append"],
     "PackedVector3Array": ["append"],
-
 ]
 
 /// Determines if the first argument name should be replaced with an underscore.
@@ -263,455 +139,582 @@ func shouldOmitFirstArgLabel(typeName: String, methodName: String, argName: Stri
     return methodName.hasSuffix ("_\(argName)") || omittedFirstArgLabelList[typeName]?.contains(methodName) == true
 }
 
-///
-/// Returns a hashtable mapping a godot method name to a Swift Name + its definition
-/// this list is used to generate later the proxies outside the class
-///
-func generateMethods (_ p: Printer,
-                      cdef: JGodotExtensionAPIClass,
-                      methods: [JGodotClassMethod],
-                      usedMethods: Set<String>,
-                      asSingleton: Bool) -> [String:(String, JGodotClassMethod)] {
-    p ("/* Methods */")
-    
-    var virtuals: [String:(String, JGodotClassMethod)] = [:]
-   
-    for method in methods {
-        performExplaniningNonCriticalErrors {
-            if let virtualMethodName = try generateMethod (p, method: method, className: cdef.name, cdef: cdef, usedMethods: usedMethods, generatedMethodKind: .classMethod, asSingleton: asSingleton) {
-                virtuals[method.name] = (virtualMethodName, method)
-            }
-        }
-    }
-    
-    if virtuals.count > 0 {
-        p ("override class func getVirtualDispatcher (name: StringName) -> GDExtensionClassCallVirtual?"){
-            p ("guard implementedOverrides().contains(name) else { return nil }")
-            p ("switch name.description") {
-                for name in virtuals.keys.sorted() {
-                    p ("case \"\(name)\":")
-                    p ("    return _\(cdef.name)_proxy\(name)")
+extension Generator {
+
+    func generateClasses (values: [JGodotExtensionAPIClass], outputDir: String?) async {
+        await withTaskGroup(of: Void.self) { group in
+            for cdef in values {
+                group.addTask {
+                    await processClass (cdef: cdef, outputDir: outputDir)
                 }
-                p ("default:")
-                p ("    return super.getVirtualDispatcher (name: name)")
             }
         }
     }
-    return virtuals
-}
 
-func generateConstants (_ p: Printer,
-                        cdef: JGodotExtensionAPIClass,
-                        _ constants: [JGodotValueElement]) {
-    p ("/* Constants */")
-    
-    for constant in constants {
-        doc (p, cdef, constant.description)
-        p ("public static let \(snakeToCamel (constant.name)) = \(constant.value)")
-    }
-}
-func generateProperties (_ p: Printer,
-                         cdef: JGodotExtensionAPIClass,
-                         _ properties: [JGodotProperty],
-                         _ methods: [JGodotClassMethod],
-                         _ referencedMethods: inout Set<String>,
-                         asSingleton: Bool)
-{
-    p ("\n/* Properties */\n")
-
-    func findMethod (forProperty: JGodotProperty, startAt: JGodotExtensionAPIClass, name: String, resolvedName: inout String, argName: inout String) -> JGodotClassMethod? {
-        if let here = methods.first(where: { $0.name == name}) {
-            return here
+    private func generateVirtualProxy (_ p: Printer,
+                                       cdef: JGodotExtensionAPIClass,
+                                       methodName: String,
+                                       method: JGodotClassMethod) {
+        // Generate the glue for the virtual methods (those that start with an underscore in Godot
+        guard method.isVirtual else {
+            print ("ERROR: internally, we passed methods that are not virtual")
+            return
         }
-        var cdef: JGodotExtensionAPIClass? = startAt
-        while true {
-            guard let parentName = cdef?.inherits, parentName != "" else {
-                return nil
+        let virtRet: String?
+        var returnOptional = false
+        if let ret = method.returnValue {
+            let godotReturnType = ret.type
+            let godotReturnTypeIsReferenceType = classMap [godotReturnType] != nil
+            returnOptional = godotReturnTypeIsReferenceType && isReturnOptional(className: cdef.name, method: methodName)
+
+            virtRet = getGodotType(ret)
+        } else {
+            virtRet = nil
+        }
+        p ("func _\(cdef.name)_proxy\(method.name) (instance: UnsafeMutableRawPointer?, args: UnsafePointer<UnsafeRawPointer?>?, retPtr: UnsafeMutableRawPointer?)") {
+            p ("guard let instance else { return }")
+            if let arguments = method.arguments, arguments.count > 0 {
+                p ("guard let args else { return }")
             }
-            cdef = classMap [parentName]
-            guard let cdef else {
-                print ("Warning: Missing type \(parentName)")
-                return nil
+            p ("let swiftObject = Unmanaged<\(cdef.name)>.fromOpaque(instance).takeUnretainedValue()")
+
+            var argCall = ""
+            var argPrep = ""
+            var i = 0
+            for arg in method.arguments ?? [] {
+                if argCall != "" { argCall += ", " }
+                let argName = escapeSwift (snakeToCamel (arg.name))
+
+                // Drop the first argument name for methods whose name already include the argument
+                // name, like 'setMultiplayerPeer (peer: ..)' becomes 'setMultiplayerPeer (_ peer: ...)'
+                if i > 0 || !method.name.hasSuffix("_\(arg.name)") {
+                    argCall += "\(argName): "
+                }
+                if arg.type == "String" {
+                    argCall += "GString.stringFromGStringPtr (ptr: args [\(i)]!) ?? \"\""
+                } else if classMap [arg.type] != nil {
+                    //
+                    // This idiom guarantees that: if this is a known object, we surface this
+                    // object, but if it is not known, then we create the instance
+                    //
+                    argPrep += "let resolved_\(i) = args [\(i)]!.load (as: UnsafeRawPointer.self)\n"
+                    let handleResolver: String
+                    if hasSubclasses.contains(cdef.name) {
+                        // If the type we are bubbling up has subclasses, we want to create the most
+                        // derived type if possible, so we perform the longer lookup
+                        handleResolver = "lookupObject (nativeHandle: resolved_\(i))!"
+                    } else {
+                        // There are no subclasses, so we can create the object right away
+                        handleResolver = "\(arg.type) (nativeHandle: resolved_\(i))"
+                    }
+                    argCall += "lookupLiveObject (handleAddress: resolved_\(i)) as? \(arg.type) ?? \(handleResolver)"
+                } else if let storage = builtinClassStorage [arg.type] {
+                    argCall += "\(mapTypeName (arg.type)) (content: args [\(i)]!.assumingMemoryBound (to: \(storage).self).pointee)"
+                } else {
+                    let gt = getGodotType(arg)
+                    argCall += "args [\(i)]!.assumingMemoryBound (to: \(gt).self).pointee"
+                }
+                i += 1
             }
-            if let there = cdef.methods?.first (where: { $0.name == name }) {
-                //print ("Congrats, found a method that was previously missing!")
-                
-                // Now, if the parent class has a property referencing this,
-                // we use the mapped name, otherwise, we use the raw name
-                if cdef.properties?.contains(where: { $0.getter == there.name || $0.setter == there.name }) ?? false {
+            let hasReturn = method.returnValue != nil
+            if argPrep != "" {
+                p (argPrep)
+            }
+            var call = "swiftObject.\(methodName) (\(argCall))"
+            if method.returnValue?.type == "String" {
+                call = "GString (\(call))"
+            }
+            if hasReturn {
+                p ("let ret = \(call)")
+            } else {
+                p ("\(call)")
+            }
+            if let ret = method.returnValue {
+                if ret.type == "Variant" {
+                    p("""
+                retPtr!.storeBytes(of: ret.content, as: Variant.ContentType.self)
+                ret?.content = Variant.zero
+                """)
+                } else if isStruct(ret.type) || isStruct(virtRet ?? "NON_EXISTENT") || ret.type.starts(with: "bitfield::"){
+                    p ("retPtr!.storeBytes (of: ret, as: \(virtRet!).self)")
+                } else if ret.type.starts(with: "enum::") {
+                    p ("retPtr!.storeBytes (of: Int32 (ret.rawValue), as: Int32.self)")
+                } else if ret.type.contains("*") {
+                    p ("retPtr!.storeBytes (of: ret, as: OpaquePointer?.self)")
+                } else {
+                    let derefField: String
+                    let derefType: String
+                    if ret.type.starts(with: "typedarray::") {
+                        derefField = "array.content"
+                        derefType = "type (of: ret.array.content)"
+                    } else if classMap [ret.type] != nil {
+                        derefField = "handle"
+                        derefType = "UnsafeRawPointer?.self"
+                    } else {
+                        derefField = "content"
+                        derefType = "type (of: ret.content)"
+                    }
+
+                    let target: String
+                    if ret.type.starts (with: "typedarray::") {
+                        target = "array.content"
+                    } else {
+                        target = classMap [ret.type] != nil ? "handle" : "content"
+                    }
+                    p ("retPtr!.storeBytes (of: ret\(returnOptional ? "?" : "").\(derefField), as: \(derefType)) // \(ret.type)")
+
+                    // Poor man's transfer the ownership: we clear the content
+                    // so the destructor has nothing to act on, because we are
+                    // returning the reference to the other side.
+                    if target == "content" {
+                        let type = getGodotType(SimpleType(type: ret.type))
+                        switch type {
+                        case "String":
+                            p ("ret.content = GString.zero")
+                        case "Array":
+                            p ("ret.content = GArray.zero")
+                        default:
+                            p ("ret.content = \(type).zero")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ///
+    /// Returns a hashtable mapping a godot method name to a Swift Name + its definition
+    /// this list is used to generate later the proxies outside the class
+    ///
+    private func generateMethods (_ p: Printer,
+                                  cdef: JGodotExtensionAPIClass,
+                                  methods: [JGodotClassMethod],
+                                  usedMethods: Set<String>,
+                                  asSingleton: Bool) -> [String:(String, JGodotClassMethod)] {
+        p ("/* Methods */")
+
+        var virtuals: [String:(String, JGodotClassMethod)] = [:]
+
+        for method in methods {
+            performExplaniningNonCriticalErrors {
+                if let virtualMethodName = try generateMethod (p, method: method, className: cdef.name, cdef: cdef, usedMethods: usedMethods, generatedMethodKind: .classMethod, asSingleton: asSingleton) {
+                    virtuals[method.name] = (virtualMethodName, method)
+                }
+            }
+        }
+
+        if virtuals.count > 0 {
+            p ("override class func getVirtualDispatcher (name: StringName) -> GDExtensionClassCallVirtual?"){
+                p ("guard implementedOverrides().contains(name) else { return nil }")
+                p ("switch name.description") {
+                    for name in virtuals.keys.sorted() {
+                        p ("case \"\(name)\":")
+                        p ("    return _\(cdef.name)_proxy\(name)")
+                    }
+                    p ("default:")
+                    p ("    return super.getVirtualDispatcher (name: name)")
+                }
+            }
+        }
+        return virtuals
+    }
+
+    private func generateConstants (_ p: Printer,
+                                    cdef: JGodotExtensionAPIClass,
+                                    _ constants: [JGodotValueElement]) {
+        p ("/* Constants */")
+
+        for constant in constants {
+            doc (p, cdef, constant.description)
+            p ("public static let \(snakeToCamel (constant.name)) = \(constant.value)")
+        }
+    }
+
+    private func generateProperties (_ p: Printer,
+                                     cdef: JGodotExtensionAPIClass,
+                                     _ properties: [JGodotProperty],
+                                     _ methods: [JGodotClassMethod],
+                                     _ referencedMethods: inout Set<String>,
+                                     asSingleton: Bool)
+    {
+        p ("\n/* Properties */\n")
+
+        func findMethod (forProperty: JGodotProperty, startAt: JGodotExtensionAPIClass, name: String, resolvedName: inout String, argName: inout String) -> JGodotClassMethod? {
+            if let here = methods.first(where: { $0.name == name}) {
+                return here
+            }
+            var cdef: JGodotExtensionAPIClass? = startAt
+            while true {
+                guard let parentName = cdef?.inherits, parentName != "" else {
+                    return nil
+                }
+                cdef = classMap [parentName]
+                guard let cdef else {
+                    print ("Warning: Missing type \(parentName)")
+                    return nil
+                }
+                if let there = cdef.methods?.first (where: { $0.name == name }) {
+                    //print ("Congrats, found a method that was previously missing!")
+
+                    // Now, if the parent class has a property referencing this,
+                    // we use the mapped name, otherwise, we use the raw name
+                    if cdef.properties?.contains(where: { $0.getter == there.name || $0.setter == there.name }) ?? false {
+                        return there
+                    }
+                    resolvedName = godotMethodToSwift (there.name)
+                    if let aname = there.arguments?.first?.name {
+                        // Now check thta this argument does not need to be dropped
+                        if !there.name.hasSuffix("_\(aname)") {
+                            argName = aname + ": "
+                        }
+                    }
                     return there
                 }
-                resolvedName = godotMethodToSwift (there.name)
-                if let aname = there.arguments?.first?.name {
-                    // Now check thta this argument does not need to be dropped
-                    if !there.name.hasSuffix("_\(aname)") {
-                        argName = aname + ": "
-                    }
-                }
-                return there
             }
         }
-    }
-    
-    for property in properties {
-        var type: String?
-    
-        // Ignore properties that only have getters, just let the setter
-        // method be surfaced instead
-        if property.getter == "" {
-            print ("Property with only a setter: \(cdef.name).\(property.name)")
-            continue
-        }
-        if property.getter.starts(with: "_") {
-            // These exist, but have no equivalent method
-            // see VisualShaderNodeParameterRef._parameter_type as an example
-            continue
-        }
 
-//        // There are properties declared, but they do not actually exist
-//        // CurveTexture claims to have a get_width, but the method does not exist
-//        if type == nil {
-//            continue
-//        }
-//        if type!.hasPrefix("Vector3.Axis") {
-//            continue
-//        }
-        let loc = "\(cdef.name).\(property.name)"
-        
-        var getterName = property.getter
-        var gettterArgName = ""
-        guard let method = findMethod (forProperty: property, startAt: cdef, name: property.getter, resolvedName: &getterName, argName: &gettterArgName) else {
-            // Not a bug, but needs to be handled https://github.com/migueldeicaza/SwiftGodot/issues/67
-            //print ("GodotBug: \(loc): property declared \(property.getter), but it does not exist with that name")
-            continue
-        }
-        var setterName = property.setter ?? ""
-        var setterArgName = ""
-        var setterMethod: JGodotClassMethod? = nil
-        if let psetter = property.setter {
-            setterMethod = findMethod(forProperty: property, startAt: cdef, name: psetter, resolvedName: &setterName, argName: &setterArgName)
-            if setterMethod == nil {
-                // Not a bug, but needs to be handled: https://github.com/migueldeicaza/SwiftGodot/issues/67
-                //print ("GodotBug \(loc) property declared \(property.setter!) but it does not exist with that name")
+        for property in properties {
+            var type: String?
+
+            // Ignore properties that only have getters, just let the setter
+            // method be surfaced instead
+            if property.getter == "" {
+                print ("Property with only a setter: \(cdef.name).\(property.name)")
                 continue
             }
-        }
-
-        if method.arguments?.count ?? 0 > 1 {
-            print ("WARNING \(loc) property references a getter method that takes more than one argument")
-            continue
-        }
-        if setterMethod?.arguments?.count ?? 0 > 2 {
-            print ("WARNING \(loc) property references a getter method that takes more than two arguments")
-            continue
-        }
-        guard (method.returnValue?.type) != nil else {
-            print ("WARNING \(loc) Could not get a return type for method")
-            continue
-        }
-        let godotReturnType = method.returnValue?.type
-        let godotReturnTypeIsReferenceType = classMap [godotReturnType ?? ""] != nil
-
-        let propertyOptional = godotReturnType == "Variant" || godotReturnTypeIsReferenceType && isReturnOptional(className: cdef.name, method: property.getter)
-        
-        // Lookup the type from the method, not the property,
-        // sometimes the method is a GString, but the property is a StringName
-        type = getGodotType (method.returnValue) + (propertyOptional ? "?" : "")
-        
-
-        // Ok, we have an indexer, this means we call the property with an int
-        // but we need the type from the method
-        var access: String
-        if let idx = property.index {
-            let type = getGodotType(method.arguments! [0])
-            if type == "Int32" {
-                access = "\(idx)"
-            } else {
-                access = "\(type) (rawValue: \(idx))!"
+            if property.getter.starts(with: "_") {
+                // These exist, but have no equivalent method
+                // see VisualShaderNodeParameterRef._parameter_type as an example
+                continue
             }
-        } else {
-            access = ""
-        }
-        
-        if property.description != "" {
-            doc (p, cdef, property.description)
-        }
-        p ("\(asSingleton ? "static" : "final") public var \(godotPropertyToSwift (property.name)): \(type!)"){
-            p ("get"){
-                p ("return \(getterName) (\(gettterArgName)\(access))")
+
+            //        // There are properties declared, but they do not actually exist
+            //        // CurveTexture claims to have a get_width, but the method does not exist
+            //        if type == nil {
+            //            continue
+            //        }
+            //        if type!.hasPrefix("Vector3.Axis") {
+            //            continue
+            //        }
+            let loc = "\(cdef.name).\(property.name)"
+
+            var getterName = property.getter
+            var gettterArgName = ""
+            guard let method = findMethod (forProperty: property, startAt: cdef, name: property.getter, resolvedName: &getterName, argName: &gettterArgName) else {
+                // Not a bug, but needs to be handled https://github.com/migueldeicaza/SwiftGodot/issues/67
+                //print ("GodotBug: \(loc): property declared \(property.getter), but it does not exist with that name")
+                continue
             }
-            referencedMethods.insert (property.getter)
-            if let setter = property.setter {
-                p ("set") {
-                    var value = "newValue"
-                    if type == "StringName" && setterMethod?.arguments![0].type == "String" {
-                        value = "String (newValue)"
-                    }
-                    var ignore = ""
-                    if setterMethod?.returnValue != nil {
-                        ignore = "_ = "
-                    }
-                    p ("\(ignore)\(setterName) (\(access)\(access != "" ? ", " : "")\(setterArgName)\(value))")
+            var setterName = property.setter ?? ""
+            var setterArgName = ""
+            var setterMethod: JGodotClassMethod? = nil
+            if let psetter = property.setter {
+                setterMethod = findMethod(forProperty: property, startAt: cdef, name: psetter, resolvedName: &setterName, argName: &setterArgName)
+                if setterMethod == nil {
+                    // Not a bug, but needs to be handled: https://github.com/migueldeicaza/SwiftGodot/issues/67
+                    //print ("GodotBug \(loc) property declared \(property.setter!) but it does not exist with that name")
+                    continue
                 }
-                referencedMethods.insert (setter)
             }
-        }
-    }
-}
 
-#if false
-var okList: Set<String> = [ "RefCounted", "Node", "Sprite2D", "Node2D", "CanvasItem", "Object", "String", "StringName", "AStar2D", "Material", "Camera3D", "Node3D", "ProjectSettings", "MeshInstance3D", "BoxMesh", "SceneTree", "Window", "Label", "Timer", "AudioStreamPlayer", "PackedScene", "PathFollow2D", "InputEvent", "ClassDB", "AnimatedSprite2D", "Input", "CollisionShape2D", "SpriteFrames", "RigidBody2D" ]
-var skipList = Set<String>()
-#else
-var okList = Set<String>()
-var skipList = Set<String>()
-#endif
-
-func generateClasses (values: [JGodotExtensionAPIClass], outputDir: String?) async {
-    await withTaskGroup(of: Void.self) { group in
-        for cdef in values {
-            group.addTask {
-                await processClass (cdef: cdef, outputDir: outputDir)
+            if method.arguments?.count ?? 0 > 1 {
+                print ("WARNING \(loc) property references a getter method that takes more than one argument")
+                continue
             }
-        }
-    }
-}
-
-func generateSignalType (_ p: Printer, _ cdef: JGodotExtensionAPIClass, _ signal: JGodotSignal, _ name: String) -> String {
-    doc (p, cdef, "Signal support.\n")
-    doc (p, cdef, "Use the ``\(name)/connect(flags:_:)`` method to connect to the signal on the container object, and ``\(name)/disconnect(_:)`` to drop the connection.\nYou can also await the ``\(name)/emitted`` property for waiting for a single emission of the signal.")
-    
-    var lambdaFull = ""
-    p ("public class \(name)") {
-        p ("var target: Object")
-        p ("var signalName: StringName")
-        p ("init (target: Object, signalName: StringName)") {
-            p ("self.target = target")
-            p ("self.signalName = signalName")
-        }
-        doc (p, cdef, "Connects the signal to the specified callback\n\nTo disconnect, call the disconnect method, with the returned token on success\n - Parameters:\n  - callback: the method to invoke when this signal is raised\n  - flags: Optional, can be also added to configure the connection's behavior (see ``Object/ConnectFlags`` constants).\n - Returns: an object token that can be used to disconnect the object from the target on success, or the error produced by Godot.")
-        
-        p ("@discardableResult /* \(name) */")
-        var args = ""
-        var argUnwrap = ""
-        var callArgs = ""
-        var argIdx = 0
-        var lambdaIgnore = ""
-        for arg in signal.arguments ?? [] {
-            if args != "" {
-                args += ", "
-                callArgs += ", "
-                lambdaIgnore += ", "
-                lambdaFull += ", "
+            if setterMethod?.arguments?.count ?? 0 > 2 {
+                print ("WARNING \(loc) property references a getter method that takes more than two arguments")
+                continue
             }
-            args += getArgumentDeclaration(arg, omitLabel: true, isOptional: arg.type == "Variant")
-            let construct: String
-            
-            if let _ = classMap [arg.type] {
-                argUnwrap += "var ptr_\(argIdx): UnsafeMutableRawPointer?\n"
-                argUnwrap += "args [\(argIdx)]!.toType (Variant.GType.object, dest: &ptr_\(argIdx))\n"
-                let handleResolver: String
-                if hasSubclasses.contains(cdef.name) {
-                    // If the type we are bubbling up has subclasses, we want to create the most
-                    // derived type if possible, so we perform the longer lookup
-                    handleResolver = "lookupObject (nativeHandle: ptr_\(argIdx)!) ?? "
+            guard (method.returnValue?.type) != nil else {
+                print ("WARNING \(loc) Could not get a return type for method")
+                continue
+            }
+            let godotReturnType = method.returnValue?.type
+            let godotReturnTypeIsReferenceType = classMap [godotReturnType ?? ""] != nil
+
+            let propertyOptional = godotReturnType == "Variant" || godotReturnTypeIsReferenceType && isReturnOptional(className: cdef.name, method: property.getter)
+
+            // Lookup the type from the method, not the property,
+            // sometimes the method is a GString, but the property is a StringName
+            type = getGodotType (method.returnValue) + (propertyOptional ? "?" : "")
+
+
+            // Ok, we have an indexer, this means we call the property with an int
+            // but we need the type from the method
+            var access: String
+            if let idx = property.index {
+                let type = getGodotType(method.arguments! [0])
+                if type == "Int32" {
+                    access = "\(idx)"
                 } else {
-                    handleResolver = ""
+                    access = "\(type) (rawValue: \(idx))!"
                 }
-                
-                construct = "lookupLiveObject (handleAddress: ptr_\(argIdx)!) as? \(arg.type) ?? \(handleResolver)\(arg.type) (nativeHandle: ptr_\(argIdx)!)"
-            } else if arg.type == "String" {
-                    construct = "\(mapTypeName(arg.type)) (args [\(argIdx)]!)!.description"
-            } else if arg.type == "Variant" {
-                construct = "args [\(argIdx)]"
             } else {
-                construct = "\(getGodotType(arg)) (args [\(argIdx)]!)!"
+                access = ""
             }
-            argUnwrap += "let arg_\(argIdx) = \(construct)\n"
-            callArgs += "arg_\(argIdx)"
-            lambdaIgnore += "_"
-            lambdaFull += escapeSwift (snakeToCamel (arg.name))
-            argIdx += 1
-        }
-        p ("public func connect (flags: Object.ConnectFlags = [], _ callback: @escaping (\(args)) -> ()) -> Object") {
-            p ("let signalProxy = SignalProxy()")
-            p ("signalProxy.proxy = ") {
-                p ("args in")
-                p (argUnwrap)
-                p ("callback (\(callArgs))")
-            }
-            p ("let callable = Callable(object: signalProxy, method: SignalProxy.proxyName)")
-            p ("let r = target.connect(signal: signalName, callable: callable, flags: UInt32 (flags.rawValue))")
-            p ("if r != .ok { print (\"Warning, error connecting to signal, code: \\(r)\") }")
-            p ("return signalProxy")
-        }
 
-        doc (p, cdef, "Disconnects a signal that was previously connected, the return value from calling ``connect(flags:_:)``")
-        p ("public func disconnect (_ token: Object)") {
-            p ("target.disconnect(signal: signalName, callable: Callable (object: token, method: SignalProxy.proxyName))")
-        }
-        doc (p, cdef, "You can await this property to wait for the signal to be emitted once")
-        p ("public var emitted: Void "){
-            p ("get async") {
-                p ("await withCheckedContinuation") {
-                    p ("c in")
-                    p ("connect (flags: .oneShot) { \(lambdaIgnore) in c.resume () }")
+            if property.description != "" {
+                doc (p, cdef, property.description)
+            }
+            p ("\(asSingleton ? "static" : "final") public var \(godotPropertyToSwift (property.name)): \(type!)"){
+                p ("get"){
+                    p ("return \(getterName) (\(gettterArgName)\(access))")
+                }
+                referencedMethods.insert (property.getter)
+                if let setter = property.setter {
+                    p ("set") {
+                        var value = "newValue"
+                        if type == "StringName" && setterMethod?.arguments![0].type == "String" {
+                            value = "String (newValue)"
+                        }
+                        var ignore = ""
+                        if setterMethod?.returnValue != nil {
+                            ignore = "_ = "
+                        }
+                        p ("\(ignore)\(setterName) (\(access)\(access != "" ? ", " : "")\(setterArgName)\(value))")
+                    }
+                    referencedMethods.insert (setter)
                 }
             }
         }
     }
-    return lambdaFull
-}
 
-func generateSignals (_ p: Printer,
-                      cdef: JGodotExtensionAPIClass,
-                      signals: [JGodotSignal]) {
-    p ("// Signals ")
-    var parameterSignals: [JGodotSignal] = []
-    var sidx = 0
-    
-    for signal in signals {
-        let signalProxyType: String
-        let lambdaSig: String
-        if signal.arguments != nil {
-            parameterSignals.append (signal)
-            
-            sidx += 1
-            signalProxyType = "Signal\(sidx)"
-            lambdaSig = " " + generateSignalType (p, cdef, signal, signalProxyType) + " in"
-        } else {
-            signalProxyType = "SimpleSignal"
-            lambdaSig = ""
-        }
-        let signalName = godotMethodToSwift (signal.name)
-        
-        doc (p, cdef, signal.description)
-        p ("///")
-        doc (p, cdef, "To connect to this signal, reference this property and call the\n`connect` method with the method you want to invoke\n")
-        doc (p, cdef, "Example:")
-        doc (p, cdef, "```swift")
-        doc (p, cdef, "obj.\(signalName).connect {\(lambdaSig)")
-        p ("///    print (\"caught signal\")\n/// }")
-        doc (p, cdef, "```")
-        p ("public var \(signalName): \(signalProxyType) { \(signalProxyType) (target: self, signalName: \"\(signal.name)\") }")
-        p ("")
-    }
-}
+    private func generateSignalType (_ p: Printer, _ cdef: JGodotExtensionAPIClass, _ signal: JGodotSignal, _ name: String) -> String {
+        doc (p, cdef, "Signal support.\n")
+        doc (p, cdef, "Use the ``\(name)/connect(flags:_:)`` method to connect to the signal on the container object, and ``\(name)/disconnect(_:)`` to drop the connection.\nYou can also await the ``\(name)/emitted`` property for waiting for a single emission of the signal.")
 
-func generateSignalDocAppendix (_ p: Printer, cdef: JGodotExtensionAPIClass, signals: [JGodotSignal]?) {
-    guard let signals = signals, signals.count > 0 else {
-        return
-    }
-    if signals.count > 0 {
-        doc (p, cdef, "\nThis object emits the following signals:")
-    } else {
-        doc (p, cdef, "\nThis object emits this signal:")
-    }
-    for signal in signals {
-        let signalName = godotMethodToSwift (signal.name)
-        doc (p, cdef, "- ``\(signalName)``")
-    }
-}
+        var lambdaFull = ""
+        p ("public class \(name)") {
+            p ("var target: Object")
+            p ("var signalName: StringName")
+            p ("init (target: Object, signalName: StringName)") {
+                p ("self.target = target")
+                p ("self.signalName = signalName")
+            }
+            doc (p, cdef, "Connects the signal to the specified callback\n\nTo disconnect, call the disconnect method, with the returned token on success\n - Parameters:\n  - callback: the method to invoke when this signal is raised\n  - flags: Optional, can be also added to configure the connection's behavior (see ``Object/ConnectFlags`` constants).\n - Returns: an object token that can be used to disconnect the object from the target on success, or the error produced by Godot.")
 
-func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
-    // Determine if it is a singleton, but exclude EditorInterface
-    let isSingleton = jsonApi.singletons.contains (where: { $0.name == cdef.name })
-    let asSingleton = isSingleton && cdef.name != "EditorInterface"
-    
-    // Clear the result
-    let p = await PrinterFactory.shared.initPrinter(cdef.name)
-    p.preamble()
-    p ("// Generated by Swift code generator - do not edit\n@_implementationOnly import GDExtension\n")
-    
-    // Save it
-    defer {
-        if let outputDir {
-            p.save(outputDir + "\(cdef.name).swift")
-        }
-    }
-    
-    let inherits = cdef.inherits ?? "Wrapped"
-    let typeDecl = "open class \(cdef.name): \(inherits)"
-    
-    var virtuals: [String: (String, JGodotClassMethod)] = [:]
-    if cdef.brief_description == "" {
-        if cdef.description != "" {
-            doc (p, cdef, cdef.description)
-        }
-    } else {
-        doc (p, cdef, cdef.brief_description)
-        if cdef.description != "" {
-            doc (p, cdef, "")      // Add a newline before the fuller description
-            doc (p, cdef, cdef.description)
-        }
-    }
-    
-    generateSignalDocAppendix (p, cdef: cdef, signals: cdef.signals)
-    // class or extension (for Object)
-    p (typeDecl) {
-        if isSingleton {
-            p ("/// The shared instance of this class")
-            p.staticVar(visibility: "public ", name: "shared", type: cdef.name) {
-                p ("return withUnsafePointer (to: &\(cdef.name).godotClassName.content)", arg: " ptr in") {
+            p ("@discardableResult /* \(name) */")
+            var args = ""
+            var argUnwrap = ""
+            var callArgs = ""
+            var argIdx = 0
+            var lambdaIgnore = ""
+            for arg in signal.arguments ?? [] {
+                if args != "" {
+                    args += ", "
+                    callArgs += ", "
+                    lambdaIgnore += ", "
+                    lambdaFull += ", "
+                }
+                args += getArgumentDeclaration(arg, omitLabel: true, isOptional: arg.type == "Variant")
+                let construct: String
+
+                if let _ = classMap [arg.type] {
+                    argUnwrap += "var ptr_\(argIdx): UnsafeMutableRawPointer?\n"
+                    argUnwrap += "args [\(argIdx)]!.toType (Variant.GType.object, dest: &ptr_\(argIdx))\n"
+                    let handleResolver: String
                     if hasSubclasses.contains(cdef.name) {
-                        p ("lookupObject (nativeHandle: gi.global_get_singleton (ptr)!)!")
+                        // If the type we are bubbling up has subclasses, we want to create the most
+                        // derived type if possible, so we perform the longer lookup
+                        handleResolver = "lookupObject (nativeHandle: ptr_\(argIdx)!) ?? "
                     } else {
-                        p ("\(cdef.name) (nativeHandle: gi.global_get_singleton (ptr)!)")
+                        handleResolver = ""
+                    }
+
+                    construct = "lookupLiveObject (handleAddress: ptr_\(argIdx)!) as? \(arg.type) ?? \(handleResolver)\(arg.type) (nativeHandle: ptr_\(argIdx)!)"
+                } else if arg.type == "String" {
+                    construct = "\(mapTypeName(arg.type)) (args [\(argIdx)]!)!.description"
+                } else if arg.type == "Variant" {
+                    construct = "args [\(argIdx)]"
+                } else {
+                    construct = "\(getGodotType(arg)) (args [\(argIdx)]!)!"
+                }
+                argUnwrap += "let arg_\(argIdx) = \(construct)\n"
+                callArgs += "arg_\(argIdx)"
+                lambdaIgnore += "_"
+                lambdaFull += escapeSwift (snakeToCamel (arg.name))
+                argIdx += 1
+            }
+            p ("public func connect (flags: Object.ConnectFlags = [], _ callback: @escaping (\(args)) -> ()) -> Object") {
+                p ("let signalProxy = SignalProxy()")
+                p ("signalProxy.proxy = ") {
+                    p ("args in")
+                    p (argUnwrap)
+                    p ("callback (\(callArgs))")
+                }
+                p ("let callable = Callable(object: signalProxy, method: SignalProxy.proxyName)")
+                p ("let r = target.connect(signal: signalName, callable: callable, flags: UInt32 (flags.rawValue))")
+                p ("if r != .ok { print (\"Warning, error connecting to signal, code: \\(r)\") }")
+                p ("return signalProxy")
+            }
+
+            doc (p, cdef, "Disconnects a signal that was previously connected, the return value from calling ``connect(flags:_:)``")
+            p ("public func disconnect (_ token: Object)") {
+                p ("target.disconnect(signal: signalName, callable: Callable (object: token, method: SignalProxy.proxyName))")
+            }
+            doc (p, cdef, "You can await this property to wait for the signal to be emitted once")
+            p ("public var emitted: Void "){
+                p ("get async") {
+                    p ("await withCheckedContinuation") {
+                        p ("c in")
+                        p ("connect (flags: .oneShot) { \(lambdaIgnore) in c.resume () }")
                     }
                 }
             }
         }
-        p ("override open class var godotClassName: StringName { \"\(cdef.name)\" }")
+        return lambdaFull
+    }
 
-        if cdef.name == "RefCounted" {
-            p ("public required init ()") {
-                p ("super.init ()")
-                p ("_ = initRef()")
-            }
-            p ("public required init(nativeHandle: UnsafeRawPointer)") {
-                p ("super.init (nativeHandle: nativeHandle)")
-                p ("reference()")
-                p ("ownsHandle = true")
-            }
-        }
-        var referencedMethods = Set<String>()
-        
-        if let enums = cdef.enums {
-            generateEnums (p, cdef: cdef, values: enums, prefix: nil)
-        }
-        
-        let oResult = p.result
-        
-        if let constants = cdef.constants {
-            generateConstants (p, cdef: cdef, constants)
-        }
-        
-        if let properties = cdef.properties {
-            generateProperties (p, cdef: cdef, properties, cdef.methods ?? [], &referencedMethods, asSingleton: asSingleton)
-        }
-        if let methods = cdef.methods {
-            virtuals = generateMethods (p, cdef: cdef, methods: methods, usedMethods: referencedMethods, asSingleton: asSingleton)
-        }
-        
-        if let signals = cdef.signals {
-            generateSignals (p, cdef: cdef, signals: signals)
-        }
+    private func generateSignals (_ p: Printer,
+                                  cdef: JGodotExtensionAPIClass,
+                                  signals: [JGodotSignal]) {
+        p ("// Signals ")
+        var parameterSignals: [JGodotSignal] = []
+        var sidx = 0
 
-        // Remove code that we did not want generated
-        if skipList.contains (cdef.name) || (okList.count > 0 && !okList.contains (cdef.name)) {
-            p.result = oResult
+        for signal in signals {
+            let signalProxyType: String
+            let lambdaSig: String
+            if signal.arguments != nil {
+                parameterSignals.append (signal)
+
+                sidx += 1
+                signalProxyType = "Signal\(sidx)"
+                lambdaSig = " " + generateSignalType (p, cdef, signal, signalProxyType) + " in"
+            } else {
+                signalProxyType = "SimpleSignal"
+                lambdaSig = ""
+            }
+            let signalName = godotMethodToSwift (signal.name)
+
+            doc (p, cdef, signal.description)
+            p ("///")
+            doc (p, cdef, "To connect to this signal, reference this property and call the\n`connect` method with the method you want to invoke\n")
+            doc (p, cdef, "Example:")
+            doc (p, cdef, "```swift")
+            doc (p, cdef, "obj.\(signalName).connect {\(lambdaSig)")
+            p ("///    print (\"caught signal\")\n/// }")
+            doc (p, cdef, "```")
+            p ("public var \(signalName): \(signalProxyType) { \(signalProxyType) (target: self, signalName: \"\(signal.name)\") }")
+            p ("")
         }
     }
 
-    if virtuals.count > 0 {
-        p ("// Support methods for proxies")
-        for k in virtuals.keys.sorted () {
-            guard let (methodName, methodDef) = virtuals [k] else {
-                print ("Internal error: in processClass \(cdef.name)")
-                continue
+    private func generateSignalDocAppendix (_ p: Printer, cdef: JGodotExtensionAPIClass, signals: [JGodotSignal]?) {
+        guard let signals = signals, signals.count > 0 else {
+            return
+        }
+        if signals.count > 0 {
+            doc (p, cdef, "\nThis object emits the following signals:")
+        } else {
+            doc (p, cdef, "\nThis object emits this signal:")
+        }
+        for signal in signals {
+            let signalName = godotMethodToSwift (signal.name)
+            doc (p, cdef, "- ``\(signalName)``")
+        }
+    }
+
+    private func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
+        // Determine if it is a singleton, but exclude EditorInterface
+        let isSingleton = jsonApi.singletons.contains (where: { $0.name == cdef.name })
+        let asSingleton = isSingleton && cdef.name != "EditorInterface"
+
+        // Clear the result
+        let p = await PrinterFactory.shared.initPrinter(cdef.name)
+        p.preamble()
+        p ("// Generated by Swift code generator - do not edit\n@_implementationOnly import GDExtension\n")
+
+        // Save it
+        defer {
+            if let outputDir {
+                p.save(outputDir + "\(cdef.name).swift")
             }
-            if !skipList.contains (cdef.name) && (okList.count == 0 || okList.contains (cdef.name)) {
-                generateVirtualProxy(p, cdef: cdef, methodName: methodName, method: methodDef)
+        }
+
+        let inherits = cdef.inherits ?? "Wrapped"
+        let typeDecl = "open class \(cdef.name): \(inherits)"
+
+        var virtuals: [String: (String, JGodotClassMethod)] = [:]
+        if cdef.brief_description == "" {
+            if cdef.description != "" {
+                doc (p, cdef, cdef.description)
+            }
+        } else {
+            doc (p, cdef, cdef.brief_description)
+            if cdef.description != "" {
+                doc (p, cdef, "")      // Add a newline before the fuller description
+                doc (p, cdef, cdef.description)
+            }
+        }
+
+        generateSignalDocAppendix (p, cdef: cdef, signals: cdef.signals)
+        // class or extension (for Object)
+        p (typeDecl) {
+            if isSingleton {
+                p ("/// The shared instance of this class")
+                p.staticVar(visibility: "public ", name: "shared", type: cdef.name) {
+                    p ("return withUnsafePointer (to: &\(cdef.name).godotClassName.content)", arg: " ptr in") {
+                        if hasSubclasses.contains(cdef.name) {
+                            p ("lookupObject (nativeHandle: gi.global_get_singleton (ptr)!)!")
+                        } else {
+                            p ("\(cdef.name) (nativeHandle: gi.global_get_singleton (ptr)!)")
+                        }
+                    }
+                }
+            }
+            p ("override open class var godotClassName: StringName { \"\(cdef.name)\" }")
+
+            if cdef.name == "RefCounted" {
+                p ("public required init ()") {
+                    p ("super.init ()")
+                    p ("_ = initRef()")
+                }
+                p ("public required init(nativeHandle: UnsafeRawPointer)") {
+                    p ("super.init (nativeHandle: nativeHandle)")
+                    p ("reference()")
+                    p ("ownsHandle = true")
+                }
+            }
+            var referencedMethods = Set<String>()
+
+            if let enums = cdef.enums {
+                generateEnums (p, cdef: cdef, values: enums, prefix: nil)
+            }
+
+            let oResult = p.result
+
+            if let constants = cdef.constants {
+                generateConstants (p, cdef: cdef, constants)
+            }
+
+            if let properties = cdef.properties {
+                generateProperties (p, cdef: cdef, properties, cdef.methods ?? [], &referencedMethods, asSingleton: asSingleton)
+            }
+            if let methods = cdef.methods {
+                virtuals = generateMethods (p, cdef: cdef, methods: methods, usedMethods: referencedMethods, asSingleton: asSingleton)
+            }
+
+            if let signals = cdef.signals {
+                generateSignals (p, cdef: cdef, signals: signals)
+            }
+
+            // Remove code that we did not want generated
+            if skipList.contains (cdef.name) || (okList.count > 0 && !okList.contains (cdef.name)) {
+                p.result = oResult
+            }
+        }
+
+        if virtuals.count > 0 {
+            p ("// Support methods for proxies")
+            for k in virtuals.keys.sorted () {
+                guard let (methodName, methodDef) = virtuals [k] else {
+                    print ("Internal error: in processClass \(cdef.name)")
+                    continue
+                }
+                if !skipList.contains (cdef.name) && (okList.count == 0 || okList.contains (cdef.name)) {
+                    generateVirtualProxy(p, cdef: cdef, methodName: methodName, method: methodDef)
+                }
             }
         }
     }

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -16,66 +16,6 @@ var okList = Set<String>()
 var skipList = Set<String>()
 #endif
 
-func makeDefaultInit (godotType: String, initCollection: String = "") -> String {
-    switch godotType {
-    case "Variant":
-        return "nil"
-    case "int":
-        return "0"
-    case "float":
-        return "0.0"
-    case "bool":
-        return "false"
-    case "String":
-        return "String ()"
-    case "Array":
-        return "GArray ()"
-    case "Dictionary":
-        return "GDictionary ()"
-    case let t where t.starts (with: "typedarray::"):
-        let nestedTypeName = String (t.dropFirst(12))
-        let simple = SimpleType(type: nestedTypeName)
-        if classMap [nestedTypeName] != nil {
-            return "ObjectCollection<\(getGodotType (simple))>(\(initCollection))"
-        } else {
-            return "VariantCollection<\(getGodotType (simple))>(\(initCollection))"
-        }
-    case "enum::Error":
-        return ".ok"
-    case "enum::Variant.Type":
-        return ".`nil`"
-    case let e where e.starts (with: "enum::"):
-        return "\(e.dropFirst(6))(rawValue: 0)!"
-    case let e where e.starts (with: "bitfield::"):
-        let simple = SimpleType (type: godotType, meta: nil)
-        return "\(getGodotType (simple)) ()"
-   
-    case let other where builtinGodotTypeNames [other] != nil:
-        return "\(godotType) ()"
-    case "void*", "const Glyph*":
-        return "nil"
-    default:
-        return "\(getGodotType(SimpleType (type: godotType))) ()"
-    }
-}
-
-func makeDefaultReturn (godotType: String) -> String {
-    return "return \(makeDefaultInit(godotType: godotType))"
-}
-
-func argTypeNeedsCopy (godotType: String) -> Bool {
-    if isStruct(godotType) {
-        return true
-    }
-    if godotType.starts(with: "enum::") {
-        return true
-    }
-    if godotType.starts(with: "bitfield::") {
-        return true
-    }
-    return false
-}
-
 // Dictioanry of Godot Type Name to array of method names that can get a @discardableResult
 // Notice that the type is looked up as the original Godot name, not
 // the mapped name (it is "Array", not "GArray"):

--- a/Generator/Generator/DocModel.swift
+++ b/Generator/Generator/DocModel.swift
@@ -34,269 +34,271 @@ func splitAtLastDot (str: String.SubSequence) -> (String, String) {
     }
 }
 
+extension Generator {
 // Attributes to handle:
 // [NAME] is a type reference
 // [b]..[/b] bold
 // [method name] is a method reference, should apply the remapping we do
 // 
-func doc (_ p: Printer, _ cdef: JClassInfo?, _ text: String?) {
-    guard let text else { return }
-//    guard ProcessInfo.processInfo.environment ["GENERATE_DOCS"] != nil else {
-//        return
-//    }
-    
-    func lookupConstant (_ txt: String.SubSequence) -> String {
-        func lookInDef (def: JClassInfo, match: String, local: Bool) -> String? {
-            // TODO: for builtins, we wont have a cdef
-            for ed in def.enums ?? [] {
-                for vp in ed.values {
-                    if vp.name == match {
-                        let enumCasePrefix = ed.values.commonPrefix()
-                        let name = vp.name.dropPrefix(enumCasePrefix)
-                        //let name = dropMatchingPrefix(enumCasePrefix, vp.name)
-                        if local && false{
-                            return ".\(escapeSwift (name))"
-                        } else {
-                            return getGodotType(SimpleType (type: "enum::" + ed.name)) + "/" + escapeSwift (snakeToCamel (name))
-                        }
-                    }
-                }
-            }
-            
-            if let cdef = def as? JGodotExtensionAPIClass {
-                for x in cdef.constants ?? [] {
-                    if match == x.name {
-                        return "\(snakeToCamel (x.name))"
-                    }
-                }
-            }
+    func doc (_ p: Printer, _ cdef: JClassInfo?, _ text: String?) {
+        guard let text else { return }
+    //    guard ProcessInfo.processInfo.environment ["GENERATE_DOCS"] != nil else {
+    //        return
+    //    }
 
-            if let cdef = def as? JGodotBuiltinClass {
-                for x in cdef.constants ?? [] {
-                    if match == x.name {
-                        return "\(snakeToCamel (x.name))"
-                    }
-                }
-            }
-            return nil
-        }
-
-        if let cdef {
-            if let result = lookInDef(def: cdef, match: String(txt), local: true) {
-                return "``\(result)``"
-            }
-        }
-        for ed in jsonApi.globalEnums {
-            for ev in ed.values {
-                if ev.name == txt {
-                    var type = ""
-                    var lookup = ed.name
-                    if let dot = ed.name.lastIndex(of: ".") {
-                        let containerType = String (ed.name [ed.name.startIndex..<dot])
-                        type = getGodotType (SimpleType (type: containerType)) + "."
-                        lookup = String (ed.name [ed.name.index(dot, offsetBy: 1)...])
-                    }
-                    let name = dropMatchingPrefix(lookup, ev.name)
-                    
-                    return "``\(type)\(getGodotType (SimpleType (type: lookup)))/\(escapeSwift(String (name)))``"
-                }
-            }
-        }
-        let (type, name) = splitAtLastDot(str: txt)
-        if type != "" {
-            if let ldef = classMap [type] {
-                if let r = lookInDef(def: ldef, match: name, local: false) {
-                    return "``\(getGodotType(SimpleType (type: type)) + "/" + r)``"
-                }
-            } else if let ldef = builtinMap[type] {
-                if let r = lookInDef(def: ldef, match: name, local: false) {
-                    return "``\(getGodotType(SimpleType (type: type)) + "/" + r)``"
-                }
-            }
-        }
-        
-        return "``\(txt)``"
-    }
-    
-    // If this is a Type.Name returns "Type", "Name"
-    // If this is Type it returns (nil, "Name")
-    func typeSplit (txt: String.SubSequence) -> (String?, String) {
-        if let dot = txt.firstIndex(of: ".") {
-            let rest = String (txt [text.index(dot, offsetBy: 1)...])
-            let typeBare = txt [txt.startIndex..<dot]
-            return (mapTypeName(String(typeBare)), rest)
-        }
-        return (nil, String (txt))
-    }
-
-    func assembleArgs (_ optMethod: JGodotClassMethod?, _ arguments: [JGodotArgument]?) -> String {
-        var args = ""
-        
-        // Assemble argument names
-        var i = 0
-        for arg in arguments ?? [] {
-            if optMethod != nil && i == 0 && optMethod!.name.hasSuffix(arg.name) {
-                args.append ("_")
-            } else {
-                args.append(godotArgumentToSwift(arg.name))
-            }
-            args.append(":")
-            i += 1
-        }
-        return args
-    }
-    
-    func convertMethod (_ txt: String.SubSequence) -> String {
-        if txt.starts(with: "@") {
-            // TODO, examples:
-            // @GlobalScope.remap
-            // @GDScript.load
-
-            return String (txt)
-        }
-        
-        func findMethod (name: String, on: JGodotExtensionAPIClass) -> JGodotClassMethod? {
-            on.methods?.first(where: { x in x.name == name })
-        }
-        func findMethod (name: String, on: JGodotBuiltinClass) -> JGodotBuiltinClassMethod? {
-            on.methods?.first(where: { x in x.name == name })
-        }
-        
-        let (type, member) = typeSplit(txt: txt)
-        
-        var args = ""
-        if let type {
-            if let m = classMap [type] {
-                if let method = findMethod (name: member, on: m) {
-                    args = assembleArgs (method, method.arguments)
-                }
-            } else if let m = builtinMap [type] {
-                if let method = findMethod (name: member, on: m) {
-                    args = assembleArgs(nil, method.arguments)
-                }
-            }
-            return "\(type)/\(godotMethodToSwift(member))(\(args))"
-        } else {
-            if let apiDef = cdef as? JGodotExtensionAPIClass {
-                if let method = findMethod(name: member, on: apiDef) {
-                    args = assembleArgs (method, method.arguments)
-                }
-            } else if let builtinDef = cdef as? JGodotBuiltinClass {
-                if let method = findMethod(name: member, on: builtinDef) {
-                    args = assembleArgs (nil, method.arguments)
-                }
-            }
-        }
-          
-        
-        return "\(godotMethodToSwift(member))(\(args))"
-    }
-
-    func convertMember (_ txt: String.SubSequence) -> String {
-        let (type, member) = typeSplit(txt: txt)
-        if let type {
-            return "\(type)/\(godotMethodToSwift(member))"
-        }
-        return godotPropertyToSwift(member)
-    }
-
-    let oIndent = p.indentStr
-    p.indentStr = "\(p.indentStr)/// "
-    
-    var inCodeBlock = false
-    let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
-    for x in lines {
-        if x.contains ("[codeblock") {
-            inCodeBlock = true
-            continue
-        }
-        if x.contains ("[/codeblock") {
-            inCodeBlock = false
-            continue
-        }
-        if inCodeBlock { continue }
-        
-        var mod = x
-        if #available(macOS 13.0, iOS 16.0, *) {
-            // Replaces [params X] with `X`
-            mod = mod.replacing(rxConstantParam, with: { x in
-                switch x.output.1 {
-                case "param":
-                    let pname = godotArgumentToSwift (String(x.output.2))
-                    if pname.starts(with: "`") {
-                        // Do not escape parameters that are already escaped, Swift wont know
-                        return pname
-                    }
-                    return "`\(pname)`"
-                case "constant":
-                    return lookupConstant (x.output.2)
-                default:
-                    print ("Doc: Error, unexpected \(x.output.1) tag")
-                    return "[\(x.output.1) \(x.output.2)]"
-                }
-            })
-            mod = mod.replacing(rxEnumMethodMember, with: { x in
-                switch x.output.1 {
-                case "method":
-                    if x.output.2 == "Object._notification" {
-                        return "``Wrapper._notification(code:reverse)``"
-                    }
-                    return "``\(convertMethod (x.output.2))``"
-                case "member":
-                    // Same as method for now?
-                    return "``\(convertMember(x.output.2))``"
-                case "enum":
-                    if let cdef {
-                        if let enums = cdef.enums {
-                            // If it is a local enum
-                            if enums.contains(where: { $0.name == x.output.2 }) {
-                                return "``\(cdef.name)/\(x.output.2)``"
+        func lookupConstant (_ txt: String.SubSequence) -> String {
+            func lookInDef (def: JClassInfo, match: String, local: Bool) -> String? {
+                // TODO: for builtins, we wont have a cdef
+                for ed in def.enums ?? [] {
+                    for vp in ed.values {
+                        if vp.name == match {
+                            let enumCasePrefix = ed.values.commonPrefix()
+                            let name = vp.name.dropPrefix(enumCasePrefix)
+                            //let name = dropMatchingPrefix(enumCasePrefix, vp.name)
+                            if local && false{
+                                return ".\(escapeSwift (name))"
+                            } else {
+                                return getGodotType(SimpleType (type: "enum::" + ed.name)) + "/" + escapeSwift (snakeToCamel (name))
                             }
                         }
                     }
-                    return "``\(getGodotType(SimpleType(type: "enum::" + x.output.2)))``"
-                    
-                default:
-                    print ("Doc: Error, unexpected \(x.output.1) tag")
-                    return "[\(x.output.1) \(x.output.2)]"
                 }
-            })
-            
-            mod = mod.replacing(rxUrl, with: { x in
-                let word = x.output.1
-                let resolved = word.replacing("$DOCS_URL", with: "https://docs.godotengine.org/en/")
-                
-                return "<a href=\"\(resolved)\">"
-            })
-            
-            // [FirstLetterIsUpperCase] is a reference to a type
-            mod = mod.replacing(rxTypeName, with: { x in
-                let word = x.output.1
-                return "``\(mapTypeNameDoc (String (word)))``"
-            })
-            // To avoid the greedy problem, it happens above, but not as much
-            mod = mod.replacing("[b]Note:[/b]", with: "> Note:")
-            mod = mod.replacing("[int]", with: "integer")
-            mod = mod.replacing("[float]", with: "float")
-            mod = mod.replacing("[b]Warning:[/b]", with: "> Warning:")
-            mod = mod.replacing("[i]", with: "_")
-            mod = mod.replacing("[/i]", with: "_")
-            mod = mod.replacing("[b]", with: "**")
-            mod = mod.replacing("[/b]", with: "**")
-            mod = mod.replacing("[code]", with: "`")
-            mod = mod.replacing("[/code]", with: "`")
-            mod = mod.replacing("[/url]", with: "</a>")
-            mod = mod.trimmingPrefix(rxEmptyLeading)
-            // TODO
-            // [member X]
-            // [signal X]
-            
+
+                if let cdef = def as? JGodotExtensionAPIClass {
+                    for x in cdef.constants ?? [] {
+                        if match == x.name {
+                            return "\(snakeToCamel (x.name))"
+                        }
+                    }
+                }
+
+                if let cdef = def as? JGodotBuiltinClass {
+                    for x in cdef.constants ?? [] {
+                        if match == x.name {
+                            return "\(snakeToCamel (x.name))"
+                        }
+                    }
+                }
+                return nil
+            }
+
+            if let cdef {
+                if let result = lookInDef(def: cdef, match: String(txt), local: true) {
+                    return "``\(result)``"
+                }
+            }
+            for ed in jsonApi.globalEnums {
+                for ev in ed.values {
+                    if ev.name == txt {
+                        var type = ""
+                        var lookup = ed.name
+                        if let dot = ed.name.lastIndex(of: ".") {
+                            let containerType = String (ed.name [ed.name.startIndex..<dot])
+                            type = getGodotType (SimpleType (type: containerType)) + "."
+                            lookup = String (ed.name [ed.name.index(dot, offsetBy: 1)...])
+                        }
+                        let name = dropMatchingPrefix(lookup, ev.name)
+
+                        return "``\(type)\(getGodotType (SimpleType (type: lookup)))/\(escapeSwift(String (name)))``"
+                    }
+                }
+            }
+            let (type, name) = splitAtLastDot(str: txt)
+            if type != "" {
+                if let ldef = classMap [type] {
+                    if let r = lookInDef(def: ldef, match: name, local: false) {
+                        return "``\(getGodotType(SimpleType (type: type)) + "/" + r)``"
+                    }
+                } else if let ldef = builtinMap[type] {
+                    if let r = lookInDef(def: ldef, match: name, local: false) {
+                        return "``\(getGodotType(SimpleType (type: type)) + "/" + r)``"
+                    }
+                }
+            }
+
+            return "``\(txt)``"
         }
-        if lines.count > 1 {
-            p (String (mod)+"\n")
-        } else {
-            p (String (mod))
+
+        // If this is a Type.Name returns "Type", "Name"
+        // If this is Type it returns (nil, "Name")
+        func typeSplit (txt: String.SubSequence) -> (String?, String) {
+            if let dot = txt.firstIndex(of: ".") {
+                let rest = String (txt [text.index(dot, offsetBy: 1)...])
+                let typeBare = txt [txt.startIndex..<dot]
+                return (mapTypeName(String(typeBare)), rest)
+            }
+            return (nil, String (txt))
         }
+
+        func assembleArgs (_ optMethod: JGodotClassMethod?, _ arguments: [JGodotArgument]?) -> String {
+            var args = ""
+
+            // Assemble argument names
+            var i = 0
+            for arg in arguments ?? [] {
+                if optMethod != nil && i == 0 && optMethod!.name.hasSuffix(arg.name) {
+                    args.append ("_")
+                } else {
+                    args.append(godotArgumentToSwift(arg.name))
+                }
+                args.append(":")
+                i += 1
+            }
+            return args
+        }
+
+        func convertMethod (_ txt: String.SubSequence) -> String {
+            if txt.starts(with: "@") {
+                // TODO, examples:
+                // @GlobalScope.remap
+                // @GDScript.load
+
+                return String (txt)
+            }
+
+            func findMethod (name: String, on: JGodotExtensionAPIClass) -> JGodotClassMethod? {
+                on.methods?.first(where: { x in x.name == name })
+            }
+            func findMethod (name: String, on: JGodotBuiltinClass) -> JGodotBuiltinClassMethod? {
+                on.methods?.first(where: { x in x.name == name })
+            }
+
+            let (type, member) = typeSplit(txt: txt)
+
+            var args = ""
+            if let type {
+                if let m = classMap [type] {
+                    if let method = findMethod (name: member, on: m) {
+                        args = assembleArgs (method, method.arguments)
+                    }
+                } else if let m = builtinMap [type] {
+                    if let method = findMethod (name: member, on: m) {
+                        args = assembleArgs(nil, method.arguments)
+                    }
+                }
+                return "\(type)/\(godotMethodToSwift(member))(\(args))"
+            } else {
+                if let apiDef = cdef as? JGodotExtensionAPIClass {
+                    if let method = findMethod(name: member, on: apiDef) {
+                        args = assembleArgs (method, method.arguments)
+                    }
+                } else if let builtinDef = cdef as? JGodotBuiltinClass {
+                    if let method = findMethod(name: member, on: builtinDef) {
+                        args = assembleArgs (nil, method.arguments)
+                    }
+                }
+            }
+
+
+            return "\(godotMethodToSwift(member))(\(args))"
+        }
+
+        func convertMember (_ txt: String.SubSequence) -> String {
+            let (type, member) = typeSplit(txt: txt)
+            if let type {
+                return "\(type)/\(godotMethodToSwift(member))"
+            }
+            return godotPropertyToSwift(member)
+        }
+
+        let oIndent = p.indentStr
+        p.indentStr = "\(p.indentStr)/// "
+
+        var inCodeBlock = false
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        for x in lines {
+            if x.contains ("[codeblock") {
+                inCodeBlock = true
+                continue
+            }
+            if x.contains ("[/codeblock") {
+                inCodeBlock = false
+                continue
+            }
+            if inCodeBlock { continue }
+
+            var mod = x
+            if #available(macOS 13.0, iOS 16.0, *) {
+                // Replaces [params X] with `X`
+                mod = mod.replacing(rxConstantParam, with: { x in
+                    switch x.output.1 {
+                    case "param":
+                        let pname = godotArgumentToSwift (String(x.output.2))
+                        if pname.starts(with: "`") {
+                            // Do not escape parameters that are already escaped, Swift wont know
+                            return pname
+                        }
+                        return "`\(pname)`"
+                    case "constant":
+                        return lookupConstant (x.output.2)
+                    default:
+                        print ("Doc: Error, unexpected \(x.output.1) tag")
+                        return "[\(x.output.1) \(x.output.2)]"
+                    }
+                })
+                mod = mod.replacing(rxEnumMethodMember, with: { x in
+                    switch x.output.1 {
+                    case "method":
+                        if x.output.2 == "Object._notification" {
+                            return "``Wrapper._notification(code:reverse)``"
+                        }
+                        return "``\(convertMethod (x.output.2))``"
+                    case "member":
+                        // Same as method for now?
+                        return "``\(convertMember(x.output.2))``"
+                    case "enum":
+                        if let cdef {
+                            if let enums = cdef.enums {
+                                // If it is a local enum
+                                if enums.contains(where: { $0.name == x.output.2 }) {
+                                    return "``\(cdef.name)/\(x.output.2)``"
+                                }
+                            }
+                        }
+                        return "``\(getGodotType(SimpleType(type: "enum::" + x.output.2)))``"
+
+                    default:
+                        print ("Doc: Error, unexpected \(x.output.1) tag")
+                        return "[\(x.output.1) \(x.output.2)]"
+                    }
+                })
+
+                mod = mod.replacing(rxUrl, with: { x in
+                    let word = x.output.1
+                    let resolved = word.replacing("$DOCS_URL", with: "https://docs.godotengine.org/en/")
+
+                    return "<a href=\"\(resolved)\">"
+                })
+
+                // [FirstLetterIsUpperCase] is a reference to a type
+                mod = mod.replacing(rxTypeName, with: { x in
+                    let word = x.output.1
+                    return "``\(mapTypeNameDoc (String (word)))``"
+                })
+                // To avoid the greedy problem, it happens above, but not as much
+                mod = mod.replacing("[b]Note:[/b]", with: "> Note:")
+                mod = mod.replacing("[int]", with: "integer")
+                mod = mod.replacing("[float]", with: "float")
+                mod = mod.replacing("[b]Warning:[/b]", with: "> Warning:")
+                mod = mod.replacing("[i]", with: "_")
+                mod = mod.replacing("[/i]", with: "_")
+                mod = mod.replacing("[b]", with: "**")
+                mod = mod.replacing("[/b]", with: "**")
+                mod = mod.replacing("[code]", with: "`")
+                mod = mod.replacing("[/code]", with: "`")
+                mod = mod.replacing("[/url]", with: "</a>")
+                mod = mod.trimmingPrefix(rxEmptyLeading)
+                // TODO
+                // [member X]
+                // [signal X]
+
+            }
+            if lines.count > 1 {
+                p (String (mod)+"\n")
+            } else {
+                p (String (mod))
+            }
+        }
+        p.indentStr = oIndent
     }
-    p.indentStr = oIndent
 }

--- a/Generator/Generator/DocModel.swift
+++ b/Generator/Generator/DocModel.swift
@@ -302,3 +302,23 @@ extension Generator {
         p.indentStr = oIndent
     }
 }
+
+private func dropMatchingPrefix (_ enumName: String, _ enumKey: String) -> String {
+    let snake = snakeToCamel (enumKey)
+    if snake.lowercased().starts(with: enumName.lowercased()) {
+        if snake.count == enumName.count {
+            return snake
+        }
+        let ret = String (snake [snake.index (snake.startIndex, offsetBy: enumName.count)...])
+        if let f = ret.first {
+            if f.isNumber {
+                return snake
+            }
+        }
+        if ret == "" {
+            return snake
+        }
+        return ret.first!.lowercased() + ret.dropFirst()
+    }
+    return snake
+}

--- a/Generator/Generator/Enums.swift
+++ b/Generator/Generator/Enums.swift
@@ -5,123 +5,123 @@
 //  Created by Miguel de Icaza on 4/19/23.
 //
 
-import Foundation
 import ExtensionApi
 
 /// Those cases don't bring anything but confusion, we don't need to export them at all
-let droppedCases: Set<String> = [
+private let droppedCases: Set<String> = [
     "Variant.Type.TYPE_MAX"
 ]
 
-func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumElement], prefix: String?) {
-    for enumDef in values {
-        let isBitField = enumDef.isBitfield ?? false
-        
-        var enumDefName = enumDef.name
-        let enumCasePrefix = enumDef.values.commonPrefix()
-        
-        if isBitField || enumDef.name == "ConnectFlags" {
-            let optionTypeName = getGodotType (SimpleType (type: enumDef.name))
-            var optionNames: [String] = []
-            p ("public struct \(optionTypeName): OptionSet, CustomDebugStringConvertible") {
-                p ("public let rawValue: Int")
-                p ("public init (rawValue: Int)") {
-                    p ("self.rawValue = rawValue")
+extension Generator {
+    func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumElement], prefix: String?) {
+        for enumDef in values {
+            let isBitField = enumDef.isBitfield ?? false
+
+            var enumDefName = enumDef.name
+            let enumCasePrefix = enumDef.values.commonPrefix()
+
+            if isBitField || enumDef.name == "ConnectFlags" {
+                let optionTypeName = getGodotType (SimpleType (type: enumDef.name))
+                var optionNames: [String] = []
+                p ("public struct \(optionTypeName): OptionSet, CustomDebugStringConvertible") {
+                    p ("public let rawValue: Int")
+                    p ("public init (rawValue: Int)") {
+                        p ("self.rawValue = rawValue")
+                    }
+                    for enumVal in enumDef.values {
+                        // These can be replaced with the empty set, and we avoid a warning
+                        if enumVal.value == 0 {
+                            continue
+                        }
+
+                        let name = snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix))
+                        doc (p, cdef, enumVal.description)
+                        let optionName = escapeSwift (name)
+                        optionNames.append(optionName)
+                        p ("public static let \(optionName) = \(enumDef.name) (rawValue: \(enumVal.value))")
+                    }
+
+                    p ("/// A textual representation of this instance, suitable for debugging")
+                    p ("public var debugDescription: String") {
+                        p ("var result = \"\"")
+                        for on in optionNames {
+                            p ("if self.contains (.\(on)) { result += \"\(on), \" }")
+                        }
+                        p ("if result.hasSuffix (\", \") { result.removeLast (2) }")
+                        p ("return result")
+                    }
                 }
+                continue
+            }
+
+            if enumDefName.starts(with: "Variant") {
+                p ("extension Variant {")
+                p.indent += 1
+                enumDefName = String (enumDefName.dropFirst("Variant.".count))
+            }
+            let extraConformances = enumDefName == "Error" ? ", Error" : ""
+
+            p ("public enum \(getGodotType (SimpleType (type: enumDefName))): Int64, CaseIterable, CustomDebugStringConvertible\(extraConformances)") {
+                var used = Set<Int> ()
+
+                func getName (_ enumVal: JGodotValueElement) -> String? {
+                    let enumValName = enumVal.name
+                    if enumDefName == "InlineAlignment" {
+                        if enumValName == "INLINE_ALIGNMENT_TOP_TO" || enumValName == "INLINE_ALIGNMENT_TO_TOP" ||
+                            enumValName == "INLINE_ALIGNMENT_IMAGE_MASK" || enumValName == "INLINE_ALIGNMENT_TEXT_MASK" {
+                            return nil
+                        }
+                    }
+                    return snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix))
+                }
+
+                var debugLines: [String] = []
                 for enumVal in enumDef.values {
-                    // These can be replaced with the empty set, and we avoid a warning
-                    if enumVal.value == 0 {
+                    if droppedCases.contains("\(enumDef.name).\(enumVal.name)") {
                         continue
                     }
 
-                    let name = snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix))
+                    guard let name = getName (enumVal) else { continue }
+                    let prefix: String
+                    if used.contains(enumVal.value) {
+                        prefix = "// "
+                    } else {
+                        prefix = ""
+                    }
+                    used.insert(enumVal.value)
+
                     doc (p, cdef, enumVal.description)
-                    let optionName = escapeSwift (name)
-                    optionNames.append(optionName)
-                    p ("public static let \(optionName) = \(enumDef.name) (rawValue: \(enumVal.value))")
+                    let enumName = escapeSwift(name)
+                    if "\(enumDef.name).\(enumVal.name)" == "Variant.Type.TYPE_NIL" {
+                        p("/// This case resurfaces during internal bridging of some operators and you will never encounter it")
+                    }
+                    p ("\(prefix)case \(enumName) = \(enumVal.value) // \(enumVal.name)")
+
+                    if prefix == "" {
+                        debugLines.append ("case .\(enumName): return \".\(enumName)\"")
+                    }
                 }
-                
+
                 p ("/// A textual representation of this instance, suitable for debugging")
                 p ("public var debugDescription: String") {
-                    p ("var result = \"\"")
-                    for on in optionNames {
-                        p ("if self.contains (.\(on)) { result += \"\(on), \" }")
-                    }
-                    p ("if result.hasSuffix (\", \") { result.removeLast (2) }")
-                    p ("return result")
-                }
-            }
-            continue
-        }
-        
-        if enumDefName.starts(with: "Variant") {
-            p ("extension Variant {")
-            p.indent += 1
-            enumDefName = String (enumDefName.dropFirst("Variant.".count))
-        }
-        let extraConformances = enumDefName == "Error" ? ", Error" : ""
-        
-        p ("public enum \(getGodotType (SimpleType (type: enumDefName))): Int64, CaseIterable, CustomDebugStringConvertible\(extraConformances)") {
-            var used = Set<Int> ()
-            
-            func getName (_ enumVal: JGodotValueElement) -> String? {
-                let enumValName = enumVal.name
-                if enumDefName == "InlineAlignment" {
-                    if enumValName == "INLINE_ALIGNMENT_TOP_TO" || enumValName == "INLINE_ALIGNMENT_TO_TOP" ||
-                        enumValName == "INLINE_ALIGNMENT_IMAGE_MASK" || enumValName == "INLINE_ALIGNMENT_TEXT_MASK" {
-                        return nil
+                    p ("switch self") {
+                        for line in debugLines {
+                            p (line)
+                        }
                     }
                 }
-                return snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix))
-            }
-
-            var debugLines: [String] = []
-            for enumVal in enumDef.values {
-                if droppedCases.contains("\(enumDef.name).\(enumVal.name)") {
-                    continue
-                }
-                                
-                guard let name = getName (enumVal) else { continue }
-                let prefix: String
-                if used.contains(enumVal.value) {
-                    prefix = "// "
-                } else {
-                    prefix = ""
-                }
-                used.insert(enumVal.value)
-
-                doc (p, cdef, enumVal.description)
-                let enumName = escapeSwift(name)
-                if "\(enumDef.name).\(enumVal.name)" == "Variant.Type.TYPE_NIL" {
-                    p("/// This case resurfaces during internal bridging of some operators and you will never encounter it")
-                }
-                p ("\(prefix)case \(enumName) = \(enumVal.value) // \(enumVal.name)")
-
-                if prefix == "" {
-                    debugLines.append ("case .\(enumName): return \".\(enumName)\"")
+                if enumDefName == "Error" {
+                    /// Provides the description of the error.
+                    p ("public var localizedDescription: String { GD.errorString(error: self.rawValue) }")
                 }
             }
-            
-            p ("/// A textual representation of this instance, suitable for debugging")
-            p ("public var debugDescription: String") {
-                p ("switch self") {
-                    for line in debugLines {
-                        p (line)
-                    }
-                }
+            if enumDef.name.starts (with: "Variant") {
+                p.indent -= 1
+                p ("}\n")
             }
-            if enumDefName == "Error" {
-                /// Provides the description of the error.
-                p ("public var localizedDescription: String { GD.errorString(error: self.rawValue) }")
+            if let prefix {
+                globalEnums [prefix + enumDef.name] = enumDef
             }
-        }
-        if enumDef.name.starts (with: "Variant") {
-            p.indent -= 1
-            p ("}\n")
-        }
-        if let prefix {
-            globalEnums [prefix + enumDef.name] = enumDef
         }
     }
 }
-

--- a/Generator/Generator/Enums.swift
+++ b/Generator/Generator/Enums.swift
@@ -13,7 +13,7 @@ private let droppedCases: Set<String> = [
 ]
 
 extension Generator {
-    func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumElement], prefix: String?) {
+    func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumElement]) {
         for enumDef in values {
             let isBitField = enumDef.isBitfield ?? false
 
@@ -118,9 +118,6 @@ extension Generator {
             if enumDef.name.starts (with: "Variant") {
                 p.indent -= 1
                 p ("}\n")
-            }
-            if let prefix {
-                globalEnums [prefix + enumDef.name] = enumDef
             }
         }
     }

--- a/Generator/Generator/Enums.swift
+++ b/Generator/Generator/Enums.swift
@@ -8,35 +8,6 @@
 import Foundation
 import ExtensionApi
 
-// The name of the form 'bitfield::'
-func findEnumDef (name: String) -> JGodotGlobalEnumElement? {
-    guard name.starts(with: "bitfield::") else {
-        return nil
-    }
-
-    let full = name.dropFirst(10)
-    guard let split = full.firstIndex(of: ".") else {
-        print ("No support for global bitfields for \(name)")
-        return nil
-    }
-    let type = full [full.startIndex..<split]
-    guard let cdef = classMap [String (type)] else {
-        print ("Could not find class \(type) for \(name)")
-        return nil
-    }
-    let enumName = full [full.index(split, offsetBy: 1)...]
-    guard let enums = cdef.enums else {
-        print ("Could not find an enum \(enumName) in \(type)")
-        return nil
-    }
-    for x in enums {
-        if x.name == enumName {
-            return x
-        }
-    }
-    return nil
-}
-
 /// Those cases don't bring anything but confusion, we don't need to export them at all
 let droppedCases: Set<String> = [
     "Variant.Type.TYPE_MAX"

--- a/Generator/Generator/Generator.swift
+++ b/Generator/Generator/Generator.swift
@@ -47,6 +47,7 @@ let generateResettableCache = false
 //skipList.insert("OpenXRInterface")
 //#endif
 
+@main
 struct GeneratorCommand: AsyncParsableCommand {
     @Flag(
         help: "Generator all output to a single Swift file. Possibly useful on Windows."
@@ -205,12 +206,3 @@ struct Generator {
         }
     }
 }
-
-let semaphore = DispatchSemaphore(value: 0)
-let _ = Task {
-    defer { semaphore.signal() }
-    await GeneratorCommand.main()
-}
-semaphore.wait()
-
-//print ("Done")

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -238,7 +238,7 @@ struct MethodArgument {
                     } else {
                         if generator.builtinSizes[src.type] != nil && src.type != "Object" {
                             translation = .contentRef
-                        } else if classMap[src.type] != nil {                            
+                        } else if generator.classMap[src.type] != nil {                            
                             if options.contains(.nonOptionalObjects) {
                                 translation = .objectRef(isOptional: false)
                             } else {

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -123,7 +123,7 @@ extension Generator {
             typeName: typeName,
             methodName: methodName,
             options: options,
-            builtinSizes: builtinSizes
+            generator: self
         )
     }
 }
@@ -198,7 +198,7 @@ struct MethodArgument {
         typeName: String,
         methodName: String,
         options: TranslationOptions,
-        builtinSizes: [String: Int]
+        generator: Generator
     ) throws {
         func makeError(reason: String) -> MethodGenError {
             MethodGenError.unsupportedArgument(typeName: typeName, methodName: methodName, argumentName: src.name, argumentTypeName: src.type, reason: reason)
@@ -236,7 +236,7 @@ struct MethodArgument {
                     if isStruct(src.type) {
                         translation = .direct
                     } else {
-                        if builtinSizes[src.type] != nil && src.type != "Object" {
+                        if generator.builtinSizes[src.type] != nil && src.type != "Object" {
                             translation = .contentRef
                         } else if classMap[src.type] != nil {                            
                             if options.contains(.nonOptionalObjects) {

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -230,7 +230,7 @@ struct MethodArgument {
                     translation = .string
                 } else if options.contains(.floatToDouble) && src.type == "float" {
                     translation = .directPromoted(to: "Double")
-                } else if options.contains(.smallIntToInt) && isSmallInt(src) {
+                } else if options.contains(.smallIntToInt) && generator.isSmallInt(src) {
                     translation = .directPromoted(to: "Int")
                 } else {
                     if generator.isStruct(src.type) {
@@ -272,6 +272,20 @@ struct MethodArgument {
             default:
                 throw makeError(reason: "Too many tokens separated by '::'")
             }
+        }
+    }
+}
+
+extension Generator {
+    fileprivate func isSmallInt(_ arg: JGodotArgument) -> Bool {
+        if arg.type != "int" {
+            return false
+        }
+        switch getGodotType(arg, kind: .classes) {
+        case "Int32", "UInt32", "Int16", "UInt16", "Int8", "UInt8":
+            return true
+        default:
+            return false
         }
     }
 }

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -857,3 +857,63 @@ func generateMethod(_ p: Printer, method: MethodDefinition, className: String, c
     }
     return registerVirtualMethodName
 }
+
+private func makeDefaultInit (godotType: String, initCollection: String = "") -> String {
+    switch godotType {
+    case "Variant":
+        return "nil"
+    case "int":
+        return "0"
+    case "float":
+        return "0.0"
+    case "bool":
+        return "false"
+    case "String":
+        return "String ()"
+    case "Array":
+        return "GArray ()"
+    case "Dictionary":
+        return "GDictionary ()"
+    case let t where t.starts (with: "typedarray::"):
+        let nestedTypeName = String (t.dropFirst(12))
+        let simple = SimpleType(type: nestedTypeName)
+        if classMap [nestedTypeName] != nil {
+            return "ObjectCollection<\(getGodotType (simple))>(\(initCollection))"
+        } else {
+            return "VariantCollection<\(getGodotType (simple))>(\(initCollection))"
+        }
+    case "enum::Error":
+        return ".ok"
+    case "enum::Variant.Type":
+        return ".`nil`"
+    case let e where e.starts (with: "enum::"):
+        return "\(e.dropFirst(6))(rawValue: 0)!"
+    case let e where e.starts (with: "bitfield::"):
+        let simple = SimpleType (type: godotType, meta: nil)
+        return "\(getGodotType (simple)) ()"
+   
+    case let other where builtinGodotTypeNames [other] != nil:
+        return "\(godotType) ()"
+    case "void*", "const Glyph*":
+        return "nil"
+    default:
+        return "\(getGodotType(SimpleType (type: godotType))) ()"
+    }
+}
+
+private func makeDefaultReturn (godotType: String) -> String {
+    return "return \(makeDefaultInit(godotType: godotType))"
+}
+
+private func argTypeNeedsCopy (godotType: String) -> Bool {
+    if isStruct(godotType) {
+        return true
+    }
+    if godotType.starts(with: "enum::") {
+        return true
+    }
+    if godotType.starts(with: "bitfield::") {
+        return true
+    }
+    return false
+}

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -938,15 +938,18 @@ private func makeDefaultReturn (godotType: String) -> String {
     return "return \(makeDefaultInit(godotType: godotType))"
 }
 
-private func argTypeNeedsCopy (godotType: String) -> Bool {
-    if isStruct(godotType) {
-        return true
+extension Generator {
+    private func argTypeNeedsCopy (godotType: String) -> Bool {
+        if isStruct(godotType) {
+            return true
+        }
+        if godotType.starts(with: "enum::") {
+            return true
+        }
+        if godotType.starts(with: "bitfield::") {
+            return true
+        }
+        return false
     }
-    if godotType.starts(with: "enum::") {
-        return true
-    }
-    if godotType.starts(with: "bitfield::") {
-        return true
-    }
-    return false
 }
+

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -903,56 +903,54 @@ extension Generator {
         }
         return registerVirtualMethodName
     }
-}
 
-private func makeDefaultInit (godotType: String, initCollection: String = "") -> String {
-    switch godotType {
-    case "Variant":
-        return "nil"
-    case "int":
-        return "0"
-    case "float":
-        return "0.0"
-    case "bool":
-        return "false"
-    case "String":
-        return "String ()"
-    case "Array":
-        return "GArray ()"
-    case "Dictionary":
-        return "GDictionary ()"
-    case let t where t.starts (with: "typedarray::"):
-        let nestedTypeName = String (t.dropFirst(12))
-        let simple = SimpleType(type: nestedTypeName)
-        if classMap [nestedTypeName] != nil {
-            return "ObjectCollection<\(getGodotType (simple))>(\(initCollection))"
-        } else {
-            return "VariantCollection<\(getGodotType (simple))>(\(initCollection))"
+    private func makeDefaultInit (godotType: String, initCollection: String = "") -> String {
+        switch godotType {
+        case "Variant":
+            return "nil"
+        case "int":
+            return "0"
+        case "float":
+            return "0.0"
+        case "bool":
+            return "false"
+        case "String":
+            return "String ()"
+        case "Array":
+            return "GArray ()"
+        case "Dictionary":
+            return "GDictionary ()"
+        case let t where t.starts (with: "typedarray::"):
+            let nestedTypeName = String (t.dropFirst(12))
+            let simple = SimpleType(type: nestedTypeName)
+            if classMap [nestedTypeName] != nil {
+                return "ObjectCollection<\(getGodotType (simple))>(\(initCollection))"
+            } else {
+                return "VariantCollection<\(getGodotType (simple))>(\(initCollection))"
+            }
+        case "enum::Error":
+            return ".ok"
+        case "enum::Variant.Type":
+            return ".`nil`"
+        case let e where e.starts (with: "enum::"):
+            return "\(e.dropFirst(6))(rawValue: 0)!"
+        case let e where e.starts (with: "bitfield::"):
+            let simple = SimpleType (type: godotType, meta: nil)
+            return "\(getGodotType (simple)) ()"
+       
+        case let other where builtinGodotTypeNames [other] != nil:
+            return "\(godotType) ()"
+        case "void*", "const Glyph*":
+            return "nil"
+        default:
+            return "\(getGodotType(SimpleType (type: godotType))) ()"
         }
-    case "enum::Error":
-        return ".ok"
-    case "enum::Variant.Type":
-        return ".`nil`"
-    case let e where e.starts (with: "enum::"):
-        return "\(e.dropFirst(6))(rawValue: 0)!"
-    case let e where e.starts (with: "bitfield::"):
-        let simple = SimpleType (type: godotType, meta: nil)
-        return "\(getGodotType (simple)) ()"
-   
-    case let other where builtinGodotTypeNames [other] != nil:
-        return "\(godotType) ()"
-    case "void*", "const Glyph*":
-        return "nil"
-    default:
-        return "\(getGodotType(SimpleType (type: godotType))) ()"
     }
-}
 
-private func makeDefaultReturn (godotType: String) -> String {
-    return "return \(makeDefaultInit(godotType: godotType))"
-}
+    private func makeDefaultReturn (godotType: String) -> String {
+        return "return \(makeDefaultInit(godotType: godotType))"
+    }
 
-extension Generator {
     private func argTypeNeedsCopy (godotType: String) -> Bool {
         if isStruct(godotType) {
             return true

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -233,7 +233,7 @@ struct MethodArgument {
                 } else if options.contains(.smallIntToInt) && isSmallInt(src) {
                     translation = .directPromoted(to: "Int")
                 } else {
-                    if isStruct(src.type) {
+                    if generator.isStruct(src.type) {
                         translation = .direct
                     } else {
                         if generator.builtinSizes[src.type] != nil && src.type != "Object" {

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -210,7 +210,7 @@ struct MethodArgument {
                 } else if options.contains(.smallIntToInt) && isSmallInt(src) {
                     translation = .directPromoted(to: "Int")
                 } else {
-                    if isStructMap[src.type] == true {
+                    if isStruct(src.type) {
                         translation = .direct
                     } else {
                         if builtinSizes[src.type] != nil && src.type != "Object" {

--- a/Generator/Generator/NativeStructures.swift
+++ b/Generator/Generator/NativeStructures.swift
@@ -5,139 +5,140 @@
 //  Created by Miguel de Icaza on 7/2/24.
 //
 
-import Foundation
 import ExtensionApi
 
-enum NativeMapType {
+private enum NativeMapType {
     case straight
     case enumeration
     case variant
 }
 
-// The types exposed here are not the same as the ones we process elsewhere
-// the additional boolean value represents whether this needs an enum wrapper
-// since our enums are 64 bit values, and the way that they are encoded in these
-// native structures is 32 bit values
-func mapNativeType (_ name: Substring) -> (String,NativeMapType)? {
-    switch name {
-    case "float":
-        return ("Float", .straight)
-    case "uint64_t":
-        return ("UInt64", .straight)
-    case "int32_t":
-        return ("Int32", .straight)
-    case "uint16_t":
-        return ("UInt16", .straight)
-    case "real_t":
-        return ("Float", .straight)
-    case "int":
-        return ("Int32", .straight)
-    case "Rect2":
-        return ("Rect2", .straight)
-    case "Vector3":
-        return ("Vector3", .straight)
-    case "Vector2":
-        return ("Vector2", .straight)
-    case "TextServer::Direction":
-        return ("TextServer.Direction", .enumeration)
-    case "ObjectID":
-        return ("ObjectID", .straight)
-    case "Object":
-        return ("Object", .variant)
-    case "RID":
-        return ("RID", .variant)
-    case "StringName":
-        return ("StringName", .variant)
-    case "uint8_t":
-        return ("UInt8", .straight)
-    case "PhysicsServer3DExtensionMotionCollision":
-        return ("PhysicsServer3DExtensionMotionCollision", .straight)
-    default:
-        print ("Failed with \(name)")
-        return nil
+extension Generator {
+    // The types exposed here are not the same as the ones we process elsewhere
+    // the additional boolean value represents whether this needs an enum wrapper
+    // since our enums are 64 bit values, and the way that they are encoded in these
+    // native structures is 32 bit values
+    private func mapNativeType (_ name: Substring) -> (String,NativeMapType)? {
+        switch name {
+        case "float":
+            return ("Float", .straight)
+        case "uint64_t":
+            return ("UInt64", .straight)
+        case "int32_t":
+            return ("Int32", .straight)
+        case "uint16_t":
+            return ("UInt16", .straight)
+        case "real_t":
+            return ("Float", .straight)
+        case "int":
+            return ("Int32", .straight)
+        case "Rect2":
+            return ("Rect2", .straight)
+        case "Vector3":
+            return ("Vector3", .straight)
+        case "Vector2":
+            return ("Vector2", .straight)
+        case "TextServer::Direction":
+            return ("TextServer.Direction", .enumeration)
+        case "ObjectID":
+            return ("ObjectID", .straight)
+        case "Object":
+            return ("Object", .variant)
+        case "RID":
+            return ("RID", .variant)
+        case "StringName":
+            return ("StringName", .variant)
+        case "uint8_t":
+            return ("UInt8", .straight)
+        case "PhysicsServer3DExtensionMotionCollision":
+            return ("PhysicsServer3DExtensionMotionCollision", .straight)
+        default:
+            print ("Failed with \(name)")
+            return nil
+        }
     }
-}
-func generateNativeStructures (_ p: Printer, values: [JGodotNativeStructure]) {
-    for structure in values {
-        var generate = true
-        var ofields: [(String,(String, NativeMapType))] = []
-        
-        for fields in structure.format.split (separator: ";") {
-            if fields.contains ("*") {
-                // TODO: need to figure out how to surface the setter for
-                // things like Object* which is a class that contains a ContentType
-                generate = false
-                continue
-            }
-            if fields.contains ("[") {
-                // Need support for inlined arrays
-                generate = false
-            }
-            let pair = fields.split (separator: " ")
-            guard pair.count >= 2 else {
-                print ("Missing values: \(fields)")
-                generate = false
-                continue
-            }
-            guard let typeInfo = mapNativeType (pair [0]) else {
-                print ("Unhandled type in nativeStrucures \(pair [0])")
-                generate = false
-                continue
-            }
-            let name = String(pair [1])
-            ofields.append ((snakeToCamel(name), typeInfo))
-        }
+    func generateNativeStructures (_ p: Printer, values: [JGodotNativeStructure]) {
+        for structure in values {
+            var generate = true
+            var ofields: [(String,(String, NativeMapType))] = []
 
-        if !generate {
-            continue
-        }
-        
-        p ("public struct \(structure.name)") {
-            for field in ofields {
-                let typeInfo = field.1
-                switch typeInfo.1 {
-                case .enumeration:
-                    p ("var _\(field.0): Int32")
-                    p ("public var \(field.0): \(field.1.0)") {
-                        p ("get") {
-                            p ("return \(field.1.0) (rawValue: Int64 (_\(field.0)))!")
-                        }
-                        p ("set") {
-                            p ("_\(field.0) = Int32 (bitPattern: UInt32(UInt64 (newValue.rawValue) & 0xffffffff))")
-                        }
-                    }
-                case .straight:
-                    p ("public var \(escapeSwift(field.0)): \(field.1.0)")
-                    
-                case .variant:
-                    let name: String
-                    let isPointer: Bool
-                    
-                    // Currently the pointer code is disabled while I figure out the
-                    // semantics of Object* in the setter
-                    if field.0.contains ("*") {
-                        name = String(field.0.dropFirst())
-                        isPointer = true
-                    } else {
-                        name = field.0
-                        isPointer = false
-                    }
-                    if isPointer {
-                        p ("var _\(name): UnsafeMutablePointer<\(field.1.0).ContentType>?")
-                    } else {
-                        p ("var _\(name): \(field.1.0).ContentType")
-                    }
-                    
-                    p ("public var \(escapeSwift(name)): \(field.1.0)\(isPointer ? "?" : "")") {
-                        p ("get") {
-                            if isPointer {
-                                p ("if let x = _\(name) { return \(field.1.0) (content: x.pointee) } else { return nil }")
-                            } else {
-                                p ("return \(field.1.0) (content: _\(field.0))")
+            for fields in structure.format.split (separator: ";") {
+                if fields.contains ("*") {
+                    // TODO: need to figure out how to surface the setter for
+                    // things like Object* which is a class that contains a ContentType
+                    generate = false
+                    continue
+                }
+                if fields.contains ("[") {
+                    // Need support for inlined arrays
+                    generate = false
+                }
+                let pair = fields.split (separator: " ")
+                guard pair.count >= 2 else {
+                    print ("Missing values: \(fields)")
+                    generate = false
+                    continue
+                }
+                guard let typeInfo = mapNativeType (pair [0]) else {
+                    print ("Unhandled type in nativeStrucures \(pair [0])")
+                    generate = false
+                    continue
+                }
+                let name = String(pair [1])
+                ofields.append ((snakeToCamel(name), typeInfo))
+            }
+
+            if !generate {
+                continue
+            }
+
+            p ("public struct \(structure.name)") {
+                for field in ofields {
+                    let typeInfo = field.1
+                    switch typeInfo.1 {
+                    case .enumeration:
+                        p ("var _\(field.0): Int32")
+                        p ("public var \(field.0): \(field.1.0)") {
+                            p ("get") {
+                                p ("return \(field.1.0) (rawValue: Int64 (_\(field.0)))!")
+                            }
+                            p ("set") {
+                                p ("_\(field.0) = Int32 (bitPattern: UInt32(UInt64 (newValue.rawValue) & 0xffffffff))")
                             }
                         }
-                        p ("set") {
-                            p ("_\(name) = newValue.content")
+                    case .straight:
+                        p ("public var \(escapeSwift(field.0)): \(field.1.0)")
+
+                    case .variant:
+                        let name: String
+                        let isPointer: Bool
+
+                        // Currently the pointer code is disabled while I figure out the
+                        // semantics of Object* in the setter
+                        if field.0.contains ("*") {
+                            name = String(field.0.dropFirst())
+                            isPointer = true
+                        } else {
+                            name = field.0
+                            isPointer = false
+                        }
+                        if isPointer {
+                            p ("var _\(name): UnsafeMutablePointer<\(field.1.0).ContentType>?")
+                        } else {
+                            p ("var _\(name): \(field.1.0).ContentType")
+                        }
+
+                        p ("public var \(escapeSwift(name)): \(field.1.0)\(isPointer ? "?" : "")") {
+                            p ("get") {
+                                if isPointer {
+                                    p ("if let x = _\(name) { return \(field.1.0) (content: x.pointee) } else { return nil }")
+                                } else {
+                                    p ("return \(field.1.0) (content: _\(field.0))")
+                                }
+                            }
+                            p ("set") {
+                                p ("_\(name) = newValue.content")
+                            }
                         }
                     }
                 }
@@ -145,3 +146,4 @@ func generateNativeStructures (_ p: Printer, values: [JGodotNativeStructure]) {
         }
     }
 }
+

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -34,11 +34,6 @@ func MemberBuiltinJsonTypeToSwift (_ type: String) -> String {
     }
 }
 
-/// Returns true for the Built-in types that are generated as classes, rather than structures
-func isBuiltinClass (_ godotTypeName: String) -> Bool {
-    builtinClassStorage [godotTypeName] != nil
-}
-
 /// Given an enumeration name, and a value associated with it, returns the Swift
 /// enum value, or nil if it can not be found.
 /// Example type: "ArrowDirection", value: "0" would return ".up"

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -352,23 +352,25 @@ func getGodotType (_ t: TypeWithMeta?, kind: ArgumentKind = .classes) -> String 
     }
 }
 
-/// Built-ins classes keep their data stored internally in a variable called
-/// "content", given a godotType name of those, this returns a pair
-/// containing the Swift-type that is used to store this, and a suitable initialization
-/// value for it.
-func getBuiltinStorage (_ name: String) -> (String, String) {
-    guard let size = builtinSizes [name] else {
-        fatalError()
-    }
-    switch size {
-    case 4, 0:
-        return ("Int32", " = 0")
-    case 8:
-        return ("Int64", " = 0")
-    case 16:
-        return ("(Int64, Int64)", " = (0, 0)")
-    default:
-        fatalError()
+extension Generator {
+    /// Built-ins classes keep their data stored internally in a variable called
+    /// "content", given a godotType name of those, this returns a pair
+    /// containing the Swift-type that is used to store this, and a suitable initialization
+    /// value for it.
+    func getBuiltinStorage (_ name: String) -> (String, String) {
+        guard let size = builtinSizes [name] else {
+            fatalError()
+        }
+        switch size {
+        case 4, 0:
+            return ("Int32", " = 0")
+        case 8:
+            return ("Int64", " = 0")
+        case 16:
+            return ("(Int64, Int64)", " = (0, 0)")
+        default:
+            fatalError()
+        }
     }
 }
 

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -226,130 +226,128 @@ enum ArgumentKind {
 @TaskLocal
 var mapStringToSwift = true
 
-/// Given a type definition with its metadata, and the context where the type is being
-/// useds, returns the type for it.
-///
-///
-func getGodotType (_ t: TypeWithMeta?, kind: ArgumentKind = .classes) -> String {
-    guard let t else {
-        return ""
-    }
-    
-    switch t.type {
-    case "int":
-        if let meta = t.meta {
-            switch meta {
-            case .int32:
-                return "Int32"
-            case .uint32:
-                return "UInt32"
-            case .int64:
-                return "Int"
-            case .uint64:
-                return "UInt"
-            case .int16:
-                return "Int16"
-            case .uint16:
-                return "UInt16"
-            case .uint8:
-                return "UInt8"
-            case .int8:
-                return "Int8"
-            case .char32:
-                return "Int32"
-            default:
-                fatalError()
-            }
-        } else {
-            if kind == .builtInField {
-                return "Int32"
-            } else {
-                return "Int64"
-            }
+extension Generator {
+    /// Given a type definition with its metadata, and the context where the type is being
+    /// useds, returns the type for it.
+    func getGodotType (_ t: TypeWithMeta?, kind: ArgumentKind = .classes) -> String {
+        guard let t else {
+            return ""
         }
-    case "float", "real":
-        if kind == .builtInField {
-            return "Float"
-        } else {
+
+        switch t.type {
+        case "int":
             if let meta = t.meta {
                 switch meta {
-                case .double:
-                    return "Double"
-                case .float:
-                    // Looks like Godot just ignores its own
-                    // metadata of "Float" and uses Double.
-                    return "Double"
+                case .int32:
+                    return "Int32"
+                case .uint32:
+                    return "UInt32"
+                case .int64:
+                    return "Int"
+                case .uint64:
+                    return "UInt"
+                case .int16:
+                    return "Int16"
+                case .uint16:
+                    return "UInt16"
+                case .uint8:
+                    return "UInt8"
+                case .int8:
+                    return "Int8"
+                case .char32:
+                    return "Int32"
                 default:
                     fatalError()
                 }
             } else {
-                return "Double"
+                if kind == .builtInField {
+                    return "Int32"
+                } else {
+                    return "Int64"
+                }
             }
-        }
-    case "Nil":
-        return "Variant"
-    case "void":
-        return ""
-    case "bool":
-        return "Bool"
-    case "String":
-        if mapStringToSwift {
-            return "String" // We are going to use Swift strings
-        } else {
-            return "GString"
-        }
-    case "Dictionary":
-        return "GDictionary"
-    case "Array":
-        return "GArray"
-    case "void*":
-        return "OpaquePointer?"
-    case "const Glyph*":
-        return "OpaquePointer?"
-    case "Type":
-        return "GType"
-    case "const void*":
-        return "OpaquePointer?"
-    case "AudioFrame*":
-        return "OpaquePointer?"
-    default:
-        if t.type == "Error" {
-            return "GodotError"
-        }
-        if t.type.starts(with: "enum::Error") {
-            return "GodotError"
-        }
-        if t.type.starts(with: "enum::Variant.Type") {
-            return "Variant.GType"
-        }
-        if t.type.starts(with: "enum::VisualShader.Type") {
-            return "VisualShader.GType"
-        }
-        if t.type.starts(with: "enum::IP.Type") {
-            return "IP.GType"
-        }
-        if t.type.starts(with: "enum::") {
-            
-            return String (t.type.dropFirst(6))
-        }
-        if t.type.starts (with: "typedarray::") {
-            let nestedTypeName = String (t.type.dropFirst(12))
-            let nested = SimpleType(type: nestedTypeName, meta: nil)
-
-            if classMap [nestedTypeName] != nil {
-                return "ObjectCollection<\(getGodotType (nested))>"
+        case "float", "real":
+            if kind == .builtInField {
+                return "Float"
             } else {
-                return "VariantCollection<\(getGodotType (nested))>"
+                if let meta = t.meta {
+                    switch meta {
+                    case .double:
+                        return "Double"
+                    case .float:
+                        // Looks like Godot just ignores its own
+                        // metadata of "Float" and uses Double.
+                        return "Double"
+                    default:
+                        fatalError()
+                    }
+                } else {
+                    return "Double"
+                }
             }
-        }
-        if t.type.starts (with: "bitfield::") {
-            return "\(t.type.dropFirst(10))"
-        }
-        return t.type
-    }
-}
+        case "Nil":
+            return "Variant"
+        case "void":
+            return ""
+        case "bool":
+            return "Bool"
+        case "String":
+            if mapStringToSwift {
+                return "String" // We are going to use Swift strings
+            } else {
+                return "GString"
+            }
+        case "Dictionary":
+            return "GDictionary"
+        case "Array":
+            return "GArray"
+        case "void*":
+            return "OpaquePointer?"
+        case "const Glyph*":
+            return "OpaquePointer?"
+        case "Type":
+            return "GType"
+        case "const void*":
+            return "OpaquePointer?"
+        case "AudioFrame*":
+            return "OpaquePointer?"
+        default:
+            if t.type == "Error" {
+                return "GodotError"
+            }
+            if t.type.starts(with: "enum::Error") {
+                return "GodotError"
+            }
+            if t.type.starts(with: "enum::Variant.Type") {
+                return "Variant.GType"
+            }
+            if t.type.starts(with: "enum::VisualShader.Type") {
+                return "VisualShader.GType"
+            }
+            if t.type.starts(with: "enum::IP.Type") {
+                return "IP.GType"
+            }
+            if t.type.starts(with: "enum::") {
 
-extension Generator {
+                return String (t.type.dropFirst(6))
+            }
+            if t.type.starts (with: "typedarray::") {
+                let nestedTypeName = String (t.type.dropFirst(12))
+                let nested = SimpleType(type: nestedTypeName, meta: nil)
+
+                if classMap [nestedTypeName] != nil {
+                    return "ObjectCollection<\(getGodotType (nested))>"
+                } else {
+                    return "VariantCollection<\(getGodotType (nested))>"
+                }
+            }
+            if t.type.starts (with: "bitfield::") {
+                return "\(t.type.dropFirst(10))"
+            }
+            return t.type
+        }
+    }
+
     /// Built-ins classes keep their data stored internally in a variable called
     /// "content", given a godotType name of those, this returns a pair
     /// containing the Swift-type that is used to store this, and a suitable initialization

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -56,7 +56,7 @@ extension Generator {
             print ("WARNING: Enum, did not find a matching value in \(enumDef) for \(value)")
             return nil
         }
-        let t = enumDef.dropFirst(6)
+        let t = enumDef.dropFirst(6) // drop "enum::" prefix
         if let globalEnumDef = globalEnums [String (t)]  {
             return findEnumMatch(element: globalEnumDef)
         }

--- a/Generator/Generator/TypeHelpers.swift
+++ b/Generator/Generator/TypeHelpers.swift
@@ -226,6 +226,7 @@ enum ArgumentKind {
     case builtIn
 }
 
+@TaskLocal
 var mapStringToSwift = true
 
 /// Given a type definition with its metadata, and the context where the type is being

--- a/Generator/Generator/UtilityGen.swift
+++ b/Generator/Generator/UtilityGen.swift
@@ -5,30 +5,32 @@
 //  Created by Miguel de Icaza on 5/14/23.
 //
 
-import Foundation
 import ExtensionApi
 
-func generateUtility(values: [JGodotUtilityFunction], outputDir: String?) async {
-    let p = await PrinterFactory.shared.initPrinter("utility")
-    p.preamble()
-    defer {
-        if let outputDir {
-            p.save (outputDir + "utility.swift")
-        }
-    }
-    
-    let emptyUsedMethods = Set<String>()
-    
-    p ("public class GD") {
-        for method in values {
-            // We ignore the request for virtual methods, should not happen for these
-            if omittedMethodsList["utility_functions"]?.contains(method.name) == true {
-                continue
+extension Generator {
+    func generateUtility(values: [JGodotUtilityFunction], outputDir: String?) async {
+        let p = await PrinterFactory.shared.initPrinter("utility")
+        p.preamble()
+        defer {
+            if let outputDir {
+                p.save (outputDir + "utility.swift")
             }
-            
-            performExplaniningNonCriticalErrors {
-                _ = try generateMethod (p, method: method, className: "Godot", cdef: nil, usedMethods: emptyUsedMethods, generatedMethodKind: .utilityFunction, asSingleton: false)
+        }
+
+        let emptyUsedMethods = Set<String>()
+
+        p ("public class GD") {
+            for method in values {
+                // We ignore the request for virtual methods, should not happen for these
+                if omittedMethodsList["utility_functions"]?.contains(method.name) == true {
+                    continue
+                }
+
+                performExplaniningNonCriticalErrors {
+                    _ = try generateMethod (p, method: method, className: "Godot", cdef: nil, usedMethods: emptyUsedMethods, generatedMethodKind: .utilityFunction, asSingleton: false)
+                }
             }
         }
     }
 }
+

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -167,8 +167,8 @@ struct Generator {
         let coreDefPrinter = await PrinterFactory.shared.initPrinter("core-defs")
         coreDefPrinter.preamble()
         generateUnsafePointerHelpers(coreDefPrinter)
-        generateEnums(coreDefPrinter, cdef: nil, values: jsonApi.globalEnums, prefix: "")
 
+        generateEnums(coreDefPrinter, cdef: nil, values: jsonApi.globalEnums, prefix: "")
         await generateBuiltinClasses(values: jsonApi.builtinClasses, outputDir: generatedBuiltinDir)
         await generateUtility(values: jsonApi.utilityFunctions, outputDir: generatedBuiltinDir)
         await generateClasses (values: jsonApi.classes, outputDir: generatedDir)

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -77,13 +77,6 @@ func dropMatchingPrefix (_ enumName: String, _ enumKey: String) -> String {
 
 var globalEnums: [String: JGodotGlobalEnumElement] = [:]
 
-// Maps from a the class name to its definition
-var classMap: [String:JGodotExtensionAPIClass] = [:]
-
-for x in jsonApi.classes {
-    classMap [x.name] = x
-}
-
 let buildConfiguration: String = "float_64"
 
 //#if os(Windows)
@@ -144,6 +137,9 @@ struct Generator {
     /// is more expensive than creating the wrapper directly.
     let hasSubclasses: Set<String>
 
+    /// Maps from a the class name to its definition
+    let classMap: [String:JGodotExtensionAPIClass]
+
     var generatedBuiltinDir: String? { command.singleFile ? nil : (command.outputDir + "/generated-builtin/") }
     var generatedDir: String? { command.singleFile ? nil : (command.outputDir + "/generated/") }
 
@@ -184,6 +180,8 @@ struct Generator {
         builtinMap = jsonApi.builtinClasses.makeDictionary(key: \.name, value: \.self)
 
         hasSubclasses = Set(jsonApi.classes.lazy.compactMap { $0.inherits })
+
+        classMap = jsonApi.classes.makeDictionary(key: \.name, value: \.self)
     }
 
     func makeFolders() throws {

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -119,14 +119,6 @@ for x in jsonApi.builtinClasses {
 }
 
 let buildConfiguration: String = "float_64"
-var builtinSizes: [String: Int] = [:]
-for cs in jsonApi.builtinClassSizes {
-    if cs.buildConfiguration == buildConfiguration {
-        for c in cs.sizes {
-            builtinSizes [c.name] = c.size
-        }
-    }
-}
 
 //#if os(Windows)
 //// Because we generate too many symbols for Windows to be able to compile the library
@@ -175,6 +167,7 @@ struct Generator {
     let command: GeneratorCommand
 
     let builtinMemberOffsets: [String: [JGodotMember]]
+    let builtinSizes: [String: Int]
 
     var generatedBuiltinDir: String? { command.singleFile ? nil : (command.outputDir + "/generated-builtin/") }
     var generatedDir: String? { command.singleFile ? nil : (command.outputDir + "/generated/") }
@@ -186,6 +179,10 @@ struct Generator {
         builtinMemberOffsets = jsonApi.builtinClassMemberOffsets
             .first { $0.buildConfiguration == buildConfiguration }?
             .classes.makeDictionary(key: \.name.rawValue, value: \.members) ?? [:]
+
+        builtinSizes = jsonApi.builtinClassSizes
+            .first { $0.buildConfiguration == buildConfiguration }?
+            .sizes.makeDictionary(key: \.name, value: \.size) ?? [:]
     }
 
     func makeFolders() throws {

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -171,8 +171,8 @@ struct Generator {
         await generateBuiltinClasses(values: jsonApi.builtinClasses, outputDir: generatedBuiltinDir)
         await generateUtility(values: jsonApi.utilityFunctions, outputDir: generatedBuiltinDir)
         await generateClasses (values: jsonApi.classes, outputDir: generatedDir)
-        generateCtorPointers (coreDefPrinter)
 
+        generateCtorPointers (coreDefPrinter)
         generateNativeStructures(coreDefPrinter, values: jsonApi.nativeStructures)
 
         if let generatedBuiltinDir {

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -55,26 +55,6 @@ if args.count < 2 {
 let jsonData = try! Data(url: URL(fileURLWithPath: jsonFile))
 let jsonApi = try! JSONDecoder().decode(JGodotExtensionAPI.self, from: jsonData)
 
-func dropMatchingPrefix (_ enumName: String, _ enumKey: String) -> String {
-    let snake = snakeToCamel (enumKey)
-    if snake.lowercased().starts(with: enumName.lowercased()) {
-        if snake.count == enumName.count {
-            return snake
-        }
-        let ret = String (snake [snake.index (snake.startIndex, offsetBy: enumName.count)...])
-        if let f = ret.first {
-            if f.isNumber {
-                return snake
-            }
-        }
-        if ret == "" {
-            return snake
-        }
-        return ret.first!.lowercased() + ret.dropFirst()
-    }
-    return snake
-}
-
 //#if os(Windows)
 //// Because we generate too many symbols for Windows to be able to compile the library
 //// we eliminate some rare classes from the build.   This is a temporary hack to unblock

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -169,8 +169,8 @@ struct Generator {
         generateUnsafePointerHelpers(coreDefPrinter)
         generateEnums(coreDefPrinter, cdef: nil, values: jsonApi.globalEnums, prefix: "")
         await generateBuiltinClasses(values: jsonApi.builtinClasses, outputDir: generatedBuiltinDir)
-        await generateUtility(values: jsonApi.utilityFunctions, outputDir: generatedBuiltinDir)
 
+        await generateUtility(values: jsonApi.utilityFunctions, outputDir: generatedBuiltinDir)
         await generateClasses (values: jsonApi.classes, outputDir: generatedDir)
         generateCtorPointers (coreDefPrinter)
         generateNativeStructures(coreDefPrinter, values: jsonApi.nativeStructures)

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -5,8 +5,9 @@
 //  Created by Miguel de Icaza on 5/20/20.
 //  Copyright © 2020-2023 Miguel de Icaza. MIT Licensed
 //
-import Foundation
+import ArgumentParser
 import ExtensionApi
+import Foundation
 
 var args = CommandLine.arguments
 
@@ -163,6 +164,7 @@ if singleFile {
 //#endif
 
 struct Generator {
+
     func run() async throws {
         let coreDefPrinter = await PrinterFactory.shared.initPrinter("core-defs")
         coreDefPrinter.preamble()

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -77,8 +77,6 @@ func dropMatchingPrefix (_ enumName: String, _ enumKey: String) -> String {
 
 var globalEnums: [String: JGodotGlobalEnumElement] = [:]
 
-let buildConfiguration: String = "float_64"
-
 //#if os(Windows)
 //// Because we generate too many symbols for Windows to be able to compile the library
 //// we eliminate some rare classes from the build.   This is a temporary hack to unblock
@@ -160,6 +158,8 @@ struct Generator {
     func isStruct(_ type: String) -> Bool { structTypes.contains(type) }
 
     init(command: GeneratorCommand) {
+        let buildConfiguration: String = "float_64"
+
         self.command = command
 
         builtinMemberOffsets = jsonApi.builtinClassMemberOffsets

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -170,8 +170,8 @@ struct Generator {
         generateEnums(coreDefPrinter, cdef: nil, values: jsonApi.globalEnums, prefix: "")
         await generateBuiltinClasses(values: jsonApi.builtinClasses, outputDir: generatedBuiltinDir)
         await generateUtility(values: jsonApi.utilityFunctions, outputDir: generatedBuiltinDir)
-        await generateClasses (values: jsonApi.classes, outputDir: generatedDir)
 
+        await generateClasses (values: jsonApi.classes, outputDir: generatedDir)
         generateCtorPointers (coreDefPrinter)
         generateNativeStructures(coreDefPrinter, values: jsonApi.nativeStructures)
 

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -168,8 +168,8 @@ struct Generator {
         coreDefPrinter.preamble()
         generateUnsafePointerHelpers(coreDefPrinter)
         generateEnums(coreDefPrinter, cdef: nil, values: jsonApi.globalEnums, prefix: "")
-        await generateBuiltinClasses(values: jsonApi.builtinClasses, outputDir: generatedBuiltinDir)
 
+        await generateBuiltinClasses(values: jsonApi.builtinClasses, outputDir: generatedBuiltinDir)
         await generateUtility(values: jsonApi.utilityFunctions, outputDir: generatedBuiltinDir)
         await generateClasses (values: jsonApi.classes, outputDir: generatedDir)
         generateCtorPointers (coreDefPrinter)

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -39,7 +39,6 @@ var defaultDocRootUrl: URL {
 }
 
 let jsonFile = args.count > 1 ? args [1] : defaultExtensionApiJsonUrl.path
-var docRoot =  args.count > 3 ? args [3] : defaultDocRootUrl.path
 let generateResettableCache = false
 
 if args.count < 2 {
@@ -50,7 +49,6 @@ if args.count < 2 {
     - doc-directory is the Godot documentation resides (godot/doc)
     Running with defaults:
         path-to-extension-api = "\(jsonFile)"
-        doc-directory = "\(docRoot)"
     """)
 }
 
@@ -161,10 +159,6 @@ struct GeneratorCommand: AsyncParsableCommand {
         help: "Path to the folder in which to write generated Swift files. I will create this if it doesn't exist.",
         completion: .directory
     ) var outputDir: String = defaultGeneratorOutputlUrl.path
-
-    @Argument(
-        help: "Path to the top-level Godot documentation folder (the `doc` folder in the root of a Godot repository)."
-    ) var docRoot: String = defaultDocRootUrl.path
 
     mutating func run() async throws {
         let generator = Generator(command: self)

--- a/Package.swift
+++ b/Package.swift
@@ -90,7 +90,9 @@ var targets: [Target] = [
         exclude: ["README.md"],
         swiftSettings: [
             // Uncomment for using legacy array-based marshalling
-            //.define("LEGACY_MARSHALING")
+            //.define("LEGACY_MARSHALING"),
+
+            //.enableExperimentalFeature("StrictConcurrency"),
         ]
     ),
     

--- a/Package.swift
+++ b/Package.swift
@@ -83,7 +83,8 @@ var targets: [Target] = [
         dependencies: [
             "ExtensionApi",
             .product(name: "SwiftSyntax", package: "swift-syntax"),
-            .product(name: "SwiftSyntaxBuilder", package: "swift-syntax")
+            .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+            .product(name: "ArgumentParser", package: "swift-argument-parser"),
         ],
         path: "Generator",
         exclude: ["README.md"],


### PR DESCRIPTION
This PR makes several changes to the `Generator` command.

The `Generator` command now uses the `ArgumentParser` module and an `AsyncParsableCommand` conformance to parse the command line and run async code. This cleans up command line parsing, improves the help message, and makes it much easier to add more command line options in the future. It also eliminates the hack of using a `DispatchSemaphore` to synchronously wait for a `Task` to finish.

This PR introduces a new `GeneratorCommand` type which conforms to `AsyncParsableCommand`. The `@main` annotation makes `GeneratorCommand` the entry point for the program. I renamed `main.swift` to `Generator.swift` because we can't have a `main.swift` if we use the `@main` annotation.

This PR also introduces a new `Generator` type, which holds every formerly-global variable that was declared in `main.swift`. All of these variables are now constant (`let`) instead of mutable (`var`).

I moved many formerly global functions into extensions of `Generator` so they can continue accessing these variables easily.

I changed many of the helper functions to `private`. I found some functions that were defined in one file but only used in a different file, and moved their definitions into the file where they are used (and made them `private` or `fileprivate`).

I removed a few completely unused functions and variables.

This PR eliminates the fatal compile-time errors that prevented `Generator` from compiling at all with strict concurrency checking enabled. There are still several concurrency warnings, but it builds and runs successfully.

I made the changes as a series of simple, somewhat trivial commits. The `Generator` program builds and produces unchanged output after each individual commit in this PR. I'm happy to squash the commits if you prefer, but I thought it would be easier to review as separate commits.
