### PR TITLE
Fix Xcode version for CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Swift Install
         uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-6.0.3-release
-          tag: 6.0.3-RELEASE
+          branch: swift-6.1-branch
+          tag: 6.1-DEVELOPMENT-SNAPSHOT-2025-01-22-a
       - uses: actions/checkout@v4
       - name: Build
         run: |

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: "16.0"
+        xcode-version: "16.2"
     - name: Build
       run: swift build --build-tests --quiet
     - name: Run tests (Swift testing)


### PR DESCRIPTION
Github have updated their Xcode versions, and no longer have 16.0, so we need to update to 16.2.
At the same time, upgrading the Windows CI to a pre-release of 16.1 potentially fixes some problems with the generator plugin.