### PR TITLE
Only run non-embedded tests once.

### DIFF
--- a/Sources/SwiftGodotTestability/EmbeddedXCTest/EmbeddedTestCase.swift
+++ b/Sources/SwiftGodotTestability/EmbeddedXCTest/EmbeddedTestCase.swift
@@ -8,12 +8,16 @@
 
 import XCTest
 
+/// Non-generic base class for EmbeddedTestCase.
+open class EmbeddedTestBase: XCTestCase {
+}
+
 /// Superclass for test cases that are embedded.
 ///
 /// When running normally, the tests will be silent and will do nothing.
 /// When re-run the embedded context, the test case will perform its normal
 /// actions.
-open class EmbeddedTestCase<T: TestHost>: XCTestCase {
+open class EmbeddedTestCase<T: TestHost>: EmbeddedTestBase {
   override open var name: String {
     return EmbeddingController.isRunningEmbedded ? "Embedded(\(super.name))" : super.name
   }

--- a/Sources/SwiftGodotTestability/EmbeddedXCTest/EmbeddingController.swift
+++ b/Sources/SwiftGodotTestability/EmbeddedXCTest/EmbeddingController.swift
@@ -63,7 +63,7 @@ public class EmbeddingController: NSObject, XCTestObservation {
   /// Record a test suite that has finished running.
   func registerSuite(_ suite: XCTestSuite) {
     if !isRunningEmbedded {
-      if let test = suite.tests.first as? XCTestCase {
+      if let test = suite.tests.first as? EmbeddedTestBase {
         let testClass = type(of: test)
         let injected = EmbeddedTestCaseSuite(for: testClass, tests: suite.tests)
         embeddedSuite.addTest(injected)
@@ -107,8 +107,6 @@ public class EmbeddingController: NSObject, XCTestObservation {
   public func testSuiteDidFinish(_ testSuite: XCTestSuite) {
     if testSuite.className == "XCTestCaseSuite" {
       registerSuite(testSuite)
-      // } else {
-      // print("SKIPPED \(testSuite) \(type(of: testSuite))")
     }
   }
 


### PR DESCRIPTION
We were incorrectly re-running all test suites inside the Godot engine. This causes a (non-fatal) exception for suites that just inherit from `XCTestCase`, warning that it had already been run once.

This change only register suites that contain EmbeddedTestCase tests for re-running inside the engine.