### PR TITLE
Extend convenience initializer coverage for Packed*Array

### DIFF
--- a/Sources/SwiftGodot/Core/Packed.swift
+++ b/Sources/SwiftGodot/Core/Packed.swift
@@ -283,6 +283,21 @@ extension PackedVector2Array {
     public func append(value: Vector2) {
         append(value)
     }
+
+    /// Initializes a PackedVector2Array from an array of Vector2 values.
+    public convenience init (_ data: [Vector2]) {
+        self.init ()
+        _ = resize(newSize: Int64(data.count))
+        if let ptr = gi.packed_vector2_array_operator_index(&content, 0) {
+            ptr.withMemoryRebound(to: Vector2.self, capacity: data.count) { typed in
+                var idx = 0
+                for value in data {
+                    typed [idx] = value
+                    idx += 1
+                }
+            }
+        }
+    }
 }
 
 extension PackedVector3Array {
@@ -300,6 +315,21 @@ extension PackedVector3Array {
     public func append(value: Vector3) {
         append(value)
     }
+
+    /// Initializes a PackedVector3Array from an array of Vector3 values.
+    public convenience init (_ data: [Vector3]) {
+        self.init ()
+        _ = resize(newSize: Int64(data.count))
+        if let ptr = gi.packed_vector3_array_operator_index(&content, 0) {
+            ptr.withMemoryRebound(to: Vector3.self, capacity: data.count) { typed in
+                var idx = 0
+                for value in data {
+                    typed [idx] = value
+                    idx += 1
+                }
+            }
+        }
+    }
 }
 
 extension PackedVector4Array {
@@ -311,6 +341,21 @@ extension PackedVector4Array {
         }
         set {
             set (index: Int64 (index), value: newValue)
+        }
+    }
+
+    /// Initializes a PackedVector4Array from an array of Vector4 values.
+    public convenience init (_ data: [Vector4]) {
+        self.init ()
+        _ = resize(newSize: Int64(data.count))
+        if let ptr = gi.packed_vector4_array_operator_index(&content, 0) {
+            ptr.withMemoryRebound(to: Vector4.self, capacity: data.count) { typed in
+                var idx = 0
+                for value in data {
+                    typed [idx] = value
+                    idx += 1
+                }
+            }
         }
     }
 }

--- a/Sources/SwiftGodot/Core/Packed.swift
+++ b/Sources/SwiftGodot/Core/Packed.swift
@@ -148,7 +148,7 @@ extension PackedFloat32Array {
         }
     }
     
-    /// Initializes a PackedByteArray from an array of Float values.
+    /// Initializes a PackedFloat32Array from an array of Float values.
     public convenience init (_ data: [Float]) {
         self.init ()
         _ = resize(newSize: Int64(data.count))
@@ -181,7 +181,7 @@ extension PackedFloat64Array {
         }
     }
     
-    /// Initializes a PackedByteArray from an array of Double values.
+    /// Initializes a PackedFloat64Array from an array of Double values.
     public convenience init (_ data: [Double]) {
         self.init ()
         _ = resize(newSize: Int64(data.count))
@@ -214,7 +214,7 @@ extension PackedInt32Array {
         }
     }
     
-    /// Initializes a PackedByteArray from an array of Int32 values values.
+    /// Initializes a PackedInt32Array from an array of Int32 values values.
     public convenience init (_ data: [Int32]) {
         self.init ()
         _ = resize(newSize: Int64(data.count))
@@ -247,7 +247,7 @@ extension PackedInt64Array {
         }
     }
     
-    /// Initializes a PackedByteArray from an array of Int32 values values.
+    /// Initializes a PackedInt64Array from an array of Int64 values values.
     public convenience init (_ data: [Int64]) {
         self.init ()
         _ = resize(newSize: Int64(data.count))

--- a/Sources/SwiftGodot/Core/Packed.swift
+++ b/Sources/SwiftGodot/Core/Packed.swift
@@ -134,6 +134,21 @@ extension PackedColorArray {
     public func append(value: Color) {
         append(value)
     }
+    
+    /// Initializes a PackedColorArray from an array of Color values.
+    public convenience init (_ data: [Color]) {
+        self.init ()
+        _ = resize(newSize: Int64(data.count))
+        if let ptr = gi.packed_color_array_operator_index(&content, 0) {
+            ptr.withMemoryRebound(to: Color.self, capacity: data.count) { typed in
+                var idx = 0
+                for value in data {
+                    typed [idx] = value
+                    idx += 1
+                }
+            }
+        }
+    }
 }
 
 extension PackedFloat32Array {

--- a/Tests/SwiftGodotTests/BuiltIn/PackedArrayTests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/PackedArrayTests.swift
@@ -42,6 +42,39 @@ final class PackedArrayTests: GodotTestCase {
         for (idx, v) in doubles.enumerated() {
             XCTAssertEqual (v, e [idx])
         }
+
+        let vec2s: [Vector2] = [
+            Vector2(),
+            Vector2(x: 0.3, y: .pi),
+            Vector2(x: .greatestFiniteMagnitude, y: -.greatestFiniteMagnitude),
+            Vector2(x: Float32.infinity, y: -.infinity),
+        ]
+        let f = PackedVector2Array(vec2s)
+        for (idx, v) in vec2s.enumerated() {
+            XCTAssertEqual (v, f [idx])
+        }
+        
+        let vec3s: [Vector3] = [
+            Vector3(),
+            Vector3(x: 0.3, y: .pi, z: 2.0 * .pi),
+            Vector3(x: .greatestFiniteMagnitude, y: -.greatestFiniteMagnitude, z: 0),
+            Vector3(x: Float32.infinity, y: -.infinity, z: 0),
+        ]
+        let g = PackedVector3Array(vec3s)
+        for (idx, v) in vec3s.enumerated() {
+            XCTAssertEqual (v, g [idx])
+        }
+        
+        let vec4s: [Vector4] = [
+            Vector4(),
+            Vector4(x: 0.3, y: .pi, z: 2.0 * .pi, w: 1.0 / .pi),
+            Vector4(x: .greatestFiniteMagnitude, y: -.greatestFiniteMagnitude, z: 0, w: -0),
+            Vector4(x: Float32.infinity, y: -.infinity, z: 0, w: -0),
+        ]
+        let h = PackedVector4Array(vec4s)
+        for (idx, v) in vec4s.enumerated() {
+            XCTAssertEqual (v, h [idx])
+        }
     }
     
     func testPackedByteArrayExtract () {

--- a/Tests/SwiftGodotTests/BuiltIn/PackedArrayTests.swift
+++ b/Tests/SwiftGodotTests/BuiltIn/PackedArrayTests.swift
@@ -75,6 +75,12 @@ final class PackedArrayTests: GodotTestCase {
         for (idx, v) in vec4s.enumerated() {
             XCTAssertEqual (v, h [idx])
         }
+        
+        let colors: [Color] = [ Color(), .red, .green, .blue, Color(r: 0.1, g: 0.2, b: 0.3, a: 0.4)]
+        let i = PackedColorArray(colors)
+        for (idx, v) in colors.enumerated() {
+            XCTAssertEqual (v, i [idx])
+        }
     }
     
     func testPackedByteArrayExtract () {


### PR DESCRIPTION
Noticed that there weren't any straightforward ways to construct PackedVector\*Arrays from arrays of Vector\*, so I hacked this together. It appears to work and passes tests. Thank you for the awesome project!

**Covered:**
- PackedColorArray
- PackedVector2Array
- PackedVector3Array
- PackedVector4Array

**Not Covered:**
- PackedStringArray