### PR TITLE
@Node macro

### DIFF
--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -216,6 +216,24 @@ public macro NativeHandleDiscarding() = #externalMacro(module: "SwiftGodotMacroL
 @attached(accessor)
 public macro SceneTree(path: String? = nil) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SceneTreeMacro")
 
+/// A macro that finds and assigns a node from the scene tree to a stored property.
+///
+/// Use this to quickly assign a stored property to a node in the scene tree.
+/// ```swift
+/// class MyNode: Node2D {
+///     @Node("Entities/Player")
+///     var player: CharacterBody2D
+/// }
+/// ```
+///
+/// If you declare the property as optional, the property will be `nil` if the node is missing.
+/// If you declare the property as non-optional, or forced-unwrap, it will be a runtime error for the node to be missing.
+/// 
+/// - Important: This property will become a computed property, and it cannot be reassigned later.
+@attached(accessor)
+public macro Node(_ path: String? = nil, required: Bool = true) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "SceneTreeMacro")
+
+
 /// Defines a Godot signal on a class.
 ///
 /// The `@Godot` macro will register any #signal defined signals so that they can be used in the editor.

--- a/Sources/SwiftGodotMacroLibrary/SceneTreeMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SceneTreeMacro.swift
@@ -16,7 +16,6 @@ public struct SceneTreeMacro: AccessorMacro {
     enum ProviderDiagnostic: String, DiagnosticMessage {
         case invalidDeclaration
         case missingTypeAnnotation
-        case nonOptionalTypeAnnotation
 
         var severity: DiagnosticSeverity { .error }
 
@@ -26,23 +25,11 @@ public struct SceneTreeMacro: AccessorMacro {
                 "SceneTree can only be applied to stored properties"
             case .missingTypeAnnotation:
                 "SceneTree requires an explicit type declaration"
-            case .nonOptionalTypeAnnotation:
-                "Stored properties with SceneTree must be marked as Optional"
             }
         }
 
         var diagnosticID: MessageID {
             MessageID(domain: "SwiftGodotMacros", id: rawValue)
-        }
-    }
-
-    struct MarkOptionalMessage: FixItMessage {
-        var message: String {
-            "Mark as Optional"
-        }
-
-        var fixItID: SwiftDiagnostics.MessageID {
-            ProviderDiagnostic.nonOptionalTypeAnnotation.diagnosticID
         }
     }
 
@@ -70,27 +57,23 @@ public struct SceneTreeMacro: AccessorMacro {
         let preferredContent = preferredIdentifierExpr?.segments.first?.as(StringSegmentSyntax.self)?.content
         let preferredIdentifier = preferredContent?.text
 
-        let unwrappedType = nodeType.as(OptionalTypeSyntax.self)?.wrappedType ?? nodeType.as(ImplicitlyUnwrappedOptionalTypeSyntax.self)?.wrappedType
+        let optionalType = nodeType.as(OptionalTypeSyntax.self)?.wrappedType
+        let unwrappedType = nodeType.as(ImplicitlyUnwrappedOptionalTypeSyntax.self)?.wrappedType ?? nodeType
 
-        guard let unwrappedType else {
-            let newOptional = OptionalTypeSyntax(wrappedType: nodeType)
-            let addOptionalFix = FixIt(message: MarkOptionalMessage(),
-                                       changes: [.replace(oldNode: Syntax(nodeType), newNode: Syntax(newOptional))])
-            let nonOptional = Diagnostic(node: nodeType.root,
-                                         message: ProviderDiagnostic.nonOptionalTypeAnnotation,
-                                         fixIts: [addOptionalFix])
-            context.diagnose(nonOptional)
+        if let optionalType {
+            // the type was optional, so use an as? case and allow nil
             return [
                 """
-                get { getNodeOrNull(path: NodePath(stringLiteral: \"\(raw: preferredIdentifier ?? nodeIdentifier.text)\")) as? \(nodeType) }
+                get { getNodeOrNull(path: NodePath(stringLiteral: \"\(raw: preferredIdentifier ?? nodeIdentifier.text)\")) as? \(optionalType) }
+                """,
+            ]
+        } else {
+            // the type was non-optional, so use as! and force unwrap; this will be a runtime error if the node is not found
+            return [
+                """
+                get { getNodeOrNull(path: NodePath(stringLiteral: \"\(raw: preferredIdentifier ?? nodeIdentifier.text)\")) as? \(unwrappedType) }
                 """,
             ]
         }
-
-        return [
-            """
-            get { getNodeOrNull(path: NodePath(stringLiteral: \"\(raw: preferredIdentifier ?? nodeIdentifier.text)\")) as? \(unwrappedType) }
-            """,
-        ]
     }
 }

--- a/Sources/SwiftGodotMacroLibrary/SceneTreeMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SceneTreeMacro.swift
@@ -71,7 +71,7 @@ public struct SceneTreeMacro: AccessorMacro {
             // the type was non-optional, so use as! and force unwrap; this will be a runtime error if the node is not found
             return [
                 """
-                get { getNodeOrNull(path: NodePath(stringLiteral: \"\(raw: preferredIdentifier ?? nodeIdentifier.text)\")) as? \(unwrappedType) }
+                get { getNodeOrNull(path: NodePath(stringLiteral: \"\(raw: preferredIdentifier ?? nodeIdentifier.text)\")) as! \(unwrappedType) }
                 """,
             ]
         }


### PR DESCRIPTION
I don't love the name or ergonomics of the @SceneTree macro.

The `path:` label for the argument is visual noise.

Requiring the variable type to be optional or implicitly unwrapped also doesn't quite make sense - we may as well support it being non-optional. For non optional variables we'll get a runtime error if the node is missing, which is also true for implicitly unwrapped vars.

This PR introduces a @Node macro. It uses the same macro implementation as @SceneTree, but tweaks the interface to be:

```swift
@Node("nodePath") var myNode: SomeNodeType
@Node("nodePath") var myOptionalNode: SomeNodeType?
```

The scene tree macro implementation has been tweaked to support non-optional type definitions, rather than complaining about them. It does still support implicitly unwrapped types, for backwards compatibility with @SceneTree, which remains unchanged.