### PR TITLE
More Minor Signal Cleanup

### DIFF
--- a/Sources/SimpleExtension/Demo.swift
+++ b/Sources/SimpleExtension/Demo.swift
@@ -24,9 +24,9 @@ class SwiftSprite: Sprite2D {
     var time_passed: Double = 0
     var count: Int = 0
     
-    #signal("picked_up_item", arguments: ["kind": String.self, "isGroovy": Bool.self, "count": Int.self])
-    #signal("scored")
-    #signal("lives_changed", arguments: ["count": Int.self])
+    @Signal var pickedUpItem: SignalWithArguments<String, Bool, Int>
+    @Signal var scored: SimpleSignal
+    @Signal var livesChanged: SignalWithArguments<Int>
     
     @Callable
     public func computeGodot (x: String, y: Int) -> Double {

--- a/Sources/SwiftGodot/Core/SignalRegistration.swift
+++ b/Sources/SwiftGodot/Core/SignalRegistration.swift
@@ -185,6 +185,7 @@ public extension Object {
     ///
     ///  - Example: emit(signal: Player.scored)
     @discardableResult
+    @available(*, deprecated, message: "Use the @Signal macro instead.")
     func emit(signal: SignalWithNoArguments) -> GodotError {
         emitSignal(signal.name)
     }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -151,18 +151,14 @@ final class MacroGodotTests: MacroGodotTestCase {
         assertExpansion(
             of: """
             @Godot class Hi: Node {
-                #signal("picked_up_item", arguments: ["kind": String.self])
-                #signal("scored")
-                #signal("different_init", arguments: [:])
-                #signal("different_init2", arguments: .init())
+                @Signal var pickedUpItem: SignalWithArguments<String>
+                @Signal var scored: SimpleSignal
             }
             """,
             into: """
             class Hi: Node {
-                static let pickedUpItem = SignalWith1Argument<String>("picked_up_item", argument1Name: "kind")
-                static let scored = SignalWithNoArguments("scored")
-                static let differentInit = SignalWithNoArguments("different_init")
-                static let differentInit2 = SignalWithNoArguments("different_init2")
+                @Signal var pickedUpItem: SignalWithArguments<String>
+                @Signal var scored: SimpleSignal
 
                 override open class var classInitializer: Void {
                     let _ = super.classInitializer
@@ -173,10 +169,8 @@ final class MacroGodotTests: MacroGodotTestCase {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
                     let classInfo = ClassInfo<Hi> (name: className)
-                    classInfo.registerSignal(name: Hi.pickedUpItem.name, arguments: Hi.pickedUpItem.arguments)
-                    classInfo.registerSignal(name: Hi.scored.name, arguments: Hi.scored.arguments)
-                    classInfo.registerSignal(name: Hi.differentInit.name, arguments: Hi.differentInit.arguments)
-                    classInfo.registerSignal(name: Hi.differentInit2.name, arguments: Hi.differentInit2.arguments)
+                    SignalWithArguments<String>.register("picked_up_item", info: classInfo)
+                    SimpleSignal.register("scored", info: classInfo)
                 } ()
             }
             """

--- a/Tests/SwiftGodotTests/SignalTests.swift
+++ b/Tests/SwiftGodotTests/SignalTests.swift
@@ -4,8 +4,7 @@ import SwiftGodotTestability
 
 @Godot
 private class TestSignalNode: Node {
-    #signal("mySignal", arguments: ["age": Int.self, "name": String.self])
-    @Signal var nuSignal: SignalWithArguments<Int, String>
+    @Signal var mySignal: SignalWithArguments<Int, String>
     var receivedInt: Int? = nil
     var receivedString: String? = nil
     
@@ -23,24 +22,14 @@ final class SignalTests: GodotTestCase {
     
     func testUserDefinedSignal() {
         let node = TestSignalNode()
-
-        node.connect (signal: TestSignalNode.mySignal, to: node, method: "receiveSignal")
-        node.emit (signal: TestSignalNode.mySignal, 22, "Joey")
-
-        XCTAssertEqual (node.receivedInt, 22, "Integers should have been the same")
-        XCTAssertEqual (node.receivedString, "Joey", "Strings should have been the same")
-    }
-
-    func testNuSignal() {
-        let node = TestSignalNode()
         var signalReceived = false
 
-        node.nuSignal.connect { age, name in
+        node.mySignal.connect { age, name in
             XCTAssertEqual (age, 22)
             XCTAssertEqual (name, "Sam")
             signalReceived = true
         }
-        node.nuSignal.emit(22, "Sam")
+        node.mySignal.emit(22, "Sam")
         XCTAssertTrue (signalReceived, "signal should have been received")
     }
 


### PR DESCRIPTION
Removes the unit test for the old `#signal` macro.
Updates the test of the signal macro itself to test the new macro.
Updates the SimpleExample to use the new macro.