### PR TITLE
Fix @Callable containing Variants as parameters and return types

### DIFF
--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -263,8 +263,11 @@ func bind_call (_ udata: UnsafeMutableRawPointer?,
     }
 
     if let returnValue, let ret {
-        if ret.gtype != finfo.retType {
-            print ("Your declared function should return the type originally set \(String(describing: finfo.retType)) and \(ret.gtype)")
+        // If returnValue is not nil and `retType` is ".nil", then it means we are expecting a `Variant` and don't care
+        // which types are stored in it.
+        // See https://github.com/godotengine/godot/issues/67544#issuecomment-1382229216
+        if finfo.retType != .nil && ret.gtype != finfo.retType {
+            print ("Function is expected to return \(String(describing: finfo.retType)), returned \(ret.gtype) instead")
             if let rError = r_error {
                 rError.pointee.error = GDEXTENSION_CALL_ERROR_INVALID_METHOD
             }

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -122,17 +122,24 @@ class GodotMacroProcessor {
         }
         
         let name = "prop_\(propertyDeclarations.count)"
-        let hint: String
         
+        let hint: String
         if propType == ".array" && hintStr != "" {
             hint = ".arrayType"
         } else {
             hint = ".none"
         }
         
+        let usage: String
+        if propType == ".nil" {
+            usage = ".nilIsVariant"
+        } else {
+            usage = ".default"
+        }
+        
         // TODO: perhaps for these prop infos that are parameters to functions, we should not bother making them unique
         // and instead share all the Ints, all the Floats and so on.
-        ctor.append ("    let \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: .default)\n")
+        ctor.append ("    let \(name) = PropInfo (propertyType: \(propType), propertyName: \"\", className: StringName(\"\(className)\"), hint: \(hint), hintStr: \"\(hintStr)\", usage: \(usage))\n")
         propertyDeclarations [key] = name
         return name
     }

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -209,6 +209,14 @@ var godotVariants = [
     "Vector3i": ".vector3i",
     "Vector4": ".vector4",
     "Vector4i": ".vector4i",
+    
+    // According to:
+    // - https://github.com/godotengine/godot/issues/67544#issuecomment-1382229216
+    // - https://github.com/godotengine/godot/blob/b6e06038f8a373f7fb8d26e92d5f06887e459598/core/doc_data.cpp#L85
+    // It's `.nil` with hint = `.nilIsVariant` in returned value prop info
+    // And `.nil` with hint = `.none` in argument prop info    
+    "Variant": ".nil",
+    "Variant?": ".nil",
 ]
 
 func godotTypeToProp (typeName: String) -> String {

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -280,7 +280,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                         prop_0,
                     ]
                     classInfo.registerMethod(name: StringName("subscribe"), flags: .default, returnValue: nil, arguments: subscribeArgs, function: Castro._mproxy_subscribe)
-                    let prop_1 = PropInfo (propertyType: .object, propertyName: "from", className: StringName("Variant"), hint: .none, hintStr: "", usage: .default)
+                    let prop_1 = PropInfo (propertyType: .nil, propertyName: "from", className: StringName(""), hint: .none, hintStr: "", usage: .default)
                     let removeSilencesArgs = [
                         prop_1,
                     ]
@@ -622,6 +622,63 @@ final class MacroGodotTests: MacroGodotTestCase {
                         prop_1,
                     ]
                     classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MultiplierNode._mproxy_multiply)
+                } ()
+            }
+            """
+        )
+    }
+    
+    func testGodotMacroWithCallableFuncHavingVariantsInSignature() {
+        assertExpansion(
+            of: """
+            @Godot
+            private class TestNode: Node {
+                @Callable
+                func foo(variant: Variant?) -> Variant? {
+                    return variant
+                }
+            }
+            """,
+            into: """
+            
+            private class TestNode: Node {
+                func foo(variant: Variant?) -> Variant? {
+                    return variant
+                }
+            
+                func _mproxy_foo(arguments: borrowing Arguments) -> Variant? {
+                    do { // safe arguments access scope
+                        let arg0: Variant? = try arguments.optionalVariantArgument(at: 0)
+                        let result = foo(variant: arg0)
+                        guard let result else {
+                            return nil
+                        }
+                        return Variant(result)
+            
+                    } catch let error as ArgumentAccessError {
+                        GD.printErr(error.description)
+                        return nil
+                    } catch {
+                        GD.printErr("Error calling `foo`: \\(error)")
+                        return nil
+                    }
+                }
+            
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
+            
+                private static let _initializeClass: Void = {
+                    let className = StringName("TestNode")
+                    assert(ClassDB.classExists(class: className))
+                    let classInfo = ClassInfo<TestNode> (name: className)
+                    let prop_0 = PropInfo (propertyType: .nil, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .nilIsVariant)
+                    let prop_1 = PropInfo (propertyType: .nil, propertyName: "variant", className: StringName(""), hint: .none, hintStr: "", usage: .default)
+                    let fooArgs = [
+                        prop_1,
+                    ]
+                    classInfo.registerMethod(name: StringName("foo"), flags: .default, returnValue: prop_0, arguments: fooArgs, function: TestNode._mproxy_foo)
                 } ()
             }
             """

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -4,6 +4,23 @@ import SwiftGodotTestability
 
 @Godot
 private class TestNode: Node {
+    @Callable
+    func foo(_ callable: Callable, a: Int, b: Int) -> Int {
+        guard let variant = callable.call(Variant(a), Variant(b)) else {
+            return -1
+        }
+        
+        guard let value = Int(variant) else {
+            return -1
+        }
+        
+        return value
+    }
+    
+    @Callable
+    func bar(_ value: Variant?) -> Variant? {
+        return value
+    }
 }
 
 final class MarshalTests: GodotTestCase {
@@ -65,6 +82,32 @@ final class MarshalTests: GodotTestCase {
                 XCTAssertEqual(max, maxVariant)
             }
         }
+    }
+    
+    func testCallableArgumentInCallable() {
+        let testNode = TestNode()
+        
+        let result = testNode.foo(Callable({ arguments in
+            guard let arg0 = arguments[0], let arg1 = arguments[1] else {
+                return nil
+            }
+            
+            guard let a = Int(arg0), let b = Int(arg1) else {
+                return nil
+            }
+            
+            return Variant(a * b)
+        }), a: 11, b: 6)
+        
+        XCTAssertTrue(result == 66)
+    }
+    
+    func testCallableMethodReturningVariant() {
+        let testNode = TestNode()
+        
+        XCTAssertEqual(testNode.call(method: "bar", Variant(42)), Variant(42))
+        XCTAssertEqual(testNode.call(method: "bar", Variant("Foo")), Variant("Foo"))
+        XCTAssertEqual(testNode.call(method: "bar", nil), nil)
     }
     
     func testUnsafePointersNMemoryLayout() {


### PR DESCRIPTION
Fix for PropInfo incorrectly constructed in macro processor for return values and parameters in callable, when it was a Variant/Variant?.

Fixes https://github.com/migueldeicaza/SwiftGodot/issues/625