### PR TITLE
Remove Generated Enum debugDescription

### DIFF
--- a/Generator/Generator/Enums.swift
+++ b/Generator/Generator/Enums.swift
@@ -90,7 +90,7 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
         }
         let extraConformances = enumDefName == "Error" ? ", Error" : ""
         
-        p ("public enum \(getGodotType (SimpleType (type: enumDefName))): Int64, CaseIterable, CustomDebugStringConvertible\(extraConformances)") {
+        p ("public enum \(getGodotType (SimpleType (type: enumDefName))): Int64, CaseIterable\(extraConformances)") {
             var used = Set<Int> ()
             
             func getName (_ enumVal: JGodotValueElement) -> String? {
@@ -104,7 +104,6 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
                 return snakeToCamel(enumVal.name.dropPrefix(enumCasePrefix))
             }
 
-            var debugLines: [String] = []
             for enumVal in enumDef.values {
                 if droppedCases.contains("\(enumDef.name).\(enumVal.name)") {
                     continue
@@ -125,20 +124,8 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
                     p("/// This case resurfaces during internal bridging of some operators and you will never encounter it")
                 }
                 p ("\(prefix)case \(enumName) = \(enumVal.value) // \(enumVal.name)")
-
-                if prefix == "" {
-                    debugLines.append ("case .\(enumName): return \".\(enumName)\"")
-                }
             }
             
-            p ("/// A textual representation of this instance, suitable for debugging")
-            p ("public var debugDescription: String") {
-                p ("switch self") {
-                    for line in debugLines {
-                        p (line)
-                    }
-                }
-            }
             if enumDefName == "Error" {
                 /// Provides the description of the error.
                 p ("public var localizedDescription: String { GD.errorString(error: self.rawValue) }")

--- a/Sources/SwiftGodot/Core/Arguments.swift
+++ b/Sources/SwiftGodot/Core/Arguments.swift
@@ -161,7 +161,7 @@ public struct Arguments: ~Copyable {
         
         if let variant = arg {
             guard let result = T.unwrap(from: variant) else {
-                throw ArgumentAccessError.mismatchingType(expected: "\(T.self)", actual: variant.gtype.debugDescription)
+                throw ArgumentAccessError.mismatchingType(expected: "\(T.self)", actual: String(describing: variant.gtype))
             }
             
             return result
@@ -180,7 +180,7 @@ public struct Arguments: ~Copyable {
         
         if let variant = arg {
             guard let result = T.unwrap(from: variant) else {
-                throw ArgumentAccessError.mismatchingType(expected: "\(T.self)", actual: variant.gtype.debugDescription)
+                throw ArgumentAccessError.mismatchingType(expected: "\(T.self)", actual: String(describing: variant.gtype))
             }
             
             return result
@@ -203,7 +203,7 @@ public struct Arguments: ~Copyable {
         }
                 
         guard let result = T.unwrap(from: variant) else {
-            throw ArgumentAccessError.mismatchingType(expected: "\(T.self)", actual: variant.gtype.debugDescription)
+            throw ArgumentAccessError.mismatchingType(expected: "\(T.self)", actual: String(describing: variant.gtype))
         }
         
         return result
@@ -223,7 +223,7 @@ public struct Arguments: ~Copyable {
         }
                 
         guard let result = T.unwrap(from: variant) else {
-            throw ArgumentAccessError.mismatchingType(expected: "\(T.self)", actual: variant.gtype.debugDescription)
+            throw ArgumentAccessError.mismatchingType(expected: "\(T.self)", actual: String(describing: variant.gtype))
         }
         
         return result
@@ -244,7 +244,7 @@ public struct Arguments: ~Copyable {
         }
         
         guard let rawValue = Int(variant) else {
-            throw ArgumentAccessError.mismatchingType(expected: "int", actual: variant.gtype.debugDescription)
+            throw ArgumentAccessError.mismatchingType(expected: "int", actual: String(describing: variant.gtype))
         }
         
         guard let result = T(rawValue: T.RawValue(rawValue)) else {
@@ -269,7 +269,7 @@ public struct Arguments: ~Copyable {
         }
         
         guard let array = GArray(variant) else {
-            throw ArgumentAccessError.mismatchingType(expected: "GArray", actual: variant.gtype.debugDescription)
+            throw ArgumentAccessError.mismatchingType(expected: "GArray", actual: String(describing: variant.gtype))
         }
         
         var result: [T] = []
@@ -303,7 +303,7 @@ public struct Arguments: ~Copyable {
         }
         
         guard let array = GArray(variant) else {
-            throw ArgumentAccessError.mismatchingType(expected: "GArray", actual: variant.gtype.debugDescription)
+            throw ArgumentAccessError.mismatchingType(expected: "GArray", actual: String(describing: variant.gtype))
         }
         
         var result: [T] = []
@@ -338,7 +338,7 @@ public struct Arguments: ~Copyable {
         }
         
         guard let array = GArray(variant) else {
-            throw ArgumentAccessError.mismatchingType(expected: "GArray", actual: variant.gtype.debugDescription)
+            throw ArgumentAccessError.mismatchingType(expected: "GArray", actual: String(describing: variant.gtype))
         }
         
         guard let result = VariantCollection<T>(array) else {
@@ -367,7 +367,7 @@ public struct Arguments: ~Copyable {
         }
         
         guard let array = GArray(variant) else {
-            throw ArgumentAccessError.mismatchingType(expected: "GArray", actual: variant.gtype.debugDescription)
+            throw ArgumentAccessError.mismatchingType(expected: "GArray", actual: String(describing: variant.gtype))
         }
         
         guard let result = ObjectCollection<T>(array) else {

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -85,7 +85,7 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     
     func unwrap(_ variant: Variant) -> Element {
         guard let element = Element(variant) else {
-            fatalError("VariantCollection<\(Element.self)> got a variant with gtype = \(variant.gtype.debugDescription)")
+            fatalError("VariantCollection<\(Element.self)> got a variant with gtype = \(variant.gtype)")
         }
         return element
     }

--- a/Tests/SwiftGodotTests/VariantTests.swift
+++ b/Tests/SwiftGodotTests/VariantTests.swift
@@ -36,7 +36,7 @@ final class VariantTests: GodotTestCase {
             }
             
             guard let value = Int(value) else {
-                XCTFail("Expected \(Variant.GType.int.debugDescription), got \(value.gtype.debugDescription) instead")
+                XCTFail("Expected \(Variant.GType.int), got \(value.gtype) instead")
                 return
             }
             XCTAssertEqual(value, 2, "ello appears twice in `\(string)` from index 0 to 11, got \(value) instead")
@@ -53,7 +53,7 @@ final class VariantTests: GodotTestCase {
             }
             
             guard let value = Int(value) else {
-                XCTFail("Expected \(Variant.GType.int.debugDescription), got \(value.gtype.debugDescription) instead")
+                XCTFail("Expected \(Variant.GType.int), got \(value.gtype) instead")
                 return
             }
             XCTAssertEqual(value, 4, "ello appears twice in `\(string)`, got \(value) instead")
@@ -71,7 +71,7 @@ final class VariantTests: GodotTestCase {
             }
             
             guard let value = Bool(value) else {
-                XCTFail("Expected \(Variant.GType.bool.debugDescription), got \(value.gtype.debugDescription) instead")
+                XCTFail("Expected \(Variant.GType.bool), got \(value.gtype) instead")
                 return
             }
             XCTAssertTrue(value, "`\(string)` ends with `llo`, got `false` instead")
@@ -89,7 +89,7 @@ final class VariantTests: GodotTestCase {
             }
             
             guard let value = Bool(value) else {
-                XCTFail("Expected \(Variant.GType.bool.debugDescription), got \(value.gtype.debugDescription) instead")
+                XCTFail("Expected \(Variant.GType.bool), got \(value.gtype) instead")
                 return
             }
             XCTAssertFalse(value, "`\(string)` is not empty, got `true` instead")


### PR DESCRIPTION
See [this conversation](https://swiftongodot.slack.com/archives/C05BYJ95S5D/p1737984087090499).

We're generating a debugDescription for enums, but it's not really required.
Removing it will lower the exported symbol count, which is a GoodThing™