### PR TITLE
Custom typename conflict

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -523,7 +523,7 @@ func generateBuiltinMethods (_ p: Printer,
             p ("return gi.variant_get_ptr_keyed_checker (\(variantType))!")
         }
         p("""
-        public subscript(key: Variant?) -> Variant? {
+        public subscript(key: SwiftGodot.Variant?) -> SwiftGodot.Variant? {
             get {                            
                 withUnsafePointer(to: key.content) { pKeyContent in
                     if Self.keyed_checker(&content, pKeyContent) != 0 {
@@ -709,7 +709,7 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
             if bc.name == "Callable" {
                 p ("/// Creates a Callable instance from a Swift function")
                 p ("/// - Parameter callback: the swift function that receives `Arguments`, and returns a `Variant`")
-                p ("public init(_ callback: @escaping (borrowing Arguments) -> Variant?)") {
+                p ("public init(_ callback: @escaping (borrowing Arguments) -> SwiftGodot.Variant?)") {
                     p ("content = CallableWrapper.callableVariantContent(wrapping: callback)")
                 }
 

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -36,14 +36,15 @@ public struct GodotCallable: PeerMacro {
                 throw MacroError.typeName (parameter)
             }
             
-            if ptype == "Variant" {
+            // We are using full qualifier SwiftGodot.Variant to prevent conflicts with user-defined Variant type
+            if ptype == "SwiftGodot.Variant" {
                 body += """
-                        let arg\(index): Variant = try arguments.variantArgument(at: \(index))
+                        let arg\(index): SwiftGodot.Variant = try arguments.variantArgument(at: \(index))
                 
                 """
-            } else if ptype == "Variant?" {
+            } else if ptype == "SwiftGodot.Variant?" {
                 body += """
-                        let arg\(index): Variant? = try arguments.optionalVariantArgument(at: \(index))
+                        let arg\(index): SwiftGodot.Variant? = try arguments.optionalVariantArgument(at: \(index))
                 
                 """
             } else if parameter.isSwiftArray, let elementType = parameter.arrayElementTypeName {
@@ -111,7 +112,7 @@ public struct GodotCallable: PeerMacro {
             
             if funcDecl.isReturnedTypeSwiftArray, let elementType = funcDecl.returnedSwiftArrayElementType {
                 body += """
-                \(indentation)    return Variant(
+                \(indentation)    return SwiftGodot.Variant(
                 \(indentation)        result.reduce(into: GArray(\(elementType).self)) { array, element in
                 \(indentation)            array.append(Variant(element))
                 \(indentation)        }
@@ -120,7 +121,7 @@ public struct GodotCallable: PeerMacro {
                 """
             } else {
                 body += """
-                \(indentation)    return Variant(result)  
+                \(indentation)    return SwiftGodot.Variant(result)  
                   
                 """
             }
@@ -132,13 +133,13 @@ public struct GodotCallable: PeerMacro {
         
         if parameters.isEmpty {
             return """
-            func _mproxy_\(funcName)(arguments: borrowing Arguments) -> Variant? {
+            func _mproxy_\(funcName)(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
             \(body)                
             }
             """
         } else {
             return """
-            func _mproxy_\(funcName)(arguments: borrowing Arguments) -> Variant? {
+            func _mproxy_\(funcName)(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                 do { // safe arguments access scope
             \(body)        
                 } catch let error as ArgumentAccessError {

--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -275,7 +275,7 @@ public struct GodotExport: PeerMacro {
 private extension GodotExport {
     private static func makeGArrayCollectionGetProxyAccessor(varName: String, elementTypeName: String) -> String {
         """
-        func _mproxy_get_\(varName)(args: borrowing Arguments) -> Variant? {
+        func _mproxy_get_\(varName)(args: borrowing Arguments) -> SwiftGodot.Variant? {
             return Variant(\(varName).array)
         }
         """
@@ -283,7 +283,7 @@ private extension GodotExport {
     
     private static func makeGArrayCollectionSetProxyAccessor(varName: String, elementTypeName: String) -> String {
         """
-        func _mproxy_set_\(varName)(args: borrowing Arguments) -> Variant? {
+        func _mproxy_set_\(varName)(args: borrowing Arguments) -> SwiftGodot.Variant? {
             guard let arg = args.first else {
                 GD.printErr("Unable to set `\(varName)`, no arguments")
                 return nil

--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -14,13 +14,13 @@ import SwiftSyntaxMacros
 
 public struct GodotExport: PeerMacro {
     
-    
+    // We are using full qualifier SwiftGodot.Variant to prevent conflicts with user-defined Variant type
     static func makeGetAccessor (varName: String, isOptional: Bool, isEnum: Bool) -> String {
         let name = "_mproxy_get_\(varName)"
         if isEnum {
             return
     """
-    func \(name) (args: borrowing Arguments) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> SwiftGodot.Variant? {
         return Variant (\(varName).rawValue)
     }
     """
@@ -29,7 +29,7 @@ public struct GodotExport: PeerMacro {
         if isOptional {
             return
     """
-    func \(name) (args: borrowing Arguments) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> SwiftGodot.Variant? {
         guard let result = \(varName) else { return nil }
         return Variant (result)
     }
@@ -37,7 +37,7 @@ public struct GodotExport: PeerMacro {
         } else {
             return
     """
-    func \(name) (args: borrowing Arguments) -> Variant? {
+    func \(name) (args: borrowing Arguments) -> SwiftGodot.Variant? {
         return Variant (\(varName))
     }
     """
@@ -166,7 +166,7 @@ public struct GodotExport: PeerMacro {
         }
                 
         return """
-        func \(name)(args: borrowing Arguments) -> Variant? {
+        func \(name)(args: borrowing Arguments) -> SwiftGodot.Variant? {
         \(body)    
             return nil
         }

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -71,7 +71,7 @@ class GodotMacroProcessor {
             className = "Array[\(godotArrayElementTypeName)]"
             hintStr = godotArrayElementTypeName
         } else if propType == ".object" {
-            className = parameterTypeName
+            className = stripQualifier(parameterTypeName)
             hintStr = ""
         } else {
             className = ""

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -226,7 +226,7 @@ func getTypeName(_ parameter: FunctionParameterSyntax) -> String? {
             return "SwiftGodot.Variant?"
         }
         else {
-            return nil
+            return typeName + "?"
         }
     }
     else {

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -37,7 +37,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vehicle_make: String = "Mazda"
             
-                func _mproxy_set_vehicle_make(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vehicle_make(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vehicle_make`, no arguments")
                         return nil
@@ -57,12 +57,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_vehicle_make (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vehicle_make (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (vehicle_make)
                 }
                 var vehicle_model: String = "RX7"
             
-                func _mproxy_set_vehicle_model(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vehicle_model(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vehicle_model`, no arguments")
                         return nil
@@ -82,7 +82,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_vehicle_model (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vehicle_model (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (vehicle_model)
                 }
             
@@ -137,7 +137,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var make: String = "Mazda"
             
-                func _mproxy_set_make(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_make(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `make`, no arguments")
                         return nil
@@ -157,12 +157,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_make (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_make (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (make)
                 }
                 var model: String = "RX7"
             
-                func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_model(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `model`, no arguments")
                         return nil
@@ -182,7 +182,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_model (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_model (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (model)
                 }
             
@@ -237,7 +237,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vin: String = "00000000000000000"
             
-                func _mproxy_set_vin(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vin(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vin`, no arguments")
                         return nil
@@ -257,12 +257,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vin (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (vin)
                 }
                 var year: Int = 1997
             
-                func _mproxy_set_year(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_year(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `year`, no arguments")
                         return nil
@@ -282,7 +282,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_year (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (year)
                 }
             
@@ -337,7 +337,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vin: String = "00000000000000000"
             
-                func _mproxy_set_vin(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vin(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vin`, no arguments")
                         return nil
@@ -357,12 +357,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vin (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (vin)
                 }
                 var year: Int = 1997
             
-                func _mproxy_set_year(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_year(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `year`, no arguments")
                         return nil
@@ -382,7 +382,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_year (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (year)
                 }
             
@@ -441,7 +441,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vin: String = ""
             
-                func _mproxy_set_vin(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vin(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vin`, no arguments")
                         return nil
@@ -461,12 +461,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vin (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (vin)
                 }
                 var year: Int = 1997
             
-                func _mproxy_set_year(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_year(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `year`, no arguments")
                         return nil
@@ -486,12 +486,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_year (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_year (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (year)
                 }
                 var make: String = "HONDA"
             
-                func _mproxy_set_make(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_make(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `make`, no arguments")
                         return nil
@@ -511,12 +511,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_make (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_make (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (make)
                 }
                 var model: String = "ACCORD"
             
-                func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_model(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `model`, no arguments")
                         return nil
@@ -536,7 +536,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_model (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_model (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (model)
                 }
             
@@ -613,11 +613,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vins: VariantCollection<String> = ["00000000000000000"]
             
-                func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(vins.array)
                 }
             
-                func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vins`, no arguments")
                         return nil
@@ -637,11 +637,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var years: VariantCollection<Int> = [1997]
             
-                func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(years.array)
                 }
             
-                func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `years`, no arguments")
                         return nil
@@ -711,11 +711,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vins: VariantCollection<String> = ["00000000000000000"]
             
-                func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(vins.array)
                 }
             
-                func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vins`, no arguments")
                         return nil
@@ -735,11 +735,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var years: VariantCollection<Int> = [1997]
             
-                func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(years.array)
                 }
             
-                func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `years`, no arguments")
                         return nil
@@ -809,11 +809,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vins: VariantCollection<String> = ["00000000000000000"]
             
-                func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(vins.array)
                 }
             
-                func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vins`, no arguments")
                         return nil
@@ -833,11 +833,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var years: VariantCollection<Int> = [1997]
             
-                func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(years.array)
                 }
             
-                func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `years`, no arguments")
                         return nil
@@ -911,11 +911,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vins: VariantCollection<String> = [""]
             
-                func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(vins.array)
                 }
             
-                func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vins`, no arguments")
                         return nil
@@ -935,11 +935,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var years: VariantCollection<Int> = [1997]
             
-                func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(years.array)
                 }
             
-                func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `years`, no arguments")
                         return nil
@@ -959,11 +959,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var makes: VariantCollection<String> = ["HONDA"]
             
-                func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_makes(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(makes.array)
                 }
             
-                func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_makes(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `makes`, no arguments")
                         return nil
@@ -983,11 +983,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var models: VariantCollection<String> = ["ACCORD"]
             
-                func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_models(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(models.array)
                 }
             
-                func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_models(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `models`, no arguments")
                         return nil
@@ -1081,11 +1081,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var makes: ObjectCollection<Node> = []
             
-                func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_makes(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(makes.array)
                 }
             
-                func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_makes(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `makes`, no arguments")
                         return nil
@@ -1105,11 +1105,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var model: ObjectCollection<Node> = []
             
-                func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_model(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(model.array)
                 }
             
-                func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_model(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `model`, no arguments")
                         return nil
@@ -1179,11 +1179,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vins: ObjectCollection<Node> = []
             
-                func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(vins.array)
                 }
             
-                func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vins`, no arguments")
                         return nil
@@ -1203,11 +1203,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var years: ObjectCollection<Node> = []
             
-                func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(years.array)
                 }
             
-                func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `years`, no arguments")
                         return nil
@@ -1277,11 +1277,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vins: ObjectCollection<Node> = []
             
-                func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(vins.array)
                 }
             
-                func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vins`, no arguments")
                         return nil
@@ -1301,11 +1301,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var years: ObjectCollection<Node> = []
             
-                func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(years.array)
                 }
             
-                func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `years`, no arguments")
                         return nil
@@ -1379,11 +1379,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vins: ObjectCollection<Node> = []
             
-                func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(vins.array)
                 }
             
-                func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vins(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vins`, no arguments")
                         return nil
@@ -1403,11 +1403,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var years: ObjectCollection<Node> = []
             
-                func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(years.array)
                 }
             
-                func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_years(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `years`, no arguments")
                         return nil
@@ -1427,11 +1427,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var makes: ObjectCollection<Node> = []
             
-                func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_makes(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(makes.array)
                 }
             
-                func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_makes(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `makes`, no arguments")
                         return nil
@@ -1451,11 +1451,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var models: ObjectCollection<Node> = []
             
-                func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_models(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(models.array)
                 }
             
-                func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_models(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `models`, no arguments")
                         return nil
@@ -1555,7 +1555,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Garage: Node {
                 var name: String = ""
             
-                func _mproxy_set_name(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_name(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `name`, no arguments")
                         return nil
@@ -1575,12 +1575,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_name (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_name (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (name)
                 }
                 var rating: Float = 0.0
             
-                func _mproxy_set_rating(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_rating(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `rating`, no arguments")
                         return nil
@@ -1600,16 +1600,16 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_rating (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_rating (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (rating)
                 }
                 var reviews: VariantCollection<String> = []
             
-                func _mproxy_get_reviews(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_reviews(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(reviews.array)
                 }
             
-                func _mproxy_set_reviews(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_reviews(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `reviews`, no arguments")
                         return nil
@@ -1629,11 +1629,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var checkIns: ObjectCollection<CheckIn> = []
             
-                func _mproxy_get_checkIns(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_checkIns(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(checkIns.array)
                 }
             
-                func _mproxy_set_checkIns(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_checkIns(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `checkIns`, no arguments")
                         return nil
@@ -1653,7 +1653,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var address: String = ""
             
-                func _mproxy_set_address(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_address(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `address`, no arguments")
                         return nil
@@ -1673,16 +1673,16 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_address (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_address (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (address)
                 }
                 var daysOfOperation: VariantCollection<String> = []
             
-                func _mproxy_get_daysOfOperation(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_daysOfOperation(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(daysOfOperation.array)
                 }
             
-                func _mproxy_set_daysOfOperation(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_daysOfOperation(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `daysOfOperation`, no arguments")
                         return nil
@@ -1702,11 +1702,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var hours: VariantCollection<String> = []
             
-                func _mproxy_get_hours(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_hours(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(hours.array)
                 }
             
-                func _mproxy_set_hours(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_hours(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `hours`, no arguments")
                         return nil
@@ -1726,11 +1726,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
             
-                func _mproxy_get_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_insuranceProvidersAccepted(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(insuranceProvidersAccepted.array)
                 }
             
-                func _mproxy_set_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_insuranceProvidersAccepted(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `insuranceProvidersAccepted`, no arguments")
                         return nil
@@ -1861,7 +1861,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Garage: Node {
                 var bar: Bool = false
             
-                func _mproxy_set_bar(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_bar(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `bar`, no arguments")
                         return nil
@@ -1881,7 +1881,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_bar (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_bar (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (bar)
                 }
             
@@ -1926,7 +1926,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             public class Issue353: Node {
                 var prefix1_prefixed_bool: Bool = true
             
-                func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `prefix1_prefixed_bool`, no arguments")
                         return nil
@@ -1946,12 +1946,12 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_prefix1_prefixed_bool (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_prefix1_prefixed_bool (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (prefix1_prefixed_bool)
                 }
                 var non_prefixed_bool: Bool = true
             
-                func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `non_prefixed_bool`, no arguments")
                         return nil
@@ -1971,7 +1971,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_non_prefixed_bool (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_non_prefixed_bool (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (non_prefixed_bool)
                 }
             
@@ -2025,11 +2025,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             class Garage: Node {
                 var bar: VariantCollection<Bool> = [false]
             
-                func _mproxy_get_bar(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_bar(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(bar.array)
                 }
             
-                func _mproxy_set_bar(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_bar(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `bar`, no arguments")
                         return nil
@@ -2089,11 +2089,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
             public class Issue353: Node {
                 var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
             
-                func _mproxy_get_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_prefix1_prefixed_bool(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(prefix1_prefixed_bool.array)
                 }
             
-                func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `prefix1_prefixed_bool`, no arguments")
                         return nil
@@ -2113,11 +2113,11 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 }
                 var non_prefixed_bool: VariantCollection<Bool> = [false]
             
-                func _mproxy_get_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_non_prefixed_bool(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(non_prefixed_bool.array)
                 }
             
-                func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `non_prefixed_bool`, no arguments")
                         return nil

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCategoryTests.swift
@@ -294,7 +294,6 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Car")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Car> (name: className)
                     let _pvin = PropInfo (
                         propertyType: .string,
                         propertyName: "vin",
@@ -302,6 +301,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                         hint: .none,
                         hintStr: "",
                         usage: .default)
+                    let classInfo = ClassInfo<Car> (name: className)
                     classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
                     classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
                     classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
@@ -394,7 +394,6 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Car")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Car> (name: className)
                     let _pvin = PropInfo (
                         propertyType: .string,
                         propertyName: "vin",
@@ -402,6 +401,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                         hint: .none,
                         hintStr: "",
                         usage: .default)
+                    let classInfo = ClassInfo<Car> (name: className)
                     classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
                     classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
                     classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
@@ -668,7 +668,6 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Car")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Car> (name: className)
                     let _pvins = PropInfo (
                         propertyType: .array,
                         propertyName: "vins",
@@ -676,6 +675,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "String",
                         usage: .default)
+                    let classInfo = ClassInfo<Car> (name: className)
                     classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
                     classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
                     classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -766,7 +766,6 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Car")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Car> (name: className)
                     let _pvins = PropInfo (
                         propertyType: .array,
                         propertyName: "vins",
@@ -774,6 +773,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "String",
                         usage: .default)
+                    let classInfo = ClassInfo<Car> (name: className)
                     classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
                     classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
                     classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -864,7 +864,6 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Car")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Car> (name: className)
                     let _pvins = PropInfo (
                         propertyType: .array,
                         propertyName: "vins",
@@ -872,6 +871,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "String",
                         usage: .default)
+                    let classInfo = ClassInfo<Car> (name: className)
                     classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
                     classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
                     classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -1234,7 +1234,6 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Car")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Car> (name: className)
                     let _pvins = PropInfo (
                         propertyType: .array,
                         propertyName: "vins",
@@ -1242,6 +1241,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "Node",
                         usage: .default)
+                    let classInfo = ClassInfo<Car> (name: className)
                     classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
                     classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
                     classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
@@ -1332,7 +1332,6 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Car")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Car> (name: className)
                     let _pvins = PropInfo (
                         propertyType: .array,
                         propertyName: "vins",
@@ -1340,6 +1339,7 @@ final class MacroGodotExportGroupTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "Node",
                         usage: .default)
+                    let classInfo = ClassInfo<Car> (name: className)
                     classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
                     classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
                     classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -96,7 +96,6 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let _pgreetings = PropInfo (
                         propertyType: .array,
                         propertyName: "greetings",
@@ -104,6 +103,7 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "String",
                         usage: .default)
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
                     classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
                     classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")
@@ -272,7 +272,6 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let _psomeArray = PropInfo (
                         propertyType: .array,
                         propertyName: "someArray",
@@ -280,6 +279,7 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                         hint: .none,
                         hintStr: "",
                         usage: .default)
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod (name: "_mproxy_get_someArray", flags: .default, returnValue: _psomeArray, arguments: [], function: SomeNode._mproxy_get_someArray)
                     classInfo.registerMethod (name: "_mproxy_set_someArray", flags: .default, returnValue: nil, arguments: [_psomeArray], function: SomeNode._mproxy_set_someArray)
                     classInfo.registerProperty (_psomeArray, getter: "_mproxy_get_someArray", setter: "_mproxy_set_someArray")
@@ -331,7 +331,6 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let _psomeNumbers = PropInfo (
                         propertyType: .array,
                         propertyName: "some_numbers",
@@ -339,6 +338,7 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "int",
                         usage: .default)
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
                     classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
                     classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
@@ -416,7 +416,6 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let _psomeNumbers = PropInfo (
                         propertyType: .array,
                         propertyName: "some_numbers",
@@ -424,6 +423,7 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "int",
                         usage: .default)
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
                     classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
                     classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
@@ -514,7 +514,6 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("ArrayTest")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<ArrayTest> (name: className)
                     let _pfirstNames = PropInfo (
                         propertyType: .array,
                         propertyName: "first_names",
@@ -522,6 +521,7 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "String",
                         usage: .default)
+                    let classInfo = ClassInfo<ArrayTest> (name: className)
                     classInfo.registerMethod (name: "get_first_names", flags: .default, returnValue: _pfirstNames, arguments: [], function: ArrayTest._mproxy_get_firstNames)
                     classInfo.registerMethod (name: "set_first_names", flags: .default, returnValue: nil, arguments: [_pfirstNames], function: ArrayTest._mproxy_set_firstNames)
                     classInfo.registerProperty (_pfirstNames, getter: "get_first_names", setter: "set_first_names")
@@ -618,7 +618,6 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let _pgreetings = PropInfo (
                         propertyType: .array,
                         propertyName: "greetings",
@@ -626,6 +625,7 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                         hint: .arrayType,
                         hintStr: "Node3D",
                         usage: .default)
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
                     classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)
                     classInfo.registerProperty (_pgreetings, getter: "get_greetings", setter: "set_greetings")

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportCollectionTests.swift
@@ -65,11 +65,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             class SomeNode: Node {
                 var greetings: VariantCollection<String> = []
 
-                func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(greetings.array)
                 }
 
-                func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `greetings`, no arguments")
                         return nil
@@ -121,11 +121,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             expandedSource: """
             var greetings: VariantCollection<String> = []
 
-            func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+            func _mproxy_get_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                 return Variant(greetings.array)
             }
 
-            func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
+            func _mproxy_set_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                 guard let arg = args.first else {
                     GD.printErr("Unable to set `greetings`, no arguments")
                     return nil
@@ -155,11 +155,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             expandedSource: """
             var greetings: VariantCollection<String> = []
             
-            func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+            func _mproxy_get_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                 return Variant(greetings.array)
             }
 
-            func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
+            func _mproxy_set_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                 guard let arg = args.first else {
                     GD.printErr("Unable to set `greetings`, no arguments")
                     return nil
@@ -190,11 +190,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             into: """
             let greetings: VariantCollection<String> = []
 
-            func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+            func _mproxy_get_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                 return Variant(greetings.array)
             }
 
-            func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
+            func _mproxy_set_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                 guard let arg = args.first else {
                     GD.printErr("Unable to set `greetings`, no arguments")
                     return nil
@@ -240,7 +240,7 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             class SomeNode: Node {
                 var someArray: GArray = GArray()
             
-                func _mproxy_set_someArray(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_someArray(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `someArray`, no arguments")
                         return nil
@@ -260,7 +260,7 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_someArray (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_someArray (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (someArray)
                 }
             
@@ -300,11 +300,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             class SomeNode: Node {
                 var someNumbers: VariantCollection<Int> = []
             
-                func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_someNumbers(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(someNumbers.array)
                 }
 
-                func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_someNumbers(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `someNumbers`, no arguments")
                         return nil
@@ -361,11 +361,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             class SomeNode: Node {
                 var someNumbers: VariantCollection<Int> = []
 
-                func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_someNumbers(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(someNumbers.array)
                 }
 
-                func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_someNumbers(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `someNumbers`, no arguments")
                         return nil
@@ -385,11 +385,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                 }
                 var someOtherNumbers: VariantCollection<Int> = []
 
-                func _mproxy_get_someOtherNumbers(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_someOtherNumbers(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(someOtherNumbers.array)
                 }
 
-                func _mproxy_set_someOtherNumbers(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_someOtherNumbers(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `someOtherNumbers`, no arguments")
                         return nil
@@ -459,11 +459,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             class ArrayTest: Node {
                var firstNames: VariantCollection<String> = ["Thelonius"]
 
-               func _mproxy_get_firstNames(args: borrowing Arguments) -> Variant? {
+               func _mproxy_get_firstNames(args: borrowing Arguments) -> SwiftGodot.Variant? {
                    return Variant(firstNames.array)
                }
 
-               func _mproxy_set_firstNames(args: borrowing Arguments) -> Variant? {
+               func _mproxy_set_firstNames(args: borrowing Arguments) -> SwiftGodot.Variant? {
                    guard let arg = args.first else {
                        GD.printErr("Unable to set `firstNames`, no arguments")
                        return nil
@@ -483,11 +483,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
                }
                var lastNames: VariantCollection<String> = ["Monk"]
 
-               func _mproxy_get_lastNames(args: borrowing Arguments) -> Variant? {
+               func _mproxy_get_lastNames(args: borrowing Arguments) -> SwiftGodot.Variant? {
                    return Variant(lastNames.array)
                }
 
-               func _mproxy_set_lastNames(args: borrowing Arguments) -> Variant? {
+               func _mproxy_set_lastNames(args: borrowing Arguments) -> SwiftGodot.Variant? {
                    guard let arg = args.first else {
                        GD.printErr("Unable to set `lastNames`, no arguments")
                        return nil
@@ -549,11 +549,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             into: """
             var greetings: ObjectCollection<Node3D> = []
 
-            func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+            func _mproxy_get_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                 return Variant(greetings.array)
             }
 
-            func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
+            func _mproxy_set_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                 guard let arg = args.first else {
                     GD.printErr("Unable to set `greetings`, no arguments")
                     return nil
@@ -587,11 +587,11 @@ final class MacroGodotExportCollectionTests: MacroGodotTestCase {
             class SomeNode: Node {
                 var greetings: ObjectCollection<Node3D> = []
 
-                func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant(greetings.array)
                 }
 
-                func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_greetings(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `greetings`, no arguments")
                         return nil

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
@@ -110,7 +110,6 @@ final class MacroGodotExportEnumTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let _pdemo = PropInfo (
                         propertyType: .int,
                         propertyName: "demo",
@@ -118,6 +117,7 @@ final class MacroGodotExportEnumTests: MacroGodotTestCase {
                         hint: .enum,
                         hintStr: tryCase (Demo.self),
                         usage: .default)
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod (name: "_mproxy_get_demo", flags: .default, returnValue: _pdemo, arguments: [], function: SomeNode._mproxy_get_demo)
                     classInfo.registerMethod (name: "_mproxy_set_demo", flags: .default, returnValue: nil, arguments: [_pdemo], function: SomeNode._mproxy_set_demo)
                     classInfo.registerProperty (_pdemo, getter: "_mproxy_get_demo", setter: "_mproxy_set_demo")

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportEnumTests.swift
@@ -43,7 +43,7 @@ final class MacroGodotExportEnumTests: MacroGodotTestCase {
             class SomeNode: Node {
                 var demo: Demo
             
-                func _mproxy_set_demo(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_demo(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `demo`, no arguments")
                         return nil
@@ -68,12 +68,12 @@ final class MacroGodotExportEnumTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_demo (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_demo (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (demo.rawValue)
                 }
                 var demo64: Demo64
             
-                func _mproxy_set_demo64(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_demo64(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `demo64`, no arguments")
                         return nil
@@ -98,7 +98,7 @@ final class MacroGodotExportEnumTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_demo64 (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_demo64 (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (demo64.rawValue)
                 }
             

--- a/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotExportSubgroupTests.swift
@@ -38,7 +38,7 @@ final class MacroGodotExportSubroupTests: MacroGodotTestCase {
             class Car: Node {
                 var vin: String = ""
             
-                func _mproxy_set_vin(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_vin(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `vin`, no arguments")
                         return nil
@@ -58,12 +58,12 @@ final class MacroGodotExportSubroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_vin (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_vin (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (vin)
                 }
                 var ymms_year: Int = 1998
             
-                func _mproxy_set_ymms_year(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_ymms_year(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `ymms_year`, no arguments")
                         return nil
@@ -83,12 +83,12 @@ final class MacroGodotExportSubroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_ymms_year (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_ymms_year (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (ymms_year)
                 }
                 var ymms_make: String = "Honda"
             
-                func _mproxy_set_ymms_make(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_ymms_make(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `ymms_make`, no arguments")
                         return nil
@@ -108,12 +108,12 @@ final class MacroGodotExportSubroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_ymms_make (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_ymms_make (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (ymms_make)
                 }
                 var ymms_model: String = "Odyssey"
             
-                func _mproxy_set_ymms_model(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_ymms_model(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `ymms_model`, no arguments")
                         return nil
@@ -133,12 +133,12 @@ final class MacroGodotExportSubroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_ymms_model (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_ymms_model (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (ymms_model)
                 }
                 var ymms_series: String = "LX"
             
-                func _mproxy_set_ymms_series(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_ymms_series(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `ymms_series`, no arguments")
                         return nil
@@ -158,7 +158,7 @@ final class MacroGodotExportSubroupTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_ymms_series (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_ymms_series (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (ymms_series)
                 }
             

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -195,13 +195,13 @@ final class MacroGodotTests: MacroGodotTestCase {
             class Castro: Node {
                 func deleteEpisode() {}
             
-                func _mproxy_deleteEpisode(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_deleteEpisode(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     deleteEpisode()
                     return nil
                 }
                 func subscribe(podcast: Podcast) {}
             
-                func _mproxy_subscribe(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_subscribe(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Podcast = try arguments.argument(ofType: Podcast.self, at: 0)
                         subscribe(podcast: arg0)
@@ -216,7 +216,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func perhapsSubscribe(podcast: Podcast?) {}
             
-                func _mproxy_perhapsSubscribe(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_perhapsSubscribe(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Podcast? = try arguments.optionlArgument(ofType: Podcast.self, at: 0)
                         perhapsSubscribe(podcast: arg0)
@@ -231,9 +231,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func removeSilences(from: Variant) {}
             
-                func _mproxy_removeSilences(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_removeSilences(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
-                        let arg0: Variant = try arguments.variantArgument(at: 0)
+                        let arg0: SwiftGodot.Variant = try arguments.variantArgument(at: 0)
                         removeSilences(from: arg0)
                         return nil
                     } catch let error as ArgumentAccessError {
@@ -246,11 +246,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func getLatestEpisode(podcast: Podcast) -> Episode {}
             
-                func _mproxy_getLatestEpisode(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_getLatestEpisode(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Podcast = try arguments.argument(ofType: Podcast.self, at: 0)
                         let result = getLatestEpisode(podcast: arg0)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -262,7 +262,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func queue(_ podcast: Podcast, after preceedingPodcast: Podcast) {}
             
-                func _mproxy_queue(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_queue(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Podcast = try arguments.argument(ofType: Podcast.self, at: 0)
                         let arg1: Podcast = try arguments.argument(ofType: Podcast.self, at: 1)
@@ -346,7 +346,7 @@ final class MacroGodotTests: MacroGodotTestCase {
             final class MyClass: Node {
                 var data: MyData = .init()
             
-                func _mproxy_set_data(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_data(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `data`, no arguments")
                         return nil
@@ -369,8 +369,8 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_data (args: borrowing Arguments) -> Variant? {
-                    return Variant (data)
+                func _mproxy_get_data (args: borrowing Arguments) -> SwiftGodot.Variant? {
+                    return SwiftGodot.Variant (data)
                 }
             
                 override public class var classInitializer: Void {
@@ -418,9 +418,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return result
                 }
             
-                func _mproxy_getIntegerCollection(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_getIntegerCollection(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = getIntegerCollection()
-                    return Variant(result)
+                    return SwiftGodot.Variant(result)
             
                 }
             
@@ -459,11 +459,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                     integers.map { $0 * $0 }.reduce(into: VariantCollection<Int>()) { $0.append(value: $1) }
                 }
             
-                func _mproxy_square(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_square(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: VariantCollection<Int> = try arguments.variantCollectionArgument(ofType: Int.self, at: 0)
                         let result = square(arg0)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -515,9 +515,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return result
                 }
             
-                func _mproxy_getNodeCollection(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_getNodeCollection(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = getNodeCollection()
-                    return Variant(result)
+                    return SwiftGodot.Variant(result)
             
                 }
             
@@ -556,7 +556,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                     nodes.forEach { print($0.name) }
                 }
             
-                func _mproxy_printNames(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_printNames(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: ObjectCollection<Node> = try arguments.objectCollectionArgument(ofType: Node.self, at: 0)
                         printNames(of: arg0)
@@ -608,11 +608,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                     integers.reduce(into: 1) { $0 *= $1 }
                 }
             
-                func _mproxy_multiply(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_multiply(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: [Int] = try arguments.arrayArgument(ofType: Int.self, at: 0)
                         let result = multiply(arg0)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -662,14 +662,14 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return variant
                 }
             
-                func _mproxy_foo(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_foo(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
-                        let arg0: Variant? = try arguments.optionalVariantArgument(at: 0)
+                        let arg0: SwiftGodot.Variant? = try arguments.optionalVariantArgument(at: 0)
                         let result = foo(variant: arg0)
                         guard let result else {
                             return nil
                         }
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -724,9 +724,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     [1, 2, 3, 4]
                 }
             
-                func _mproxy_get_ages(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_get_ages(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = get_ages()
-                    return Variant(
+                    return SwiftGodot.Variant(
                         result.reduce(into: GArray(Int.self)) { array, element in
                             array.append(Variant(element))
                         }
@@ -737,9 +737,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     [.init(), .init(), .init()]
                 }
             
-                func _mproxy_get_markers(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_get_markers(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = get_markers()
-                    return Variant(
+                    return SwiftGodot.Variant(
                         result.reduce(into: GArray(Marker3D.self)) { array, element in
                             array.append(Variant(element))
                         }
@@ -784,11 +784,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                     integers.reduce(into: 1) { $0 *= $1 }
                 }
             
-                func _mproxy_multiply(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_multiply(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: [Int] = try arguments.arrayArgument(ofType: Int.self, at: 0)
                         let result = multiply(arg0)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -843,9 +843,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     [1, 2, 3, 4]
                 }
             
-                func _mproxy_get_ages(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_get_ages(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = get_ages()
-                    return Variant(
+                    return SwiftGodot.Variant(
                         result.reduce(into: GArray(Int.self)) { array, element in
                             array.append(Variant(element))
                         }
@@ -856,9 +856,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     [.init(), .init(), .init()]
                 }
             
-                func _mproxy_get_markers(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_get_markers(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = get_markers()
-                    return Variant(
+                    return SwiftGodot.Variant(
                         result.reduce(into: GArray(Marker3D.self)) { array, element in
                             array.append(Variant(element))
                         }
@@ -898,12 +898,12 @@ final class MacroGodotTests: MacroGodotTestCase {
             class MathHelper: Node {
                 func multiply(_ a: Int, by b: Int) -> Int { a * b}
             
-                func _mproxy_multiply(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_multiply(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Int = try arguments.argument(ofType: Int.self, at: 0)
                         let arg1: Int = try arguments.argument(ofType: Int.self, at: 1)
                         let result = multiply(arg0, by: arg1)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -915,12 +915,12 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func divide(_ a: Float, by b: Float) -> Float { a / b }
             
-                func _mproxy_divide(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_divide(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Float = try arguments.argument(ofType: Float.self, at: 0)
                         let arg1: Float = try arguments.argument(ofType: Float.self, at: 1)
                         let result = divide(arg0, by: arg1)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -932,12 +932,12 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func areBothTrue(_ a: Bool, and b: Bool) -> Bool { a == b }
             
-                func _mproxy_areBothTrue(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_areBothTrue(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Bool = try arguments.argument(ofType: Bool.self, at: 0)
                         let arg1: Bool = try arguments.argument(ofType: Bool.self, at: 1)
                         let result = areBothTrue(arg0, and: arg1)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -998,7 +998,7 @@ final class MacroGodotTests: MacroGodotTestCase {
             class Hi: Node {
                 var goodName: String = "Supertop"
             
-                func _mproxy_set_goodName(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_goodName(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `goodName`, no arguments")
                         return nil
@@ -1018,7 +1018,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_goodName (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (goodName)
                 }
             
@@ -1058,7 +1058,7 @@ final class MacroGodotTests: MacroGodotTestCase {
             class Hi: Node {
                 var goodName: String = "Supertop"
             
-                func _mproxy_set_goodName(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_goodName(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `goodName`, no arguments")
                         return nil
@@ -1078,7 +1078,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_goodName (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (goodName)
                 }
             

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -42,7 +42,6 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Hi> (name: className)
                 } ()
             }
             """
@@ -68,7 +67,6 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Hi> (name: className)
                 } ()
 
                 override public class func implementedOverrides () -> [StringName] {
@@ -103,7 +101,6 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Hi> (name: className)
                 } ()
             
                 override open class func implementedOverrides () -> [StringName] {
@@ -139,7 +136,6 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Hi> (name: className)
                 } ()
             }
             """
@@ -189,6 +185,7 @@ final class MacroGodotTests: MacroGodotTestCase {
             @Godot class Castro: Node {
                 @Callable func deleteEpisode() {}
                 @Callable func subscribe(podcast: Podcast) {}
+                @Callable func perhapsSubscribe(podcast: Podcast?) {}
                 @Callable func removeSilences(from: Variant) {}
                 @Callable func getLatestEpisode(podcast: Podcast) -> Episode {}
                 @Callable func queue(_ podcast: Podcast, after preceedingPodcast: Podcast) {}
@@ -214,6 +211,21 @@ final class MacroGodotTests: MacroGodotTestCase {
                         return nil
                     } catch {
                         GD.printErr("Error calling `subscribe`: \\(error)")
+                        return nil
+                    }
+                }
+                func perhapsSubscribe(podcast: Podcast?) {}
+            
+                func _mproxy_perhapsSubscribe(arguments: borrowing Arguments) -> Variant? {
+                    do { // safe arguments access scope
+                        let arg0: Podcast? = try arguments.optionlArgument(ofType: Podcast.self, at: 0)
+                        perhapsSubscribe(podcast: arg0)
+                        return nil
+                    } catch let error as ArgumentAccessError {
+                        GD.printErr(error.description)
+                        return nil
+                    } catch {
+                        GD.printErr("Error calling `perhapsSubscribe`: \\(error)")
                         return nil
                     }
                 }
@@ -280,6 +292,10 @@ final class MacroGodotTests: MacroGodotTestCase {
                         prop_0,
                     ]
                     classInfo.registerMethod(name: StringName("subscribe"), flags: .default, returnValue: nil, arguments: subscribeArgs, function: Castro._mproxy_subscribe)
+                    let perhapsSubscribeArgs = [
+                        prop_0,
+                    ]
+                    classInfo.registerMethod(name: StringName("perhapsSubscribe"), flags: .default, returnValue: nil, arguments: perhapsSubscribeArgs, function: Castro._mproxy_perhapsSubscribe)
                     let prop_1 = PropInfo (propertyType: .nil, propertyName: "from", className: StringName(""), hint: .none, hintStr: "", usage: .default)
                     let removeSilencesArgs = [
                         prop_1,
@@ -325,7 +341,6 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("MyData")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<MyData> (name: className)
                 } ()
             }
             final class MyClass: Node {
@@ -366,7 +381,6 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("MyClass")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<MyClass> (name: className)
                     let _pdata = PropInfo (
                         propertyType: .object,
                         propertyName: "data",
@@ -374,6 +388,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                         hint: .none,
                         hintStr: "",
                         usage: .default)
+                    let classInfo = ClassInfo<MyClass> (name: className)
                     classInfo.registerMethod (name: "_mproxy_get_data", flags: .default, returnValue: _pdata, arguments: [], function: MyClass._mproxy_get_data)
                     classInfo.registerMethod (name: "_mproxy_set_data", flags: .default, returnValue: nil, arguments: [_pdata], function: MyClass._mproxy_set_data)
                     classInfo.registerProperty (_pdata, getter: "_mproxy_get_data", setter: "_mproxy_set_data")
@@ -417,8 +432,8 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod(name: StringName("getIntegerCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getIntegerCollection)
                 } ()
             }
@@ -467,12 +482,12 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     let squareArgs = [
                         prop_1,
                     ]
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod(name: StringName("square"), flags: .default, returnValue: prop_0, arguments: squareArgs, function: SomeNode._mproxy_square)
                 } ()
             }
@@ -514,8 +529,8 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .default)
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod(name: StringName("getNodeCollection"), flags: .default, returnValue: prop_0, arguments: [], function: SomeNode._mproxy_getNodeCollection)
                 } ()
             }
@@ -563,11 +578,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("SomeNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<SomeNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .array, propertyName: "nodes", className: StringName("Array[Node]"), hint: .arrayType, hintStr: "Node", usage: .default)
                     let printNamesArgs = [
                         prop_0,
                     ]
+                    let classInfo = ClassInfo<SomeNode> (name: className)
                     classInfo.registerMethod(name: StringName("printNames"), flags: .default, returnValue: nil, arguments: printNamesArgs, function: SomeNode._mproxy_printNames)
                 } ()
             }
@@ -616,12 +631,12 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("MultiplierNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<MultiplierNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
                     let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     let multiplyArgs = [
                         prop_1,
                     ]
+                    let classInfo = ClassInfo<MultiplierNode> (name: className)
                     classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MultiplierNode._mproxy_multiply)
                 } ()
             }
@@ -673,12 +688,12 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("TestNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<TestNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .nil, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .nilIsVariant)
                     let prop_1 = PropInfo (propertyType: .nil, propertyName: "variant", className: StringName(""), hint: .none, hintStr: "", usage: .default)
                     let fooArgs = [
                         prop_1,
                     ]
+                    let classInfo = ClassInfo<TestNode> (name: className)
                     classInfo.registerMethod(name: StringName("foo"), flags: .default, returnValue: prop_0, arguments: fooArgs, function: TestNode._mproxy_foo)
                 } ()
             }
@@ -740,8 +755,8 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("CallableCollectionsNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                    let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
                     classInfo.registerMethod(name: StringName("get_ages"), flags: .default, returnValue: prop_0, arguments: [], function: CallableCollectionsNode._mproxy_get_ages)
                     let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .default)
                     classInfo.registerMethod(name: StringName("get_markers"), flags: .default, returnValue: prop_1, arguments: [], function: CallableCollectionsNode._mproxy_get_markers)
@@ -792,12 +807,12 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("MultiplierNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<MultiplierNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
                     let prop_1 = PropInfo (propertyType: .array, propertyName: "integers", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
                     let multiplyArgs = [
                         prop_1,
                     ]
+                    let classInfo = ClassInfo<MultiplierNode> (name: className)
                     classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MultiplierNode._mproxy_multiply)
                 } ()
             }
@@ -859,8 +874,8 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("CallableCollectionsNode")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
                     let prop_0 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[int]"), hint: .arrayType, hintStr: "int", usage: .default)
+                    let classInfo = ClassInfo<CallableCollectionsNode> (name: className)
                     classInfo.registerMethod(name: StringName("get_ages"), flags: .default, returnValue: prop_0, arguments: [], function: CallableCollectionsNode._mproxy_get_ages)
                     let prop_1 = PropInfo (propertyType: .array, propertyName: "", className: StringName("Array[Marker3D]"), hint: .arrayType, hintStr: "Marker3D", usage: .default)
                     classInfo.registerMethod(name: StringName("get_markers"), flags: .default, returnValue: prop_1, arguments: [], function: CallableCollectionsNode._mproxy_get_markers)
@@ -941,7 +956,6 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("MathHelper")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<MathHelper> (name: className)
                     let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
                     let prop_1 = PropInfo (propertyType: .int, propertyName: "a", className: StringName(""), hint: .none, hintStr: "", usage: .default)
                     let prop_2 = PropInfo (propertyType: .int, propertyName: "b", className: StringName(""), hint: .none, hintStr: "", usage: .default)
@@ -949,6 +963,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                         prop_1,
                         prop_2,
                     ]
+                    let classInfo = ClassInfo<MathHelper> (name: className)
                     classInfo.registerMethod(name: StringName("multiply"), flags: .default, returnValue: prop_0, arguments: multiplyArgs, function: MathHelper._mproxy_multiply)
                     let prop_3 = PropInfo (propertyType: .float, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
                     let prop_4 = PropInfo (propertyType: .float, propertyName: "a", className: StringName(""), hint: .none, hintStr: "", usage: .default)
@@ -971,7 +986,67 @@ final class MacroGodotTests: MacroGodotTestCase {
             """
         )
     }
-    
+
+    func testExportGodotUsage() {
+        assertExpansion(
+            of: """
+            @Godot class Hi: Node {
+                @Export(usage: [.editor, .array]) var goodName: String = "Supertop"
+            }
+            """,
+            into: """
+            class Hi: Node {
+                var goodName: String = "Supertop"
+            
+                func _mproxy_set_goodName(args: borrowing Arguments) -> Variant? {
+                    guard let arg = args.first else {
+                        GD.printErr("Unable to set `goodName`, no arguments")
+                        return nil
+                    }
+            
+                    guard let variant = arg else {
+                        GD.printErr("Unable to set `goodName`, argument is nil")
+                        return nil
+                    }
+            
+                    guard let newValue = String(variant) else {
+                        GD.printErr("Unable to set `goodName`, argument is not String")
+                        return nil
+                    }
+            
+                    goodName = newValue
+                    return nil
+                }
+            
+                func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
+                    return Variant (goodName)
+                }
+            
+                override open class var classInitializer: Void {
+                    let _ = super.classInitializer
+                    return _initializeClass
+                }
+            
+                private static let _initializeClass: Void = {
+                    let className = StringName("Hi")
+                    assert(ClassDB.classExists(class: className))
+                    let _pgoodName = PropInfo (
+                        propertyType: .string,
+                        propertyName: "goodName",
+                        className: className,
+                        hint: .none,
+                        hintStr: "",
+                        usage: [.editor, .array])
+                    let classInfo = ClassInfo<Hi> (name: className)
+                    classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
+                    classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
+                    classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
+                } ()
+            }
+            """
+        )
+    }
+
     func testExportGodotMacro() {
         assertExpansion(
             of: """
@@ -1015,7 +1090,6 @@ final class MacroGodotTests: MacroGodotTestCase {
                 private static let _initializeClass: Void = {
                     let className = StringName("Hi")
                     assert(ClassDB.classExists(class: className))
-                    let classInfo = ClassInfo<Hi> (name: className)
                     let _pgoodName = PropInfo (
                         propertyType: .string,
                         propertyName: "goodName",
@@ -1023,6 +1097,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                         hint: .none,
                         hintStr: "",
                         usage: .default)
+                    let classInfo = ClassInfo<Hi> (name: className)
                     classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
                     classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
                     classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -195,13 +195,13 @@ final class MacroGodotTests: MacroGodotTestCase {
             class Castro: Node {
                 func deleteEpisode() {}
             
-                func _mproxy_deleteEpisode(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_deleteEpisode(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     deleteEpisode()
                     return nil
                 }
                 func subscribe(podcast: Podcast) {}
             
-                func _mproxy_subscribe(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_subscribe(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Podcast = try arguments.argument(ofType: Podcast.self, at: 0)
                         subscribe(podcast: arg0)
@@ -216,7 +216,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func perhapsSubscribe(podcast: Podcast?) {}
             
-                func _mproxy_perhapsSubscribe(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_perhapsSubscribe(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Podcast? = try arguments.optionlArgument(ofType: Podcast.self, at: 0)
                         perhapsSubscribe(podcast: arg0)
@@ -231,9 +231,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func removeSilences(from: Variant) {}
             
-                func _mproxy_removeSilences(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_removeSilences(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
-                        let arg0: Variant = try arguments.variantArgument(at: 0)
+                        let arg0: SwiftGodot.Variant = try arguments.variantArgument(at: 0)
                         removeSilences(from: arg0)
                         return nil
                     } catch let error as ArgumentAccessError {
@@ -246,11 +246,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func getLatestEpisode(podcast: Podcast) -> Episode {}
             
-                func _mproxy_getLatestEpisode(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_getLatestEpisode(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Podcast = try arguments.argument(ofType: Podcast.self, at: 0)
                         let result = getLatestEpisode(podcast: arg0)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -262,7 +262,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func queue(_ podcast: Podcast, after preceedingPodcast: Podcast) {}
             
-                func _mproxy_queue(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_queue(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Podcast = try arguments.argument(ofType: Podcast.self, at: 0)
                         let arg1: Podcast = try arguments.argument(ofType: Podcast.self, at: 1)
@@ -346,7 +346,7 @@ final class MacroGodotTests: MacroGodotTestCase {
             final class MyClass: Node {
                 var data: MyData = .init()
             
-                func _mproxy_set_data(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_data(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `data`, no arguments")
                         return nil
@@ -369,7 +369,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_data (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_data (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (data)
                 }
             
@@ -418,9 +418,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return result
                 }
             
-                func _mproxy_getIntegerCollection(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_getIntegerCollection(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = getIntegerCollection()
-                    return Variant(result)
+                    return SwiftGodot.Variant(result)
             
                 }
             
@@ -459,11 +459,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                     integers.map { $0 * $0 }.reduce(into: VariantCollection<Int>()) { $0.append(value: $1) }
                 }
             
-                func _mproxy_square(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_square(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: VariantCollection<Int> = try arguments.variantCollectionArgument(ofType: Int.self, at: 0)
                         let result = square(arg0)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -515,9 +515,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return result
                 }
             
-                func _mproxy_getNodeCollection(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_getNodeCollection(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = getNodeCollection()
-                    return Variant(result)
+                    return SwiftGodot.Variant(result)
             
                 }
             
@@ -556,7 +556,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                     nodes.forEach { print($0.name) }
                 }
             
-                func _mproxy_printNames(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_printNames(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: ObjectCollection<Node> = try arguments.objectCollectionArgument(ofType: Node.self, at: 0)
                         printNames(of: arg0)
@@ -608,11 +608,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                     integers.reduce(into: 1) { $0 *= $1 }
                 }
             
-                func _mproxy_multiply(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_multiply(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: [Int] = try arguments.arrayArgument(ofType: Int.self, at: 0)
                         let result = multiply(arg0)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -662,14 +662,14 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return variant
                 }
             
-                func _mproxy_foo(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_foo(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
-                        let arg0: Variant? = try arguments.optionalVariantArgument(at: 0)
+                        let arg0: SwiftGodot.Variant? = try arguments.optionalVariantArgument(at: 0)
                         let result = foo(variant: arg0)
                         guard let result else {
                             return nil
                         }
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -724,9 +724,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     [1, 2, 3, 4]
                 }
             
-                func _mproxy_get_ages(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_get_ages(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = get_ages()
-                    return Variant(
+                    return SwiftGodot.Variant(
                         result.reduce(into: GArray(Int.self)) { array, element in
                             array.append(Variant(element))
                         }
@@ -737,9 +737,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     [.init(), .init(), .init()]
                 }
             
-                func _mproxy_get_markers(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_get_markers(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = get_markers()
-                    return Variant(
+                    return SwiftGodot.Variant(
                         result.reduce(into: GArray(Marker3D.self)) { array, element in
                             array.append(Variant(element))
                         }
@@ -784,11 +784,11 @@ final class MacroGodotTests: MacroGodotTestCase {
                     integers.reduce(into: 1) { $0 *= $1 }
                 }
             
-                func _mproxy_multiply(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_multiply(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: [Int] = try arguments.arrayArgument(ofType: Int.self, at: 0)
                         let result = multiply(arg0)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -843,9 +843,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     [1, 2, 3, 4]
                 }
             
-                func _mproxy_get_ages(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_get_ages(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = get_ages()
-                    return Variant(
+                    return SwiftGodot.Variant(
                         result.reduce(into: GArray(Int.self)) { array, element in
                             array.append(Variant(element))
                         }
@@ -856,9 +856,9 @@ final class MacroGodotTests: MacroGodotTestCase {
                     [.init(), .init(), .init()]
                 }
             
-                func _mproxy_get_markers(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_get_markers(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     let result = get_markers()
-                    return Variant(
+                    return SwiftGodot.Variant(
                         result.reduce(into: GArray(Marker3D.self)) { array, element in
                             array.append(Variant(element))
                         }
@@ -898,12 +898,12 @@ final class MacroGodotTests: MacroGodotTestCase {
             class MathHelper: Node {
                 func multiply(_ a: Int, by b: Int) -> Int { a * b}
             
-                func _mproxy_multiply(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_multiply(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Int = try arguments.argument(ofType: Int.self, at: 0)
                         let arg1: Int = try arguments.argument(ofType: Int.self, at: 1)
                         let result = multiply(arg0, by: arg1)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -915,12 +915,12 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func divide(_ a: Float, by b: Float) -> Float { a / b }
             
-                func _mproxy_divide(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_divide(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Float = try arguments.argument(ofType: Float.self, at: 0)
                         let arg1: Float = try arguments.argument(ofType: Float.self, at: 1)
                         let result = divide(arg0, by: arg1)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -932,12 +932,12 @@ final class MacroGodotTests: MacroGodotTestCase {
                 }
                 func areBothTrue(_ a: Bool, and b: Bool) -> Bool { a == b }
             
-                func _mproxy_areBothTrue(arguments: borrowing Arguments) -> Variant? {
+                func _mproxy_areBothTrue(arguments: borrowing Arguments) -> SwiftGodot.Variant? {
                     do { // safe arguments access scope
                         let arg0: Bool = try arguments.argument(ofType: Bool.self, at: 0)
                         let arg1: Bool = try arguments.argument(ofType: Bool.self, at: 1)
                         let result = areBothTrue(arg0, and: arg1)
-                        return Variant(result)
+                        return SwiftGodot.Variant(result)
             
                     } catch let error as ArgumentAccessError {
                         GD.printErr(error.description)
@@ -998,7 +998,7 @@ final class MacroGodotTests: MacroGodotTestCase {
             class Hi: Node {
                 var goodName: String = "Supertop"
             
-                func _mproxy_set_goodName(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_goodName(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `goodName`, no arguments")
                         return nil
@@ -1018,7 +1018,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_goodName (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (goodName)
                 }
             
@@ -1058,7 +1058,7 @@ final class MacroGodotTests: MacroGodotTestCase {
             class Hi: Node {
                 var goodName: String = "Supertop"
             
-                func _mproxy_set_goodName(args: borrowing Arguments) -> Variant? {
+                func _mproxy_set_goodName(args: borrowing Arguments) -> SwiftGodot.Variant? {
                     guard let arg = args.first else {
                         GD.printErr("Unable to set `goodName`, no arguments")
                         return nil
@@ -1078,7 +1078,7 @@ final class MacroGodotTests: MacroGodotTestCase {
                     return nil
                 }
             
-                func _mproxy_get_goodName (args: borrowing Arguments) -> Variant? {
+                func _mproxy_get_goodName (args: borrowing Arguments) -> SwiftGodot.Variant? {
                     return Variant (goodName)
                 }
             

--- a/Tests/SwiftGodotMacrosTests/SceneTreeMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/SceneTreeMacroTests.swift
@@ -13,9 +13,10 @@ import XCTest
 final class SceneTreeMacroTests: XCTestCase {
     let testMacros: [String: Macro.Type] = [
         "SceneTree": SceneTreeMacro.self,
+        "Node": SceneTreeMacro.self,
     ]
 
-    func testMacroExpansion() {
+    func testSceneTreeMacroExpansion() {
         assertMacroExpansion(
             """
             class MyNode: Node {
@@ -36,7 +37,7 @@ final class SceneTreeMacroTests: XCTestCase {
         )
     }
 
-    func testMacroExpansionWithImplicitlyUnwrappedOptional() {
+    func testSceneTreeMacroExpansionWithImplicitlyUnwrappedOptional() {
         assertMacroExpansion(
             """
             class MyNode: Node {
@@ -57,7 +58,7 @@ final class SceneTreeMacroTests: XCTestCase {
         )
     }
 
-    func testMacroExpansionWithDefaultArgument() {
+    func testSceneTreeMacroExpansionWithDefaultArgument() {
         assertMacroExpansion(
             """
             class MyNode: Node {
@@ -77,11 +78,32 @@ final class SceneTreeMacroTests: XCTestCase {
         )
     }
 
-    func testMacroNotOptionalDiagnostic() {
+    func testNodeMacroExpansionWithOptional() {
         assertMacroExpansion(
             """
             class MyNode: Node {
-                @SceneTree(path: "Entities/CharacterBody2D")
+                @Node("Entities/CharacterBody2D")
+                var character: CharacterBody2D?
+            }
+            """,
+            expandedSource: """
+            class MyNode: Node {
+                var character: CharacterBody2D? {
+                    get {
+                        getNodeOrNull(path: NodePath(stringLiteral: "Entities/CharacterBody2D")) as? CharacterBody2D
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+    }
+
+    func testNodeMacroExpansion() {
+        assertMacroExpansion(
+            """
+            class MyNode: Node {
+                @Node("Entities/CharacterBody2D")
                 var character: CharacterBody2D
             }
             """,
@@ -89,19 +111,31 @@ final class SceneTreeMacroTests: XCTestCase {
             class MyNode: Node {
                 var character: CharacterBody2D {
                     get {
-                        getNodeOrNull(path: NodePath(stringLiteral: "Entities/CharacterBody2D")) as? CharacterBody2D
+                        getNodeOrNull(path: NodePath(stringLiteral: "Entities/CharacterBody2D")) as! CharacterBody2D
                     }
                 }
             }
             """,
-            diagnostics: [
-                .init(message: "Stored properties with SceneTree must be marked as Optional",
-                      line: 2,
-                      column: 5,
-                      fixIts: [
-                          .init(message: "Mark as Optional"),
-                      ]),
-            ],
+            macros: testMacros
+        )
+    }
+
+    func testNodeMacroExpansionWithDefaultArgument() {
+        assertMacroExpansion(
+            """
+            class MyNode: Node {
+                @Node var character: CharacterBody2D?
+            }
+            """,
+            expandedSource: """
+            class MyNode: Node {
+                var character: CharacterBody2D? {
+                    get {
+                        getNodeOrNull(path: NodePath(stringLiteral: "character")) as? CharacterBody2D
+                    }
+                }
+            }
+            """,
             macros: testMacros
         )
     }


### PR DESCRIPTION
Resolves conflicts of custom defined `Variant` by prefixing them with `SwiftGodot.`

Fix for #667