### PR TITLE
Build As DLL, Use Swift 6.1 prelease, on Windows

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Swift Install
         uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.0.3-release
-          tag: 6.0.3-RELEASE
+          branch: swift-6.1-branch
+          tag: 6.1-DEVELOPMENT-SNAPSHOT-2025-01-22-a
       - uses: actions/checkout@v4
       - name: Build
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: "16.0"
+        xcode-version: "16.2"
     - name: Build
       run: swift build --build-tests --quiet
     - name: Run tests (Swift testing)

--- a/Package.swift
+++ b/Package.swift
@@ -4,11 +4,7 @@ import CompilerPluginSupport
 import PackageDescription
 
 var libraryType: Product.Library.LibraryType
-#if os(Windows)
-    libraryType = .static
-#else
-    libraryType = .dynamic
-#endif
+libraryType = .dynamic
 
 // Products define the executables and libraries a package produces, and make them visible to other packages.
 var products: [Product] = [

--- a/Package.swift
+++ b/Package.swift
@@ -3,14 +3,11 @@
 import CompilerPluginSupport
 import PackageDescription
 
-var libraryType: Product.Library.LibraryType
-libraryType = .dynamic
-
 // Products define the executables and libraries a package produces, and make them visible to other packages.
 var products: [Product] = [
     .library(
         name: "SwiftGodot",
-        type: libraryType,
+        type: .dynamic,
         targets: ["SwiftGodot"]
     ),
 
@@ -39,11 +36,12 @@ var products: [Product] = [
 
     .library(
         name: "SimpleExtension",
-        type: libraryType,
+        type: .dynamic,
         targets: ["SimpleExtension"]
     ),
 ]
 
+/// Targets are the basic building blocks of a package. A target can define a module, plugin, test suite, etc.
 var targets: [Target] = [
     .executableTarget(
         name: "EntryPointGenerator",
@@ -91,13 +89,16 @@ var targets: [Target] = [
     ),
 
     // This is a build-time plugin that invokes the generator and produces
-    // the bindings that are compiled into SwiftGodot
+    // the bindings that are compiled into SwiftGodot.
     .plugin(
         name: "CodeGeneratorPlugin",
         capability: .buildTool(),
         dependencies: ["Generator"]
     ),
 
+    // This is a build-time plugin that generates the EntryPoint.swift file,
+    // which is used to bootstrap the SwiftGodot API and register your
+    // extension and classes with Godot.
     .plugin(
         name: "EntryPointGeneratorPlugin",
         capability: .buildTool(),
@@ -129,7 +130,6 @@ var targets: [Target] = [
         exclude: ["SwiftSprite.gdextension", "README.md"],
         swiftSettings: [.swiftLanguageMode(.v5)]
     ),
-    //linkerSettings: linkerSettings),
 
     // This is the binding itself, it is made up of our generated code for the
     // Godot API, supporting infrastructure and extensions to the API to provide
@@ -137,7 +137,6 @@ var targets: [Target] = [
     .target(
         name: "SwiftGodot",
         dependencies: ["GDExtension"],
-        //linkerSettings: linkerSettings,
         swiftSettings: [
             .swiftLanguageMode(.v5),
             .define("CUSTOM_BUILTIN_IMPLEMENTATIONS"),

--- a/Plugins/CodeGeneratorPlugin/plugin.swift
+++ b/Plugins/CodeGeneratorPlugin/plugin.swift
@@ -34,25 +34,20 @@ import PackagePlugin
         }
         arguments.append(context.package.directoryURL.appending(path: "doc").path)
         arguments.append("--combined")
-        commands.append(
-            Command.prebuildCommand(
-                displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
-                executable: generator,
-                arguments: arguments,
-                outputFilesDirectory: genSourcesDir
-            )
-        )
 #else
         outputFiles.append(contentsOf: knownBuiltin.map { genSourcesDir.appending(["generated-builtin", $0]) })
         outputFiles.append(contentsOf: known.map { genSourcesDir.appending(["generated", $0]) })
+#endif
+
         commands.append(
             Command.buildCommand(
                 displayName: "Generating Swift API from \(api) to \(genSourcesDir)",
                 executable: generator,
                 arguments: arguments,
                 inputFiles: [api],
-                outputFiles: outputFiles))
-#endif
+                outputFiles: outputFiles
+            )
+        )
 
         return commands
     }


### PR DESCRIPTION
Contains the following changes:

- brings Windows into line with the other platforms by building SwiftGodot as a shared library
- updates the Xcode/Swift versions in the CI workflow
- removes a workaround for the Generator plugin on Windows, which no longer seems to be necessary when building with Swift 6.1.