### PR TITLE
Deprecate old signal API

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: "16.0"
+        xcode-version: "16.2"
     - name: Build
       run: swift build --build-tests --quiet
     - name: Run tests (Swift testing)

--- a/Sources/SwiftGodot/Core/SignalRegistration.swift
+++ b/Sources/SwiftGodot/Core/SignalRegistration.swift
@@ -7,6 +7,7 @@
 
 /// Describes a signal and its arguments.
 /// - note: It is recommended to use the @Signal macro instead of using this directly.
+@available(*, deprecated, message: "Use the @Signal macro instead.")
 public struct SignalWithNoArguments {
     public let name: StringName
     public let arguments: [PropInfo] = [] // needed for registration in macro, but always []
@@ -18,6 +19,7 @@ public struct SignalWithNoArguments {
 
 /// Describes a signal and its arguments.
 /// - note: It is recommended to use the @Signal macro instead of using this directly.
+@available(*, deprecated, message: "Use the @Signal macro instead.")
 public struct SignalWith1Argument<Argument: VariantStorable> {
     public let name: StringName
     public let arguments: [PropInfo]
@@ -35,6 +37,7 @@ public struct SignalWith1Argument<Argument: VariantStorable> {
 
 /// Describes a signal and its arguments.
 /// - note: It is recommended to use the @Signal macro instead of using this directly.
+@available(*, deprecated, message: "Use the @Signal macro instead.")
 public struct SignalWith2Arguments<
     Argument1: VariantStorable,
     Argument2: VariantStorable
@@ -57,6 +60,7 @@ public struct SignalWith2Arguments<
 
 /// Describes a signal and its arguments.
 /// - note: It is recommended to use the @Signal macro instead of using this directly.
+@available(*, deprecated, message: "Use the @Signal macro instead.")
 public struct SignalWith3Arguments<
     Argument1: VariantStorable,
     Argument2: VariantStorable,
@@ -82,6 +86,7 @@ public struct SignalWith3Arguments<
 
 /// Describes a signal and its arguments.
 /// - note: It is recommended to use the @Signal macro instead of using this directly.
+@available(*, deprecated, message: "Use the @Signal macro instead.")
 public struct SignalWith4Arguments<
     Argument1: VariantStorable,
     Argument2: VariantStorable,
@@ -110,6 +115,7 @@ public struct SignalWith4Arguments<
 
 /// Describes a signal and its arguments.
 /// - note: It is recommended to use the @Signal macro instead of using this directly.
+@available(*, deprecated, message: "Use the @Signal macro instead.")
 public struct SignalWith5Arguments<
     Argument1: VariantStorable,
     Argument2: VariantStorable,
@@ -141,6 +147,7 @@ public struct SignalWith5Arguments<
 
 /// Describes a signal and its arguments.
 /// - note: It is recommended to use the @Signal macro instead of using this directly.
+@available(*, deprecated, message: "Use the @Signal macro instead.")
 public struct SignalWith6Arguments<
     Argument1: VariantStorable,
     Argument2: VariantStorable,
@@ -189,6 +196,7 @@ public extension Object {
     ///     - method: the name of a @Callable method defined on the `target` object.
     ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func connect(signal: SignalWithNoArguments, to target: some Object, method: String) -> GodotError {
         connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
     }
@@ -197,6 +205,7 @@ public extension Object {
     /// The argument must match the type of the argument at that position in the signal.
     ///  - Example: emit(signal: Player.scored, 12)
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func emit<A: VariantStorable>(signal: SignalWith1Argument<A>, _ argument: A) -> GodotError {
         emitSignal(signal.name, .init(argument))
     }
@@ -208,6 +217,7 @@ public extension Object {
     ///     - method: the name of a @Callable method defined on the `target` object.
     ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func connect(signal: SignalWith1Argument<some Any>, to target: some Object, method: String) -> GodotError {
         connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
     }
@@ -216,6 +226,7 @@ public extension Object {
     /// The argument must match the type of the argument at that position in the signal.
     ///  - Example: emit(signal: Player.scored, 12, "hooray")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func emit<A: VariantStorable, B: VariantStorable>(
         signal: SignalWith2Arguments<A, B>,
         _ argument1: A,
@@ -231,6 +242,7 @@ public extension Object {
     ///     - method: the name of a @Callable method defined on the `target` object.
     ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func connect(signal: SignalWith2Arguments<some Any, some Any>, to target: some Object, method: String) -> GodotError {
         connect(signal: signal.name, callable: .init(object: target, method: .init(method)))
     }
@@ -239,6 +251,7 @@ public extension Object {
     /// The argument must match the type of the argument at that position in the signal.
     ///  - Example: emit(signal: Player.scored, 12, "hooray", self)
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func emit<A: VariantStorable, B: VariantStorable, C: VariantStorable>(
         signal: SignalWith3Arguments<A, B, C>,
         _ argument1: A,
@@ -255,6 +268,7 @@ public extension Object {
     ///     - method: the name of a @Callable method defined on the `target` object.
     ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func connect(
         signal: SignalWith3Arguments<some Any, some Any, some Any>,
         to target: some Object,
@@ -267,6 +281,7 @@ public extension Object {
     /// The argument must match the type of the argument at that position in the signal.
     ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4)
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func emit<A: VariantStorable, B: VariantStorable, C: VariantStorable, D: VariantStorable>(
         signal: SignalWith4Arguments<A, B, C, D>,
         _ argument1: A,
@@ -290,6 +305,7 @@ public extension Object {
     ///     - method: the name of a @Callable method defined on the `target` object.
     ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func connect(
         signal: SignalWith4Arguments<some Any, some Any, some Any, some Any>,
         to target: some Object,
@@ -302,6 +318,7 @@ public extension Object {
     /// The argument must match the type of the argument at that position in the signal.
     ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4, "another_one")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func emit<A: VariantStorable, B: VariantStorable, C: VariantStorable, D: VariantStorable, E: VariantStorable>(
         signal: SignalWith5Arguments<A, B, C, D, E>,
         _ argument1: A,
@@ -327,6 +344,7 @@ public extension Object {
     ///     - method: the name of a @Callable method defined on the `target` object.
     ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func connect(
         signal: SignalWith5Arguments<some Any, some Any, some Any, some Any, some Any>,
         to target: some Object,
@@ -339,6 +357,7 @@ public extension Object {
     /// The argument must match the type of the argument at that position in the signal.
     ///  - Example: emit(signal: Player.scored, 12, "hooray", self, 4, reason)
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func emit<A: VariantStorable, B: VariantStorable, C: VariantStorable, D: VariantStorable, E: VariantStorable, F: VariantStorable>(
         signal: SignalWith6Arguments<A, B, C, D, E, F>,
         _ argument1: A,
@@ -366,6 +385,7 @@ public extension Object {
     ///     - method: the name of a @Callable method defined on the `target` object.
     ///  - Example: connect(signal: Player.scored, to: self, method: "updateScore")
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func connect(
         signal: SignalWith6Arguments<some Any, some Any, some Any, some Any, some Any, some Any>,
         to target: some Object,

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -238,6 +238,7 @@ public macro SceneTree(path: String? = nil) = #externalMacro(module: "SwiftGodot
 /// example, ["name" : String.self] declares that the signal takes one argument of string type. The argument name is provided to the godot
 /// editor. Argument types are enforced on the `emit(signal:_argument)` method. Argument types must conform to GodotVariant.
 @freestanding(declaration, names: arbitrary)
+@available(*, deprecated, message: "Use the @Signal macro instead.")
 public macro signal(_ signalName: String, arguments: Dictionary<String, Any.Type> = [:]) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SignalMacro")
 
 /// Defines a Godot signal on a class.


### PR DESCRIPTION
If we're happy with the new `@Signal` macro, we should probably aim to strip the old one out eventually.

A first step is to deprecate the old one, and the associated API.