### PR TITLE
Reduce Entrypoint Generator Output

### DIFF
--- a/Sources/EntryPointGenerator/EntryPointGenerator.swift
+++ b/Sources/EntryPointGenerator/EntryPointGenerator.swift
@@ -18,12 +18,15 @@ struct EntryPointGenerator: ParsableCommand {
     @Argument(help: "Source files containing @Godot classes to generate entry points for.")
     var sourceFiles: [String]
 
+    @Option(name: .shortAndLong, help: "Produce more output.") 
+    var verbose: Bool = false
+
     mutating func run() throws {
-        let visitor = GodotMacroSearchingVisitor(viewMode: .all)
+        let visitor = GodotMacroSearchingVisitor(viewMode: .all, logger: verbose ? logVerbose : nil)
         
-        print("Scanning source files...")
+        logVerbose("Scanning source files...")
         for file in sourceFiles {
-            print("Scanning '\(file)'...")
+            logVerbose("Scanning '\(file)'...")
             let source = try String(contentsOf: URL(fileURLWithPath: file))
             let fileSyntax = Parser.parse(source: source)
             
@@ -31,9 +34,7 @@ struct EntryPointGenerator: ParsableCommand {
         }
         
         let names = visitor.classes
-            .map { name in
-                "    \(name).self"
-            }
+            .map { name in "    \(name).self" }
             .joined(separator: ",\n")
         
         let source = """
@@ -45,9 +46,22 @@ struct EntryPointGenerator: ParsableCommand {
         
         """
         
-        print("Writing \(visitor.classes.count) to '\(outputFile)'...")
+        let count = visitor.classes.count
+        logVerbose("Writing \(count) to '\(outputFile)'...")
         let outputURL = URL(fileURLWithPath: outputFile)
         try source.write(to: outputURL, atomically: true, encoding: .utf8)
-        print("Success! Entry point is `swift_entry_point`.")
+        log("Generated swift_entry_point, registering \(count) classes, in \(outputURL.lastPathComponent).")
+    }
+
+    /// Log a message to the console.
+    func log(_ message: String) {
+        print(message)
+    }
+
+    /// Log a message to the console if verbose mode is enabled.
+    func logVerbose(_ message: String) {
+        if verbose {
+            print(message)
+        }
     }
 }

--- a/Sources/EntryPointGenerator/GodotMacroSearchingVisitor.swift
+++ b/Sources/EntryPointGenerator/GodotMacroSearchingVisitor.swift
@@ -8,17 +8,27 @@
 import Foundation
 import SwiftSyntax
 
+/// Visitor that searches for classes with the @Godot macro
 public class GodotMacroSearchingVisitor: SyntaxVisitor {
+    /// Initialize the visitor, optionally with a logger.
+    internal init(viewMode: SyntaxTreeViewMode, logger: ((String) -> Void)? = nil) {
+        self.logger = logger
+        super.init(viewMode: viewMode)
+    }
+
+    /// List of classes with the @Godot macro
     public var classes: [String] = []
+
+    /// Logger function for verbose output
+    public let logger: ((String) -> Void)?
     
     public override func visit(_ classDecl: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-        // Check for attached macros (attributes)
         for attribute in classDecl.attributes {
             if let attributeSyntax = attribute.as(AttributeSyntax.self) {
                 let attributeName = attributeSyntax.attributeName.description.trimmingCharacters(in: .whitespacesAndNewlines)
                 if attributeName == "Godot" {
                     let className = classDecl.name.text
-                    print("Found '\(className)' with @Godot macro.")
+                    logger?("Found '\(className)' with @Godot macro.")
                     classes.append(className)
                     break // Found the @Godot macro, no need to check further
                 }


### PR DESCRIPTION
The entrypoint generator spams the log with information that's not strictly necessary.

This PR changes the tool so that the default output is simply one line, of the form: `Generated swift_entry_point, registering <n> classes, in EntryPoint.generated.swift.`.

The previous logging is still available when invoking the tool manually, by passing a `--verbose` flag.