### PR TITLE
Generate singletons/shared static items with initial values as "let" …

### DIFF
--- a/Generator/Generator/Printer.swift
+++ b/Generator/Generator/Printer.swift
@@ -84,7 +84,7 @@ class Printer {
                 self ("return ret")
             }
         } else {
-            b ("\(visibility)static var \(name): \(type) =", suffix: "()", block: block)
+            b ("\(visibility)static let \(name): \(type) =", suffix: "()", block: block)
         }
     }
 


### PR DESCRIPTION
…constants

Swift Concurrency doesn't like accessing Singletons via, for instance, a ".shared" property that's declared as a 'var' because it's global state that can be changed. It's more correct to declare these as "let" variables. For example, before:
    public static var shared: EditorInterface = {
after:
    public static let shared: EditorInterface = {

What I'm not completely confident about here is that my change to the generator is as targeted to JUST that case as I intend because I've never mucked with the generator before, so hopefully someone more familiar can take a look.