### PR TITLE
Iteration on _GodotBridgeable

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -860,6 +860,13 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
             }
             """)
             
+            p("""
+            /// Internal API. For indicating that Godot `Array` of ``\(typeName)`` has type `Array[\(bc.name)]`
+            @inline(__always)
+            @inlinable
+            public static var _macroGodotGetVariablePropInfoArrayType: String { "\(bc.name)" }
+            """)
+            
             // Generate the synthetic `end` property
             if bc.name == "Rect2" || bc.name == "Rect2i" || bc.name == "AABB" {
                 let retType: String

--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -842,15 +842,13 @@ func generateBuiltinClasses (values: [JGodotBuiltinClass], outputDir: String?) a
             /// Internal API. Returns ``PropInfo`` for when any ``\(typeName)`` is used as an `@Exported` variable
             @inline(__always)
             @inlinable
-            public static func _macroGodotGetVariablePropInfo<Root>(
-                rootType: Root.Type,
+            public static func _macroGodotGetVariablePropInfo(                
                 name: String,
                 userHint: PropertyHint?,
                 userHintStr: String?,
                 userUsage: PropertyUsageFlags?
             ) -> PropInfo {
                 _macroGodotGetVariablePropInfoSimple(
-                    rootType: rootType,
                     propertyType: \(propInfoPropertyType),
                     name: name,
                     userHint: userHint,

--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -549,7 +549,7 @@ func generateSignalDocAppendix (_ p: Printer, cdef: JGodotExtensionAPIClass, sig
     }
 }
 
-let objectInherits = "Wrapped, _GodotBridgeable"
+let objectInherits = "Wrapped, _GodotBridgeableObject"
 
 func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
     // Determine if it is a singleton, but exclude EditorInterface

--- a/Sources/SimpleExtension/SimpleExtension.swift
+++ b/Sources/SimpleExtension/SimpleExtension.swift
@@ -19,6 +19,10 @@ class Rigid: RigidBody2D {
     }
 }
 
+func someFunc() -> Node3D {
+    fatalError()
+}
+
 @Godot
 class MultiBindingExample: Node {
 //    @Export var one: String = "one", two: Bool = false, three: Int = 50

--- a/Sources/SimpleExtension/SimpleExtension.swift
+++ b/Sources/SimpleExtension/SimpleExtension.swift
@@ -19,10 +19,6 @@ class Rigid: RigidBody2D {
     }
 }
 
-func someFunc() -> Node3D {
-    fatalError()
-}
-
 @Godot
 class MultiBindingExample: Node {
 //    @Export var one: String = "one", two: Bool = false, three: Int = 50

--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -207,7 +207,7 @@ public struct PropInfo: CustomDebugStringConvertible {
     public var propertyType: Variant.GType
     /// The name for the property
     public var propertyName: StringName
-    /// The class name where this is defined
+    /// The special identifier needed in some cases: class name for `.object` props, Array[typename] for typed Arrays, empty otherwise
     public var className: StringName
     /// Property Hint for this property
     public var hint: PropertyHint

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -399,8 +399,7 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
         
     @inline(__always)
     @inlinable
-    public static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    public static func _macroGodotGetVariablePropInfo(        
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,

--- a/Sources/SwiftGodot/Core/ObjectCollection.swift
+++ b/Sources/SwiftGodot/Core/ObjectCollection.swift
@@ -396,4 +396,23 @@ public class ObjectCollection<Element: Object>: Collection, ExpressibleByArrayLi
     public final func isReadOnly ()-> Bool {
         array.isReadOnly()
     }
+        
+    @inline(__always)
+    @inlinable
+    public static func _macroGodotGetVariablePropInfo<Root>(
+        rootType: Root.Type,
+        name: String,
+        userHint: PropertyHint?,
+        userHintStr: String?,
+        userUsage: PropertyUsageFlags?
+    ) -> PropInfo {
+        PropInfo(
+            propertyType: .array,
+            propertyName: StringName(name),
+            className: StringName("Array[\(Element.self)]"),
+            hint: userHint ?? .arrayType,
+            hintStr: GString(userHintStr ?? "\(Element.self)"),
+            usage: userUsage ?? .default
+        )
+    }
 }

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -362,8 +362,7 @@ public extension VariantCollection where Element: _GodotBridgeable {
     /// Internal API. Returns ``PropInfo`` for when any ``VariantCollection`` is used as an `@Exported` variable
     @inlinable
     @inline(__always)
-    static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    static func _macroGodotGetVariablePropInfo(        
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,

--- a/Sources/SwiftGodot/Core/VariantCollection.swift
+++ b/Sources/SwiftGodot/Core/VariantCollection.swift
@@ -15,7 +15,7 @@ extension VariantCollection: VariantStorable {
 }
 
 /// This represents a typed array of one of the built-in types from Godot
-public class VariantCollection<Element: VariantStorable>: Collection, ExpressibleByArrayLiteral, GArrayCollection {
+public class VariantCollection<Element>: Collection, ExpressibleByArrayLiteral, GArrayCollection where Element: VariantStorable {
     public typealias ArrayLiteralElement = Element
     
     /// The underlying GArray, passed to the Godot client, and reassigned by the Godot client via the proxy accessors
@@ -356,5 +356,26 @@ public class VariantCollection<Element: VariantStorable>: Collection, Expressibl
     public final func isReadOnly ()-> Bool {
         array.isReadOnly()
     }
+}
 
+public extension VariantCollection where Element: _GodotBridgeable {
+    /// Internal API. Returns ``PropInfo`` for when any ``VariantCollection`` is used as an `@Exported` variable
+    @inlinable
+    @inline(__always)
+    static func _macroGodotGetVariablePropInfo<Root>(
+        rootType: Root.Type,
+        name: String,
+        userHint: PropertyHint?,
+        userHintStr: String?,
+        userUsage: PropertyUsageFlags?
+    ) -> PropInfo {
+        PropInfo(
+            propertyType: .array,
+            propertyName: StringName(name),
+            className: StringName("Array[\(Element._macroGodotGetVariablePropInfoArrayType)]"),
+            hint: userHint ?? .arrayType,
+            hintStr: GString(userHintStr ?? "\(Element._macroGodotGetVariablePropInfoArrayType)"),
+            usage: userUsage ?? .default
+        )
+    }
 }

--- a/Sources/SwiftGodot/Core/VariantConvertible.swift
+++ b/Sources/SwiftGodot/Core/VariantConvertible.swift
@@ -95,8 +95,7 @@ public protocol VariantConvertible {
 ///
 public protocol _GodotBridgeable: VariantConvertible {
     /// Internal API. Return PropInfo when this class is used as an @Exported property.
-    static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    static func _macroGodotGetVariablePropInfo(
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,
@@ -117,19 +116,16 @@ public extension _GodotBridgeableObject where Self: Object {
     /// Internal API. Returns ``PropInfo`` for when any ``Object`` or its subclass instance is used as an `@Exported` variable
     @inline(__always)
     @inlinable
-    static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    static func _macroGodotGetVariablePropInfo(
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,
         userUsage: PropertyUsageFlags?
     ) -> PropInfo {
-        // QoL
-        
         return _macroGodotGetVariablePropInfoSimple(
-            rootType: rootType,
             propertyType: .object,
             name: name,
+            className: StringName("\(Self.self)"),
             userHint: userHint,
             userHintStr: userHintStr,
             userUsage: userUsage
@@ -187,10 +183,10 @@ public extension Optional where Wrapped: VariantConvertible {
 // Simple common case for most of the bridged types
 @inline(__always)
 @inlinable
-func _macroGodotGetVariablePropInfoSimple<T>(
-    rootType: T.Type,
+func _macroGodotGetVariablePropInfoSimple(
     propertyType: Variant.GType,
     name: String,
+    className: StringName? = nil,
     userHint: PropertyHint?,
     userHintStr: String?,
     userUsage: PropertyUsageFlags?
@@ -198,7 +194,7 @@ func _macroGodotGetVariablePropInfoSimple<T>(
     return PropInfo(
         propertyType: propertyType,
         propertyName: StringName(name),
-        className: "\(rootType)",
+        className: className ?? "",
         hint: userHint ?? .none,
         hintStr: userHintStr.map { GString($0) } ?? GString(),
         usage: userUsage ?? .default
@@ -225,15 +221,13 @@ public extension BinaryInteger {
     /// Internal API. Returns ``PropInfo`` for when any ``BinaryInteger`` is used as an `@Exported` variable
     @inline(__always)
     @inlinable
-    static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    static func _macroGodotGetVariablePropInfo(
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,
         userUsage: PropertyUsageFlags?
     ) -> PropInfo {
         _macroGodotGetVariablePropInfoSimple(
-            rootType: rootType,
             propertyType: .int,
             name: name,
             userHint: userHint,
@@ -274,15 +268,13 @@ extension Bool: _GodotBridgeable {
     /// Internal API. Returns ``PropInfo`` for when any ``Bool`` is used as an `@Exported` variable
     @inline(__always)
     @inlinable
-    public static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    public static func _macroGodotGetVariablePropInfo(
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,
         userUsage: PropertyUsageFlags?
     ) -> PropInfo {
         _macroGodotGetVariablePropInfoSimple(
-            rootType: rootType,
             propertyType: .bool,
             name: name,
             userHint: userHint,
@@ -312,15 +304,13 @@ extension String: _GodotBridgeable {
     /// Internal API. Returns ``PropInfo`` for when any ``String`` is used as an `@Exported` variable
     @inline(__always)
     @inlinable
-    public static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    public static func _macroGodotGetVariablePropInfo(
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,
         userUsage: PropertyUsageFlags?
     ) -> PropInfo {
         _macroGodotGetVariablePropInfoSimple(
-            rootType: rootType,
             propertyType: .string,
             name: name,
             userHint: userHint,
@@ -366,15 +356,13 @@ public extension BinaryFloatingPoint {
     /// Internal API. Returns ``PropInfo`` for when any ``BinaryFloatingPoint`` is used as an `@Exported` variable
     @inline(__always)
     @inlinable
-    static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    static func _macroGodotGetVariablePropInfo(
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,
         userUsage: PropertyUsageFlags?
     ) -> PropInfo {
         _macroGodotGetVariablePropInfoSimple(
-            rootType: rootType,
             propertyType: .float,
             name: name,
             userHint: userHint,

--- a/Sources/SwiftGodot/Core/VariantConvertible.swift
+++ b/Sources/SwiftGodot/Core/VariantConvertible.swift
@@ -52,7 +52,7 @@ public protocol VariantConvertible {
 /// public protocol CustomGodotBridgeable: _GodotBridgeable {
 ///     associatedtype GodotCompatibleRepresentation: _GodotBridgeable
 ///
-///     func to(_ type: GodotCompatibleRepresentation.Type) -> GodotCompatibleRepresentation
+///     func to(_ type: GodotCompatibleRepresentation) -> GodotCompatibleRepresentation
 ///     static func from(_ godotCompatibleInstance: GodotCompatibleRepresentation) -> Self?
 ///
 /// }

--- a/Sources/SwiftGodot/Core/VariantConvertible.swift
+++ b/Sources/SwiftGodot/Core/VariantConvertible.swift
@@ -133,47 +133,6 @@ public extension _GodotBridgeableObject where Self: Object {
     }
 }
 
-
-/// Returns the metatype of the `Value` at given key path.
-///
-/// For example:
-/// ```
-/// struct A {
-///  let a = 10
-///  static func foo() {
-///    type(at: \A.a).max // returns Int.max
-///  }
-/// }
-/// ```
-/// This can be used for accessing static members of the type of the property from the static context of the containing type without relying on explicit type of `Value`.
-/// See how in example above `Int` is not mentioned anywhere in the code explicitly.
-@inline(__always)
-@inlinable
-public func valueType<Root, Value>(at keyPath: KeyPath<Root, Value>) -> Value.Type {
-    Value.self
-}
-
-public extension KeyPath {
-    /// Returns the metatype of the `Value` of the ``KeyPath``
-    ///
-    /// For example:
-    /// ```
-    /// struct A {
-    ///  let a = 10
-    ///  static func foo() {
-    ///    (\A.a).valueType // returns Int.max
-    ///  }
-    /// }
-    /// ```
-    /// This can be used for accessing static members of the type of the property from the static context of the containing type without relying on explicit type of `Value`.
-    /// See how in example above `Int` is not mentioned anywhere in the code explicitly.
-    @inline(__always)
-    @inlinable
-    var valueType: Value.Type {
-        Value.self
-    }
-}
-
 public extension Optional where Wrapped: VariantConvertible {
     func toVariant() -> Variant? {
         self?.toVariant()

--- a/Sources/SwiftGodot/Core/VariantConvertible.swift
+++ b/Sources/SwiftGodot/Core/VariantConvertible.swift
@@ -124,7 +124,9 @@ public extension _GodotBridgeableObject where Self: Object {
         userHintStr: String?,
         userUsage: PropertyUsageFlags?
     ) -> PropInfo {
-        _macroGodotGetVariablePropInfoSimple(
+        // QoL
+        
+        return _macroGodotGetVariablePropInfoSimple(
             rootType: rootType,
             propertyType: .object,
             name: name,

--- a/Sources/SwiftGodot/Core/VariantConvertible.swift
+++ b/Sources/SwiftGodot/Core/VariantConvertible.swift
@@ -102,6 +102,9 @@ public protocol _GodotBridgeable: VariantConvertible {
         userHintStr: String?,
         userUsage: PropertyUsageFlags?
     ) -> PropInfo
+    
+    /// Internal API. Returns Godot type name for typed array.
+    static var _macroGodotGetVariablePropInfoArrayType: String { get }
 }
 
 /// Internal API.
@@ -202,6 +205,7 @@ func _macroGodotGetVariablePropInfoSimple<T>(
 
 extension Int64: _GodotBridgeable {
     // _macroGodotGetVariablePropInfo is implemented below for all `BinaryInteger`
+    // _macroGodotGetVariablePropInfoArrayType is implemented below for all `BinaryInteger`
     
     /// Wrap a ``Int64``  into ``Variant``.
     public func toVariant() -> Variant {
@@ -235,6 +239,11 @@ public extension BinaryInteger {
             userUsage: userUsage
         )
     }
+    
+    /// Internal API. For indicating that Godot` Array` of ``BinaryInteger`` has type `Array[int]`
+    @inline(__always)
+    @inlinable
+    static var _macroGodotGetVariablePropInfoArrayType: String { "int" }
     
     /// Wrap an integer number  into ``Variant``.
     func toVariant() -> Variant {
@@ -280,6 +289,11 @@ extension Bool: _GodotBridgeable {
         )
     }
     
+    /// Internal API. For indicating that Godot` Array` of ``Bool`` has type `Array[bool]`
+    @inline(__always)
+    @inlinable
+    public static var _macroGodotGetVariablePropInfoArrayType: String { "bool" }
+    
     /// Wrap a ``Bool``  into ``Variant``.
     public func toVariant() -> Variant {
         Variant(self)
@@ -313,6 +327,11 @@ extension String: _GodotBridgeable {
         )
     }
     
+    /// Internal API. For indicating that Godot` Array` of ``BinaryInteger`` has type `Array[int]`
+    @inline(__always)
+    @inlinable
+    public static var _macroGodotGetVariablePropInfoArrayType: String { "String" }
+    
     /// Wrap a ``String``  into ``Variant``.
     public func toVariant() -> Variant {
         Variant(self)
@@ -327,6 +346,7 @@ extension String: _GodotBridgeable {
 
 extension Double: _GodotBridgeable {
     // _macroGodotGetVariablePropInfo is implemented below for all `BinaryFloatingPoint`
+    // _macroGodotGetVariablePropInfoArrayType is implemented below for all `BinaryFloatingPoint`
     
     /// Wrap a ``Double``  into ``Variant``.
     public func toVariant() -> Variant {
@@ -360,6 +380,11 @@ public extension BinaryFloatingPoint {
             userUsage: userUsage
         )
     }
+    
+    /// Internal API. For indicating that Godot` Array` of ``BinaryFloatingPoint`` has type `Array[float]`
+    @inline(__always)
+    @inlinable
+    static var _macroGodotGetVariablePropInfoArrayType: String { "float" }
     
     /// Wrap a floating point number into ``Variant``.
     func toVariant() -> Variant {

--- a/Sources/SwiftGodot/MacroIntegration/MacroExportGet.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroExportGet.swift
@@ -106,7 +106,7 @@ public func _macroExportGet<T>(
 @available(*, unavailable, message: "Optional enums are not supported by @Export macro")
 public func _macroExportGet<T>(
     _ value: T?
-) -> Variant? where T: RawRepresentable, T: CaseIterable, T.RawValue: BinaryInteger {
+) -> Variant? where T: RawRepresentable, T: CaseIterable {
     fatalError("Unreachable")
 }
 

--- a/Sources/SwiftGodot/MacroIntegration/MacroExportGet.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroExportGet.swift
@@ -5,6 +5,21 @@
 //  Created by Elijah Semyonov on 09/04/2025.
 //
 
+/// Internal API. Variant.
+@inline(__always)
+@inlinable
+public func _macroExportGet(_ value: Variant) -> Variant? {
+    return value
+}
+
+/// Internal API. Optional Variant.
+@inline(__always)
+@inlinable
+public func _macroExportGet(_ value: Variant?) -> Variant? {
+    return value
+}
+
+
 /// Internal API. Builtin type.
 @inline(__always)
 @inlinable

--- a/Sources/SwiftGodot/MacroIntegration/MacroExportSet.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroExportSet.swift
@@ -5,6 +5,47 @@
 //  Created by Elijah Semyonov on 09/04/2025.
 //
 
+/// Internal API.  Variant.
+@inline(__always)
+@inlinable
+public func _macroExportSet(
+    _ arguments: borrowing Arguments,
+    _ name: StaticString,
+    _ old: Variant,
+    _ set: (Variant) -> Void
+) -> Variant? {
+    guard let variantOrNil = arguments.first else {
+        GD.printErr("Unable to set `\(name)`, no arguments")
+        return nil
+    }
+
+    guard let variant = variantOrNil else {
+        GD.printErr("Unable to set `\(name)`, argument is nil")
+        return nil
+    }
+    
+    set(variant)
+    return nil
+}
+
+/// Internal API.  Optional Variant.
+@inline(__always)
+@inlinable
+public func _macroExportSet(
+    _ arguments: borrowing Arguments,
+    _ name: StaticString,
+    _ old: Variant?,
+    _ set: (Variant?) -> Void
+) -> Variant? {
+    guard let variantOrNil = arguments.first else {
+        GD.printErr("Unable to set `\(name)`, no arguments")
+        return nil
+    }
+    
+    set(variantOrNil)
+    return nil
+}
+
 /// Internal API.  Builtin types.
 @inline(__always)
 @inlinable

--- a/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
@@ -81,6 +81,44 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     )
 }
 
+/// Internal API. VariantCollection.
+@inline(__always)
+@inlinable
+public func _macroGodotGetVariablePropInfo<Root, T>(
+    at keyPath: KeyPath<Root, VariantCollection<T>>,
+    name: String,
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
+) -> PropInfo where T: VariantStorable, T: _GodotBridgeable {
+    VariantCollection<T>._macroGodotGetVariablePropInfo(
+        rootType: Root.self,
+        name: name,
+        userHint: userHint,
+        userHintStr: userHintStr,
+        userUsage: userUsage
+    )
+}
+
+/// Internal API. ObjectCollection.
+@inline(__always)
+@inlinable
+public func _macroGodotGetVariablePropInfo<Root, T>(
+    at keyPath: KeyPath<Root, ObjectCollection<T>>,
+    name: String,
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
+) -> PropInfo where T: Object {
+    ObjectCollection<T>._macroGodotGetVariablePropInfo(
+        rootType: Root.self,
+        name: name,
+        userHint: userHint,
+        userHintStr: userHintStr,
+        userUsage: userUsage
+    )
+}
+
 @available(*, unavailable, message: "Type is not supported for @Export")
 @_disfavoredOverload
 public func _macroGodotGetVariablePropInfo<Root, T>(

--- a/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
@@ -5,6 +5,42 @@
 //  Created by Elijah Semyonov on 10/04/2025.
 //
 
+/// Internal API. Variant.
+@inline(__always)
+@inlinable
+public func _macroGodotGetVariablePropInfo<Root>(
+    at keyPath: KeyPath<Root, Variant>,
+    name: String,
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
+) -> PropInfo {
+    Variant._macroGodotGetVariablePropInfo(
+        name: name,
+        userHint: userHint,
+        userHintStr: userHintStr,
+        userUsage: userUsage
+    )
+}
+
+/// Internal API. Optional Variant.
+@inline(__always)
+@inlinable
+public func _macroGodotGetVariablePropInfo<Root>(
+    at keyPath: KeyPath<Root, Variant?>,
+    name: String,
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
+) -> PropInfo {
+    Variant._macroGodotGetVariablePropInfo(
+        name: name,
+        userHint: userHint,
+        userHintStr: userHintStr,
+        userUsage: userUsage
+    )
+}
+
 /// Internal API. Builtin type.
 @inline(__always)
 @inlinable
@@ -125,7 +161,7 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     userHintStr: String? = nil,
     userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo where T: Object {
-    ObjectCollection<T>._macroGodotGetVariablePropInfo(        
+    ObjectCollection<T>._macroGodotGetVariablePropInfo(
         name: name,
         userHint: userHint,
         userHintStr: userHintStr,

--- a/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
@@ -108,7 +108,6 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo where T: VariantStorable, T: _GodotBridgeable {
     VariantCollection<T>._macroGodotGetVariablePropInfo(
-        rootType: Root.self,
         name: name,
         userHint: userHint,
         userHintStr: userHintStr,
@@ -126,8 +125,7 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     userHintStr: String? = nil,
     userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo where T: Object {
-    ObjectCollection<T>._macroGodotGetVariablePropInfo(
-        rootType: Root.self,
+    ObjectCollection<T>._macroGodotGetVariablePropInfo(        
         name: name,
         userHint: userHint,
         userHintStr: userHintStr,

--- a/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
@@ -11,9 +11,9 @@
 public func _macroGodotGetVariablePropInfo<Root, T>(
     at keyPath: KeyPath<Root, T>,
     name: String,
-    userHint: PropertyHint?,
-    userHintStr: String?,
-    userUsage: PropertyUsageFlags?
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo where T: _GodotBridgeable {
     T._macroGodotGetVariablePropInfo(
         rootType: Root.self,
@@ -24,17 +24,17 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     )
 }
 
-/// Internal API. Optional Builtin type.
+/// Internal API. Optional Builtin type. Facaded as Godot Variant, because Godot builtin types can't be nil, unlike objects.
 @inline(__always)
 @inlinable
 public func _macroGodotGetVariablePropInfo<Root, T>(
     at keyPath: KeyPath<Root, T?>,
     name: String,
-    userHint: PropertyHint?,
-    userHintStr: String?,
-    userUsage: PropertyUsageFlags?
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo where T: _GodotBridgeable {
-    T._macroGodotGetVariablePropInfo(
+    Variant._macroGodotGetVariablePropInfo(
         rootType: Root.self,
         name: name,
         userHint: userHint,
@@ -49,9 +49,28 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
 public func _macroGodotGetVariablePropInfo<Root, T>(
     at keyPath: KeyPath<Root, T>,
     name: String,
-    userHint: PropertyHint?,
-    userHintStr: String?,
-    userUsage: PropertyUsageFlags?
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
+) -> PropInfo where T: Object {
+    T._macroGodotGetVariablePropInfo(
+        rootType: Root.self,
+        name: name,
+        userHint: userHint,
+        userHintStr: userHintStr,
+        userUsage: userUsage
+    )
+}
+
+/// Internal API. Optional Object.
+@inline(__always)
+@inlinable
+public func _macroGodotGetVariablePropInfo<Root, T>(
+    at keyPath: KeyPath<Root, T?>,
+    name: String,
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo where T: Object {
     T._macroGodotGetVariablePropInfo(
         rootType: Root.self,
@@ -67,9 +86,9 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
 public func _macroGodotGetVariablePropInfo<Root, T>(
     at keyPath: KeyPath<Root, T>,
     name: String,
-    userHint: PropertyHint?,
-    userHintStr: String?,
-    userUsage: PropertyUsageFlags?
+    userHint: PropertyHint? = nil,
+    userHintStr: String? = nil,
+    userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo {
     fatalError("Unreachable")
 }

--- a/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
@@ -1,0 +1,75 @@
+//
+//  MacroGodotGet.swift
+//  SwiftGodot
+//
+//  Created by Elijah Semyonov on 10/04/2025.
+//
+
+/// Internal API. Builtin type.
+@inline(__always)
+@inlinable
+public func _macroGodotGetVariablePropInfo<Root, T>(
+    at keyPath: KeyPath<Root, T>,
+    name: String,
+    userHint: PropertyHint?,
+    userHintStr: String?,
+    userUsage: PropertyUsageFlags?
+) -> PropInfo where T: _GodotBridgeable {
+    T._macroGodotGetVariablePropInfo(
+        rootType: Root.self,
+        name: name,
+        userHint: userHint,
+        userHintStr: userHintStr,
+        userUsage: userUsage
+    )
+}
+
+/// Internal API. Optional Builtin type.
+@inline(__always)
+@inlinable
+public func _macroGodotGetVariablePropInfo<Root, T>(
+    at keyPath: KeyPath<Root, T?>,
+    name: String,
+    userHint: PropertyHint?,
+    userHintStr: String?,
+    userUsage: PropertyUsageFlags?
+) -> PropInfo where T: _GodotBridgeable {
+    T._macroGodotGetVariablePropInfo(
+        rootType: Root.self,
+        name: name,
+        userHint: userHint,
+        userHintStr: userHintStr,
+        userUsage: userUsage
+    )
+}
+
+/// Internal API. Object.
+@inline(__always)
+@inlinable
+public func _macroGodotGetVariablePropInfo<Root, T>(
+    at keyPath: KeyPath<Root, T>,
+    name: String,
+    userHint: PropertyHint?,
+    userHintStr: String?,
+    userUsage: PropertyUsageFlags?
+) -> PropInfo where T: Object {
+    T._macroGodotGetVariablePropInfo(
+        rootType: Root.self,
+        name: name,
+        userHint: userHint,
+        userHintStr: userHintStr,
+        userUsage: userUsage
+    )
+}
+
+@available(*, unavailable, message: "Type is not supported for @Export")
+@_disfavoredOverload
+public func _macroGodotGetVariablePropInfo<Root, T>(
+    at keyPath: KeyPath<Root, T>,
+    name: String,
+    userHint: PropertyHint?,
+    userHintStr: String?,
+    userUsage: PropertyUsageFlags?
+) -> PropInfo {
+    fatalError("Unreachable")
+}

--- a/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
+++ b/Sources/SwiftGodot/MacroIntegration/MacroGodotGetVariablePropInfo.swift
@@ -16,7 +16,6 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo where T: _GodotBridgeable {
     T._macroGodotGetVariablePropInfo(
-        rootType: Root.self,
         name: name,
         userHint: userHint,
         userHintStr: userHintStr,
@@ -35,7 +34,6 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     userUsage: PropertyUsageFlags? = nil
 ) -> PropInfo where T: _GodotBridgeable {
     Variant._macroGodotGetVariablePropInfo(
-        rootType: Root.self,
         name: name,
         userHint: userHint,
         userHintStr: userHintStr,
@@ -71,7 +69,6 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     var userHintStr = userHintStr
     improveObjectVariablePropInfo(objectType: T.self, userHint: &userHint, userHintStr: &userHintStr)
     return T._macroGodotGetVariablePropInfo(
-        rootType: Root.self,
         name: name,
         userHint: userHint,
         userHintStr: userHintStr,
@@ -92,8 +89,7 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     var userHint = userHint
     var userHintStr = userHintStr
     improveObjectVariablePropInfo(objectType: T.self, userHint: &userHint, userHintStr: &userHintStr)
-    return T._macroGodotGetVariablePropInfo(
-        rootType: Root.self,
+    return T._macroGodotGetVariablePropInfo(        
         name: name,
         userHint: userHint,
         userHintStr: userHintStr,
@@ -171,7 +167,6 @@ public func _macroGodotGetVariablePropInfo<Root, T>(
     }
     
     return _macroGodotGetVariablePropInfoSimple(
-        rootType: Root.self,
         propertyType: .int,
         name: name,
         userHint: userHint,

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -149,18 +149,16 @@ public final class Variant: Hashable, Equatable, CustomDebugStringConvertible {
         }
     }
     
-    /// Internal API. Returns ``PropInfo`` for when any ``\(typeName)`` is used as an `@Exported` variable
+    /// Internal API. Returns ``PropInfo`` for when any ``Variant`` or ``Variant?`` is used as an `@Exported` variable
     @inline(__always)
     @inlinable
-    public static func _macroGodotGetVariablePropInfo<Root>(
-        rootType: Root.Type,
+    public static func _macroGodotGetVariablePropInfo(
         name: String,
         userHint: PropertyHint?,
         userHintStr: String?,
         userUsage: PropertyUsageFlags?
     ) -> PropInfo {
         _macroGodotGetVariablePropInfoSimple(
-            rootType: Root.self,
             propertyType: .nil, // Godot treats .nil as Godot Variant
             name: name,
             userHint: userHint,

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -149,6 +149,26 @@ public final class Variant: Hashable, Equatable, CustomDebugStringConvertible, _
         }
     }
     
+    /// Internal API. Returns ``PropInfo`` for when any ``\(typeName)`` is used as an `@Exported` variable
+    @inline(__always)
+    @inlinable
+    public static func _macroGodotGetVariablePropInfo<Root>(
+        rootType: Root.Type,
+        name: String,
+        userHint: PropertyHint?,
+        userHintStr: String?,
+        userUsage: PropertyUsageFlags?
+    ) -> PropInfo {
+        _macroGodotGetVariablePropInfoSimple(
+            rootType: Root.self,
+            propertyType: .nil, // Godot treats .nil as Godot Variant
+            name: name,
+            userHint: userHint,
+            userHintStr: userHintStr,
+            userUsage: userUsage
+        )
+    }
+    
     /// Returns true if the variant is not an object, or the object is missing from the lookup table
     public var isNull: Bool {
         return asObject(Object.self) == nil

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -37,7 +37,7 @@
 ///
 /// Modifications to a container will modify all references to it.
 
-public final class Variant: Hashable, Equatable, CustomDebugStringConvertible, _GodotBridgeable {
+public final class Variant: Hashable, Equatable, CustomDebugStringConvertible {
     static let fromTypeMap: [GDExtensionVariantFromTypeConstructorFunc] = {
         var map: [GDExtensionVariantFromTypeConstructorFunc] = []
         

--- a/Sources/SwiftGodotMacroLibrary/MacroExport.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroExport.swift
@@ -35,16 +35,16 @@ extension SwiftSyntax.AttributeSyntax {
 public struct GodotExport: PeerMacro {
     static func makeGetAccessor(identifier: String) -> String {
         """
-        func _mproxy_get_\(identifier)(args: borrowing Arguments) -> Variant? {
-            _macroExportGet(\(identifier))                        
+        func _mproxy_get_\(identifier)(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+            SwiftGodot._macroExportGet(\(identifier))                        
         }                        
         """
     }
     
     static func makeSetAccessor(identifier: String) -> String {
         """
-        func _mproxy_set_\(identifier)(args: borrowing Arguments) -> Variant? {
-            _macroExportSet(args, "\(identifier)", \(identifier)) {
+        func _mproxy_set_\(identifier)(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+            SwiftGodot._macroExportSet(args, "\(identifier)", \(identifier)) {
                 \(identifier) = $0
             }
         }

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -262,8 +262,8 @@ class GodotMacroProcessor {
             let varNameWithoutPrefix = String(varNameWithPrefix.trimmingPrefix(prefix ?? ""))
             let proxySetterName = "_mproxy_set_\(varNameWithPrefix)"
             let proxyGetterName = "_mproxy_get_\(varNameWithPrefix)"
-            let setterName = "_mproxy_set_\(varNameWithoutPrefix)"
-            let getterName = "_mproxy_get_\(varNameWithoutPrefix)"
+            let setterName = "set_\(varNameWithoutPrefix.camelCaseToSnakeCase())"
+            let getterName = "get_\(varNameWithoutPrefix.camelCaseToSnakeCase())"
             
             if let accessors = singleVar.accessorBlock {
                 if CodeBlockSyntax (accessors) != nil {
@@ -396,7 +396,7 @@ class GodotMacroProcessor {
         assert(ClassDB.classExists(class: className))\n
     """
         var previousGroupPrefix: String? = nil
-        var previousSubgroupPrefix: String? = nil        
+        var previousSubgroupPrefix: String? = nil
         for member in classDecl.memberBlock.members.enumerated() {
             let decl = member.element.decl
             let macroExpansion = MacroExpansionDeclSyntax(decl)

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
@@ -30,8 +30,8 @@ class MacroGodotTestCase: XCTestCase {
     
     /// Set it to local path to regenerate expansions test data in case the macro was updated
     let regeneratedResourcesPath: String? =
-//        nil
-        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
+        nil
+//        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
         
     
     func regenerateExpansionResource(input: String, outputUrl: URL) {

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
@@ -30,8 +30,8 @@ class MacroGodotTestCase: XCTestCase {
     
     /// Set it to local path to regenerate expansions test data in case the macro was updated
     let regeneratedResourcesPath: String? =
-        nil
-        //URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
+//        nil
+        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
         
     
     func regenerateExpansionResource(input: String, outputUrl: URL) {

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArrayIntGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArrayIntGodotMacro.swift
@@ -2,14 +2,14 @@
 class SomeNode: Node {
     var someNumbers: VariantCollection<Int> = []
 
-    func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "someNumbers", someNumbers) {
+    func _mproxy_set_someNumbers(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "someNumbers", someNumbers) {
             someNumbers = $0
         }
     }
 
-    func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(someNumbers)
+    func _mproxy_get_someNumbers(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(someNumbers)
     }
 
     override open class var classInitializer: Void {
@@ -20,13 +20,13 @@ class SomeNode: Node {
     private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
-        let _psomeNumbers = PropInfo (
-            propertyType: .array,
-            propertyName: "some_numbers",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
+        let _psomeNumbers = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \SomeNode.someNumbers,
+            name: "some_numbers",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<SomeNode> (name: className)
         classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
         classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArrayStringMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArrayStringMacro.swift
@@ -1,11 +1,11 @@
 var greetings: VariantCollection<String> = []
 
-func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-    _macroExportSet(args, "greetings", greetings) {
+func _mproxy_set_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+    SwiftGodot._macroExportSet(args, "greetings", greetings) {
         greetings = $0
     }
 }
 
-func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-    _macroExportGet(greetings)
+func _mproxy_get_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+    SwiftGodot._macroExportGet(greetings)
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArraysIntGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArraysIntGodotMacro.swift
@@ -2,25 +2,25 @@
 class SomeNode: Node {
     var someNumbers: VariantCollection<Int> = []
 
-    func _mproxy_set_someNumbers(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "someNumbers", someNumbers) {
+    func _mproxy_set_someNumbers(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "someNumbers", someNumbers) {
             someNumbers = $0
         }
     }
 
-    func _mproxy_get_someNumbers(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(someNumbers)
+    func _mproxy_get_someNumbers(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(someNumbers)
     }
     var someOtherNumbers: VariantCollection<Int> = []
 
-    func _mproxy_set_someOtherNumbers(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "someOtherNumbers", someOtherNumbers) {
+    func _mproxy_set_someOtherNumbers(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "someOtherNumbers", someOtherNumbers) {
             someOtherNumbers = $0
         }
     }
 
-    func _mproxy_get_someOtherNumbers(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(someOtherNumbers)
+    func _mproxy_get_someOtherNumbers(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(someOtherNumbers)
     }
 
     override open class var classInitializer: Void {
@@ -31,24 +31,24 @@ class SomeNode: Node {
     private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
-        let _psomeNumbers = PropInfo (
-            propertyType: .array,
-            propertyName: "some_numbers",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
+        let _psomeNumbers = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \SomeNode.someNumbers,
+            name: "some_numbers",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<SomeNode> (name: className)
         classInfo.registerMethod (name: "get_some_numbers", flags: .default, returnValue: _psomeNumbers, arguments: [], function: SomeNode._mproxy_get_someNumbers)
         classInfo.registerMethod (name: "set_some_numbers", flags: .default, returnValue: nil, arguments: [_psomeNumbers], function: SomeNode._mproxy_set_someNumbers)
         classInfo.registerProperty (_psomeNumbers, getter: "get_some_numbers", setter: "set_some_numbers")
-        let _psomeOtherNumbers = PropInfo (
-            propertyType: .array,
-            propertyName: "some_other_numbers",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
+        let _psomeOtherNumbers = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \SomeNode.someOtherNumbers,
+            name: "some_other_numbers",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_some_other_numbers", flags: .default, returnValue: _psomeOtherNumbers, arguments: [], function: SomeNode._mproxy_get_someOtherNumbers)
         classInfo.registerMethod (name: "set_some_other_numbers", flags: .default, returnValue: nil, arguments: [_psomeOtherNumbers], function: SomeNode._mproxy_set_someOtherNumbers)
         classInfo.registerProperty (_psomeOtherNumbers, getter: "get_some_other_numbers", setter: "set_some_other_numbers")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportConstantGenericArrayStringMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportConstantGenericArrayStringMacro.swift
@@ -1,11 +1,11 @@
 let greetings: VariantCollection<String> = []
 
-func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-    _macroExportSet(args, "greetings", greetings) {
+func _mproxy_set_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+    SwiftGodot._macroExportSet(args, "greetings", greetings) {
         greetings = $0
     }
 }
 
-func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-    _macroExportGet(greetings)
+func _mproxy_get_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+    SwiftGodot._macroExportGet(greetings)
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGArray.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGArray.swift
@@ -2,14 +2,14 @@
 class SomeNode: Node {
     var someArray: GArray = GArray()
 
-    func _mproxy_set_someArray(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "someArray", someArray) {
+    func _mproxy_set_someArray(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "someArray", someArray) {
             someArray = $0
         }
     }
 
-    func _mproxy_get_someArray(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(someArray)
+    func _mproxy_get_someArray(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(someArray)
     }
 
     override open class var classInitializer: Void {
@@ -20,16 +20,16 @@ class SomeNode: Node {
     private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
-        let _psomeArray = PropInfo (
-            propertyType: .array,
-            propertyName: "someArray",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+        let _psomeArray = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \SomeNode.someArray,
+            name: "some_array",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<SomeNode> (name: className)
-        classInfo.registerMethod (name: "_mproxy_get_someArray", flags: .default, returnValue: _psomeArray, arguments: [], function: SomeNode._mproxy_get_someArray)
-        classInfo.registerMethod (name: "_mproxy_set_someArray", flags: .default, returnValue: nil, arguments: [_psomeArray], function: SomeNode._mproxy_set_someArray)
-        classInfo.registerProperty (_psomeArray, getter: "_mproxy_get_someArray", setter: "_mproxy_set_someArray")
+        classInfo.registerMethod (name: "get_some_array", flags: .default, returnValue: _psomeArray, arguments: [], function: SomeNode._mproxy_get_someArray)
+        classInfo.registerMethod (name: "set_some_array", flags: .default, returnValue: nil, arguments: [_psomeArray], function: SomeNode._mproxy_set_someArray)
+        classInfo.registerProperty (_psomeArray, getter: "get_some_array", setter: "set_some_array")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGenericArrayStringGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGenericArrayStringGodotMacro.swift
@@ -2,14 +2,14 @@
 class SomeNode: Node {
     var greetings: VariantCollection<String> = []
 
-    func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "greetings", greetings) {
+    func _mproxy_set_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "greetings", greetings) {
             greetings = $0
         }
     }
 
-    func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(greetings)
+    func _mproxy_get_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(greetings)
     }
 
     override open class var classInitializer: Void {
@@ -20,13 +20,13 @@ class SomeNode: Node {
     private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
-        let _pgreetings = PropInfo (
-            propertyType: .array,
-            propertyName: "greetings",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pgreetings = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \SomeNode.greetings,
+            name: "greetings",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<SomeNode> (name: className)
         classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
         classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGenericArrayStringMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGenericArrayStringMacro.swift
@@ -1,11 +1,11 @@
 var greetings: VariantCollection<String> = []
 
-func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-    _macroExportSet(args, "greetings", greetings) {
+func _mproxy_set_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+    SwiftGodot._macroExportSet(args, "greetings", greetings) {
         greetings = $0
     }
 }
 
-func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-    _macroExportGet(greetings)
+func _mproxy_get_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+    SwiftGodot._macroExportGet(greetings)
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportObjectCollection.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportObjectCollection.swift
@@ -1,11 +1,11 @@
 var greetings: ObjectCollection<Node3D> = []
 
-func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-    _macroExportSet(args, "greetings", greetings) {
+func _mproxy_set_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+    SwiftGodot._macroExportSet(args, "greetings", greetings) {
         greetings = $0
     }
 }
 
-func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-    _macroExportGet(greetings)
+func _mproxy_get_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+    SwiftGodot._macroExportGet(greetings)
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportObjectCollection.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportObjectCollection.swift
@@ -2,14 +2,14 @@
 class SomeNode: Node {
     var greetings: ObjectCollection<Node3D> = []
 
-    func _mproxy_set_greetings(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "greetings", greetings) {
+    func _mproxy_set_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "greetings", greetings) {
             greetings = $0
         }
     }
 
-    func _mproxy_get_greetings(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(greetings)
+    func _mproxy_get_greetings(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(greetings)
     }
 
     override open class var classInitializer: Void {
@@ -20,13 +20,13 @@ class SomeNode: Node {
     private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
-        let _pgreetings = PropInfo (
-            propertyType: .array,
-            propertyName: "greetings",
-            className: StringName("Array[Node3D]"),
-            hint: .arrayType,
-            hintStr: "Node3D",
-            usage: .default)
+        let _pgreetings = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \SomeNode.greetings,
+            name: "greetings",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<SomeNode> (name: className)
         classInfo.registerMethod (name: "get_greetings", flags: .default, returnValue: _pgreetings, arguments: [], function: SomeNode._mproxy_get_greetings)
         classInfo.registerMethod (name: "set_greetings", flags: .default, returnValue: nil, arguments: [_pgreetings], function: SomeNode._mproxy_set_greetings)

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTwoStringArrays.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTwoStringArrays.swift
@@ -2,25 +2,25 @@ import SwiftGodot
 class ArrayTest: Node {
    var firstNames: VariantCollection<String> = ["Thelonius"]
 
-   func _mproxy_set_firstNames(args: borrowing Arguments) -> Variant? {
-       _macroExportSet(args, "firstNames", firstNames) {
+   func _mproxy_set_firstNames(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+       SwiftGodot._macroExportSet(args, "firstNames", firstNames) {
            firstNames = $0
        }
    }
 
-   func _mproxy_get_firstNames(args: borrowing Arguments) -> Variant? {
-       _macroExportGet(firstNames)
+   func _mproxy_get_firstNames(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+       SwiftGodot._macroExportGet(firstNames)
    }
    var lastNames: VariantCollection<String> = ["Monk"]
 
-   func _mproxy_set_lastNames(args: borrowing Arguments) -> Variant? {
-       _macroExportSet(args, "lastNames", lastNames) {
+   func _mproxy_set_lastNames(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+       SwiftGodot._macroExportSet(args, "lastNames", lastNames) {
            lastNames = $0
        }
    }
 
-   func _mproxy_get_lastNames(args: borrowing Arguments) -> Variant? {
-       _macroExportGet(lastNames)
+   func _mproxy_get_lastNames(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+       SwiftGodot._macroExportGet(lastNames)
    }
 
     override open class var classInitializer: Void {
@@ -31,24 +31,24 @@ class ArrayTest: Node {
     private static let _initializeClass: Void = {
         let className = StringName("ArrayTest")
         assert(ClassDB.classExists(class: className))
-        let _pfirstNames = PropInfo (
-            propertyType: .array,
-            propertyName: "first_names",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pfirstNames = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \ArrayTest.firstNames,
+            name: "first_names",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<ArrayTest> (name: className)
         classInfo.registerMethod (name: "get_first_names", flags: .default, returnValue: _pfirstNames, arguments: [], function: ArrayTest._mproxy_get_firstNames)
         classInfo.registerMethod (name: "set_first_names", flags: .default, returnValue: nil, arguments: [_pfirstNames], function: ArrayTest._mproxy_set_firstNames)
         classInfo.registerProperty (_pfirstNames, getter: "get_first_names", setter: "set_first_names")
-        let _plastNames = PropInfo (
-            propertyType: .array,
-            propertyName: "last_names",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _plastNames = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \ArrayTest.lastNames,
+            name: "last_names",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_last_names", flags: .default, returnValue: _plastNames, arguments: [], function: ArrayTest._mproxy_get_lastNames)
         classInfo.registerMethod (name: "set_last_names", flags: .default, returnValue: nil, arguments: [_plastNames], function: ArrayTest._mproxy_set_lastNames)
         classInfo.registerProperty (_plastNames, getter: "get_last_names", setter: "set_last_names")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportEnumTests.testExportEnumGodot.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportEnumTests.testExportEnumGodot.swift
@@ -7,25 +7,25 @@ enum Demo64: Int64, CaseIterable {
 class SomeNode: Node {
     var demo: Demo
 
-    func _mproxy_set_demo(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "demo", demo) {
+    func _mproxy_set_demo(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "demo", demo) {
             demo = $0
         }
     }
 
-    func _mproxy_get_demo(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(demo)
+    func _mproxy_get_demo(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(demo)
     }
     var demo64: Demo64
 
-    func _mproxy_set_demo64(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "demo64", demo64) {
+    func _mproxy_set_demo64(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "demo64", demo64) {
             demo64 = $0
         }
     }
 
-    func _mproxy_get_demo64(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(demo64)
+    func _mproxy_get_demo64(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(demo64)
     }
 
     override open class var classInitializer: Void {
@@ -36,34 +36,26 @@ class SomeNode: Node {
     private static let _initializeClass: Void = {
         let className = StringName("SomeNode")
         assert(ClassDB.classExists(class: className))
-        let _pdemo = PropInfo (
-            propertyType: .int,
-            propertyName: "demo",
-            className: className,
-            hint: .enum,
-            hintStr: tryCase (Demo.self),
-            usage: .default)
+        let _pdemo = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \SomeNode.demo,
+            name: "demo",
+            userHint: .enum,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<SomeNode> (name: className)
-        classInfo.registerMethod (name: "_mproxy_get_demo", flags: .default, returnValue: _pdemo, arguments: [], function: SomeNode._mproxy_get_demo)
-        classInfo.registerMethod (name: "_mproxy_set_demo", flags: .default, returnValue: nil, arguments: [_pdemo], function: SomeNode._mproxy_set_demo)
-        classInfo.registerProperty (_pdemo, getter: "_mproxy_get_demo", setter: "_mproxy_set_demo")
-        let _pdemo64 = PropInfo (
-            propertyType: .int,
-            propertyName: "demo64",
-            className: className,
-            hint: .enum,
-            hintStr: tryCase (Demo64.self),
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_demo64", flags: .default, returnValue: _pdemo64, arguments: [], function: SomeNode._mproxy_get_demo64)
-        classInfo.registerMethod (name: "_mproxy_set_demo64", flags: .default, returnValue: nil, arguments: [_pdemo64], function: SomeNode._mproxy_set_demo64)
-        classInfo.registerProperty (_pdemo64, getter: "_mproxy_get_demo64", setter: "_mproxy_set_demo64")
-        func tryCase <T : RawRepresentable & CaseIterable> (_ type: T.Type) -> GString {
-            GString (type.allCases.map { v in
-                "\(v):\(v.rawValue)"
-            } .joined(separator: ","))
-        }
-        func tryCase <T : RawRepresentable> (_ type: T.Type) -> String {
-            ""
-        }
+        classInfo.registerMethod (name: "get_demo", flags: .default, returnValue: _pdemo, arguments: [], function: SomeNode._mproxy_get_demo)
+        classInfo.registerMethod (name: "set_demo", flags: .default, returnValue: nil, arguments: [_pdemo], function: SomeNode._mproxy_set_demo)
+        classInfo.registerProperty (_pdemo, getter: "get_demo", setter: "set_demo")
+        let _pdemo64 = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \SomeNode.demo64,
+            name: "demo64",
+            userHint: .enum,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_demo64", flags: .default, returnValue: _pdemo64, arguments: [], function: SomeNode._mproxy_get_demo64)
+        classInfo.registerMethod (name: "set_demo64", flags: .default, returnValue: nil, arguments: [_pdemo64], function: SomeNode._mproxy_set_demo64)
+        classInfo.registerProperty (_pdemo64, getter: "get_demo64", setter: "set_demo64")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesObjectCollectionPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesObjectCollectionPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vins", vins) {
+    func _mproxy_set_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vins", vins) {
             vins = $0
         }
     }
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vins)
+    func _mproxy_get_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vins)
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "years", years) {
+    func _mproxy_set_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "years", years) {
             years = $0
         }
     }
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(years)
+    func _mproxy_get_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(years)
     }
 
     override open class var classInitializer: Void {
@@ -31,25 +31,25 @@ class Car: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pvins = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vins,
+            name: "vins",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
         classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
         classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMMS", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pyears = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.years,
+            name: "years",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
         classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
         classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var vin: String = "00000000000000000"
 
-    func _mproxy_set_vin(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vin", vin) {
+    func _mproxy_set_vin(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vin", vin) {
             vin = $0
         }
     }
 
-    func _mproxy_get_vin(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vin)
+    func _mproxy_get_vin(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "year", year) {
+    func _mproxy_set_year(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "year", year) {
             year = $0
         }
     }
 
-    func _mproxy_get_year(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(year)
+    func _mproxy_get_year(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(year)
     }
 
     override open class var classInitializer: Void {
@@ -31,27 +31,27 @@ class Car: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
-        let _pvin = PropInfo (
-            propertyType: .string,
-            propertyName: "vin",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+        let _pvin = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vin,
+            name: "vin",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Car> (name: className)
-        classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-        classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-        classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+        classInfo.registerMethod (name: "get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+        classInfo.registerMethod (name: "set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+        classInfo.registerProperty (_pvin, getter: "get_vin", setter: "set_vin")
         classInfo.addPropertyGroup(name: "YMMS", prefix: "")
-        let _pyear = PropInfo (
-            propertyType: .int,
-            propertyName: "year",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-        classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-        classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+        let _pyear = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.year,
+            name: "year",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+        classInfo.registerMethod (name: "set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+        classInfo.registerProperty (_pyear, getter: "get_year", setter: "set_year")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesVariantCollectionPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesVariantCollectionPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vins", vins) {
+    func _mproxy_set_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vins", vins) {
             vins = $0
         }
     }
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vins)
+    func _mproxy_get_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vins)
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "years", years) {
+    func _mproxy_set_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "years", years) {
             years = $0
         }
     }
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(years)
+    func _mproxy_get_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(years)
     }
 
     override open class var classInitializer: Void {
@@ -31,25 +31,25 @@ class Car: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pvins = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vins,
+            name: "vins",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
         classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
         classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMMS", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
+        let _pyears = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.years,
+            name: "years",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
         classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
         classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesObjectCollectionPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesObjectCollectionPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
@@ -2,47 +2,47 @@
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vins", vins) {
+    func _mproxy_set_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vins", vins) {
             vins = $0
         }
     }
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vins)
+    func _mproxy_get_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vins)
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "years", years) {
+    func _mproxy_set_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "years", years) {
             years = $0
         }
     }
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(years)
+    func _mproxy_get_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(years)
     }
     var makes: ObjectCollection<Node> = []
 
-    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "makes", makes) {
+    func _mproxy_set_makes(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "makes", makes) {
             makes = $0
         }
     }
 
-    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(makes)
+    func _mproxy_get_makes(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(makes)
     }
     var models: ObjectCollection<Node> = []
 
-    func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "models", models) {
+    func _mproxy_set_models(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "models", models) {
             models = $0
         }
     }
 
-    func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(models)
+    func _mproxy_get_models(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(models)
     }
 
     override open class var classInitializer: Void {
@@ -55,44 +55,44 @@ class Car: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.addPropertyGroup(name: "VIN", prefix: "")
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pvins = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vins,
+            name: "vins",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
         classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
         classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMM", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pyears = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.years,
+            name: "years",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
         classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
         classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
-        let _pmakes = PropInfo (
-            propertyType: .array,
-            propertyName: "makes",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pmakes = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.makes,
+            name: "makes",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
         classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
         classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
-        let _pmodels = PropInfo (
-            propertyType: .array,
-            propertyName: "models",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pmodels = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.models,
+            name: "models",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
         classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
         classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesObjectCollectionPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesObjectCollectionPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var makes: ObjectCollection<Node> = []
 
-    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "makes", makes) {
+    func _mproxy_set_makes(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "makes", makes) {
             makes = $0
         }
     }
 
-    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(makes)
+    func _mproxy_get_makes(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(makes)
     }
     var model: ObjectCollection<Node> = []
 
-    func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "model", model) {
+    func _mproxy_set_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "model", model) {
             model = $0
         }
     }
 
-    func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(model)
+    func _mproxy_get_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(model)
     }
 
     override open class var classInitializer: Void {
@@ -33,23 +33,23 @@ class Car: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
-        let _pmakes = PropInfo (
-            propertyType: .array,
-            propertyName: "makes",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pmakes = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.makes,
+            name: "makes",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
         classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
         classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
-        let _pmodel = PropInfo (
-            propertyType: .array,
-            propertyName: "model",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pmodel = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.model,
+            name: "model",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
         classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
         classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesObjectCollectionPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesObjectCollectionPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var vins: ObjectCollection<Node> = []
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vins", vins) {
+    func _mproxy_set_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vins", vins) {
             vins = $0
         }
     }
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vins)
+    func _mproxy_get_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vins)
     }
     var years: ObjectCollection<Node> = []
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "years", years) {
+    func _mproxy_set_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "years", years) {
             years = $0
         }
     }
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(years)
+    func _mproxy_get_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(years)
     }
 
     override open class var classInitializer: Void {
@@ -31,24 +31,24 @@ class Car: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pvins = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vins,
+            name: "vins",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
         classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
         classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[Node]"),
-            hint: .arrayType,
-            hintStr: "Node",
-            usage: .default)
+        let _pyears = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.years,
+            name: "years",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
         classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
         classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenMixingVariantCollectionObjectCollectionAndNormalVariableProperties.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenMixingVariantCollectionObjectCollectionAndNormalVariableProperties.swift
@@ -2,91 +2,91 @@
 class Garage: Node {
     var name: String = ""
 
-    func _mproxy_set_name(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "name", name) {
+    func _mproxy_set_name(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "name", name) {
             name = $0
         }
     }
 
-    func _mproxy_get_name(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(name)
+    func _mproxy_get_name(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(name)
     }
     var rating: Float = 0.0
 
-    func _mproxy_set_rating(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "rating", rating) {
+    func _mproxy_set_rating(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "rating", rating) {
             rating = $0
         }
     }
 
-    func _mproxy_get_rating(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(rating)
+    func _mproxy_get_rating(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(rating)
     }
     var reviews: VariantCollection<String> = []
 
-    func _mproxy_set_reviews(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "reviews", reviews) {
+    func _mproxy_set_reviews(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "reviews", reviews) {
             reviews = $0
         }
     }
 
-    func _mproxy_get_reviews(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(reviews)
+    func _mproxy_get_reviews(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(reviews)
     }
     var checkIns: ObjectCollection<CheckIn> = []
 
-    func _mproxy_set_checkIns(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "checkIns", checkIns) {
+    func _mproxy_set_checkIns(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "checkIns", checkIns) {
             checkIns = $0
         }
     }
 
-    func _mproxy_get_checkIns(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(checkIns)
+    func _mproxy_get_checkIns(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(checkIns)
     }
     var address: String = ""
 
-    func _mproxy_set_address(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "address", address) {
+    func _mproxy_set_address(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "address", address) {
             address = $0
         }
     }
 
-    func _mproxy_get_address(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(address)
+    func _mproxy_get_address(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(address)
     }
     var daysOfOperation: VariantCollection<String> = []
 
-    func _mproxy_set_daysOfOperation(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "daysOfOperation", daysOfOperation) {
+    func _mproxy_set_daysOfOperation(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "daysOfOperation", daysOfOperation) {
             daysOfOperation = $0
         }
     }
 
-    func _mproxy_get_daysOfOperation(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(daysOfOperation)
+    func _mproxy_get_daysOfOperation(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(daysOfOperation)
     }
     var hours: VariantCollection<String> = []
 
-    func _mproxy_set_hours(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "hours", hours) {
+    func _mproxy_set_hours(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "hours", hours) {
             hours = $0
         }
     }
 
-    func _mproxy_get_hours(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(hours)
+    func _mproxy_get_hours(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(hours)
     }
     var insuranceProvidersAccepted: ObjectCollection<InsuranceProvider> = []
 
-    func _mproxy_set_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "insuranceProvidersAccepted", insuranceProvidersAccepted) {
+    func _mproxy_set_insuranceProvidersAccepted(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "insuranceProvidersAccepted", insuranceProvidersAccepted) {
             insuranceProvidersAccepted = $0
         }
     }
 
-    func _mproxy_get_insuranceProvidersAccepted(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(insuranceProvidersAccepted)
+    func _mproxy_get_insuranceProvidersAccepted(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(insuranceProvidersAccepted)
     }
 
     override open class var classInitializer: Void {
@@ -99,85 +99,85 @@ class Garage: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Garage> (name: className)
         classInfo.addPropertyGroup(name: "Front Page", prefix: "")
-        let _pname = PropInfo (
-            propertyType: .string,
-            propertyName: "name",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_name", flags: .default, returnValue: _pname, arguments: [], function: Garage._mproxy_get_name)
-        classInfo.registerMethod (name: "_mproxy_set_name", flags: .default, returnValue: nil, arguments: [_pname], function: Garage._mproxy_set_name)
-        classInfo.registerProperty (_pname, getter: "_mproxy_get_name", setter: "_mproxy_set_name")
-        let _prating = PropInfo (
-            propertyType: .float,
-            propertyName: "rating",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_rating", flags: .default, returnValue: _prating, arguments: [], function: Garage._mproxy_get_rating)
-        classInfo.registerMethod (name: "_mproxy_set_rating", flags: .default, returnValue: nil, arguments: [_prating], function: Garage._mproxy_set_rating)
-        classInfo.registerProperty (_prating, getter: "_mproxy_get_rating", setter: "_mproxy_set_rating")
+        let _pname = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.name,
+            name: "name",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_name", flags: .default, returnValue: _pname, arguments: [], function: Garage._mproxy_get_name)
+        classInfo.registerMethod (name: "set_name", flags: .default, returnValue: nil, arguments: [_pname], function: Garage._mproxy_set_name)
+        classInfo.registerProperty (_pname, getter: "get_name", setter: "set_name")
+        let _prating = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.rating,
+            name: "rating",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_rating", flags: .default, returnValue: _prating, arguments: [], function: Garage._mproxy_get_rating)
+        classInfo.registerMethod (name: "set_rating", flags: .default, returnValue: nil, arguments: [_prating], function: Garage._mproxy_set_rating)
+        classInfo.registerProperty (_prating, getter: "get_rating", setter: "set_rating")
         classInfo.addPropertyGroup(name: "More Details", prefix: "")
-        let _previews = PropInfo (
-            propertyType: .array,
-            propertyName: "reviews",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _previews = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.reviews,
+            name: "reviews",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_reviews", flags: .default, returnValue: _previews, arguments: [], function: Garage._mproxy_get_reviews)
         classInfo.registerMethod (name: "set_reviews", flags: .default, returnValue: nil, arguments: [_previews], function: Garage._mproxy_set_reviews)
         classInfo.registerProperty (_previews, getter: "get_reviews", setter: "set_reviews")
-        let _pcheckIns = PropInfo (
-            propertyType: .array,
-            propertyName: "check_ins",
-            className: StringName("Array[CheckIn]"),
-            hint: .arrayType,
-            hintStr: "CheckIn",
-            usage: .default)
+        let _pcheckIns = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.checkIns,
+            name: "check_ins",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_check_ins", flags: .default, returnValue: _pcheckIns, arguments: [], function: Garage._mproxy_get_checkIns)
         classInfo.registerMethod (name: "set_check_ins", flags: .default, returnValue: nil, arguments: [_pcheckIns], function: Garage._mproxy_set_checkIns)
         classInfo.registerProperty (_pcheckIns, getter: "get_check_ins", setter: "set_check_ins")
-        let _paddress = PropInfo (
-            propertyType: .string,
-            propertyName: "address",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_address", flags: .default, returnValue: _paddress, arguments: [], function: Garage._mproxy_get_address)
-        classInfo.registerMethod (name: "_mproxy_set_address", flags: .default, returnValue: nil, arguments: [_paddress], function: Garage._mproxy_set_address)
-        classInfo.registerProperty (_paddress, getter: "_mproxy_get_address", setter: "_mproxy_set_address")
+        let _paddress = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.address,
+            name: "address",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_address", flags: .default, returnValue: _paddress, arguments: [], function: Garage._mproxy_get_address)
+        classInfo.registerMethod (name: "set_address", flags: .default, returnValue: nil, arguments: [_paddress], function: Garage._mproxy_set_address)
+        classInfo.registerProperty (_paddress, getter: "get_address", setter: "set_address")
         classInfo.addPropertyGroup(name: "Hours and Insurance", prefix: "")
-        let _pdaysOfOperation = PropInfo (
-            propertyType: .array,
-            propertyName: "days_of_operation",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pdaysOfOperation = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.daysOfOperation,
+            name: "days_of_operation",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_days_of_operation", flags: .default, returnValue: _pdaysOfOperation, arguments: [], function: Garage._mproxy_get_daysOfOperation)
         classInfo.registerMethod (name: "set_days_of_operation", flags: .default, returnValue: nil, arguments: [_pdaysOfOperation], function: Garage._mproxy_set_daysOfOperation)
         classInfo.registerProperty (_pdaysOfOperation, getter: "get_days_of_operation", setter: "set_days_of_operation")
-        let _phours = PropInfo (
-            propertyType: .array,
-            propertyName: "hours",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _phours = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.hours,
+            name: "hours",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_hours", flags: .default, returnValue: _phours, arguments: [], function: Garage._mproxy_get_hours)
         classInfo.registerMethod (name: "set_hours", flags: .default, returnValue: nil, arguments: [_phours], function: Garage._mproxy_set_hours)
         classInfo.registerProperty (_phours, getter: "get_hours", setter: "set_hours")
-        let _pinsuranceProvidersAccepted = PropInfo (
-            propertyType: .array,
-            propertyName: "insurance_providers_accepted",
-            className: StringName("Array[InsuranceProvider]"),
-            hint: .arrayType,
-            hintStr: "InsuranceProvider",
-            usage: .default)
+        let _pinsuranceProvidersAccepted = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.insuranceProvidersAccepted,
+            name: "insurance_providers_accepted",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_insurance_providers_accepted", flags: .default, returnValue: _pinsuranceProvidersAccepted, arguments: [], function: Garage._mproxy_get_insuranceProvidersAccepted)
         classInfo.registerMethod (name: "set_insurance_providers_accepted", flags: .default, returnValue: nil, arguments: [_pinsuranceProvidersAccepted], function: Garage._mproxy_set_insuranceProvidersAccepted)
         classInfo.registerProperty (_pinsuranceProvidersAccepted, getter: "get_insurance_providers_accepted", setter: "set_insurance_providers_accepted")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
@@ -2,47 +2,47 @@
 class Car: Node {
     var vin: String = ""
 
-    func _mproxy_set_vin(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vin", vin) {
+    func _mproxy_set_vin(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vin", vin) {
             vin = $0
         }
     }
 
-    func _mproxy_get_vin(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vin)
+    func _mproxy_get_vin(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "year", year) {
+    func _mproxy_set_year(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "year", year) {
             year = $0
         }
     }
 
-    func _mproxy_get_year(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(year)
+    func _mproxy_get_year(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(year)
     }
     var make: String = "HONDA"
 
-    func _mproxy_set_make(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "make", make) {
+    func _mproxy_set_make(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "make", make) {
             make = $0
         }
     }
 
-    func _mproxy_get_make(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(make)
+    func _mproxy_get_make(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(make)
     }
     var model: String = "ACCORD"
 
-    func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "model", model) {
+    func _mproxy_set_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "model", model) {
             model = $0
         }
     }
 
-    func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(model)
+    func _mproxy_get_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(model)
     }
 
     override open class var classInitializer: Void {
@@ -55,47 +55,47 @@ class Car: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.addPropertyGroup(name: "VIN", prefix: "")
-        let _pvin = PropInfo (
-            propertyType: .string,
-            propertyName: "vin",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-        classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-        classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+        let _pvin = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vin,
+            name: "vin",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+        classInfo.registerMethod (name: "set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+        classInfo.registerProperty (_pvin, getter: "get_vin", setter: "set_vin")
         classInfo.addPropertyGroup(name: "YMM", prefix: "")
-        let _pyear = PropInfo (
-            propertyType: .int,
-            propertyName: "year",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-        classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-        classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
-        let _pmake = PropInfo (
-            propertyType: .string,
-            propertyName: "make",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
-        classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
-        classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
-        let _pmodel = PropInfo (
-            propertyType: .string,
-            propertyName: "model",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-        classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-        classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+        let _pyear = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.year,
+            name: "year",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+        classInfo.registerMethod (name: "set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+        classInfo.registerProperty (_pyear, getter: "get_year", setter: "set_year")
+        let _pmake = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.make,
+            name: "make",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
+        classInfo.registerMethod (name: "set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
+        classInfo.registerProperty (_pmake, getter: "get_make", setter: "set_make")
+        let _pmodel = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.model,
+            name: "model",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+        classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+        classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
     } ()
     
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var make: String = "Mazda"
 
-    func _mproxy_set_make(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "make", make) {
+    func _mproxy_set_make(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "make", make) {
             make = $0
         }
     }
 
-    func _mproxy_get_make(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(make)
+    func _mproxy_get_make(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(make)
     }
     var model: String = "RX7"
 
-    func _mproxy_set_model(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "model", model) {
+    func _mproxy_set_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "model", model) {
             model = $0
         }
     }
 
-    func _mproxy_get_model(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(model)
+    func _mproxy_get_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(model)
     }
 
     override open class var classInitializer: Void {
@@ -33,25 +33,25 @@ class Car: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
-        let _pmake = PropInfo (
-            propertyType: .string,
-            propertyName: "make",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
-        classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
-        classInfo.registerProperty (_pmake, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
-        let _pmodel = PropInfo (
-            propertyType: .string,
-            propertyName: "model",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
-        classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
-        classInfo.registerProperty (_pmodel, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+        let _pmake = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.make,
+            name: "make",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_make", flags: .default, returnValue: _pmake, arguments: [], function: Car._mproxy_get_make)
+        classInfo.registerMethod (name: "set_make", flags: .default, returnValue: nil, arguments: [_pmake], function: Car._mproxy_set_make)
+        classInfo.registerProperty (_pmake, getter: "get_make", setter: "set_make")
+        let _pmodel = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.model,
+            name: "model",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pmodel, arguments: [], function: Car._mproxy_get_model)
+        classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pmodel], function: Car._mproxy_set_model)
+        classInfo.registerProperty (_pmodel, getter: "get_model", setter: "set_model")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var vin: String = "00000000000000000"
 
-    func _mproxy_set_vin(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vin", vin) {
+    func _mproxy_set_vin(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vin", vin) {
             vin = $0
         }
     }
 
-    func _mproxy_get_vin(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vin)
+    func _mproxy_get_vin(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vin)
     }
     var year: Int = 1997
 
-    func _mproxy_set_year(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "year", year) {
+    func _mproxy_set_year(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "year", year) {
             year = $0
         }
     }
 
-    func _mproxy_get_year(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(year)
+    func _mproxy_get_year(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(year)
     }
 
     override open class var classInitializer: Void {
@@ -31,27 +31,27 @@ class Car: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
-        let _pvin = PropInfo (
-            propertyType: .string,
-            propertyName: "vin",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+        let _pvin = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vin,
+            name: "vin",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Car> (name: className)
-        classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-        classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-        classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
-        let _pyear = PropInfo (
-            propertyType: .int,
-            propertyName: "year",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
-        classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
-        classInfo.registerProperty (_pyear, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
+        classInfo.registerMethod (name: "get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+        classInfo.registerMethod (name: "set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+        classInfo.registerProperty (_pvin, getter: "get_vin", setter: "set_vin")
+        let _pyear = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.year,
+            name: "year",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_year", flags: .default, returnValue: _pyear, arguments: [], function: Car._mproxy_get_year)
+        classInfo.registerMethod (name: "set_year", flags: .default, returnValue: nil, arguments: [_pyear], function: Car._mproxy_set_year)
+        classInfo.registerProperty (_pyear, getter: "get_year", setter: "set_year")
         classInfo.addPropertyGroup(name: "Pointless", prefix: "")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesVariantCollectionPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesVariantCollectionPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
@@ -2,47 +2,47 @@
 class Car: Node {
     var vins: VariantCollection<String> = [""]
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vins", vins) {
+    func _mproxy_set_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vins", vins) {
             vins = $0
         }
     }
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vins)
+    func _mproxy_get_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vins)
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "years", years) {
+    func _mproxy_set_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "years", years) {
             years = $0
         }
     }
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(years)
+    func _mproxy_get_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(years)
     }
     var makes: VariantCollection<String> = ["HONDA"]
 
-    func _mproxy_set_makes(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "makes", makes) {
+    func _mproxy_set_makes(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "makes", makes) {
             makes = $0
         }
     }
 
-    func _mproxy_get_makes(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(makes)
+    func _mproxy_get_makes(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(makes)
     }
     var models: VariantCollection<String> = ["ACCORD"]
 
-    func _mproxy_set_models(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "models", models) {
+    func _mproxy_set_models(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "models", models) {
             models = $0
         }
     }
 
-    func _mproxy_get_models(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(models)
+    func _mproxy_get_models(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(models)
     }
 
     override open class var classInitializer: Void {
@@ -55,44 +55,44 @@ class Car: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.addPropertyGroup(name: "VIN", prefix: "")
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pvins = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vins,
+            name: "vins",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
         classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
         classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMM", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
+        let _pyears = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.years,
+            name: "years",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
         classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
         classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")
-        let _pmakes = PropInfo (
-            propertyType: .array,
-            propertyName: "makes",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pmakes = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.makes,
+            name: "makes",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_makes", flags: .default, returnValue: _pmakes, arguments: [], function: Car._mproxy_get_makes)
         classInfo.registerMethod (name: "set_makes", flags: .default, returnValue: nil, arguments: [_pmakes], function: Car._mproxy_set_makes)
         classInfo.registerProperty (_pmakes, getter: "get_makes", setter: "set_makes")
-        let _pmodels = PropInfo (
-            propertyType: .array,
-            propertyName: "models",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pmodels = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.models,
+            name: "models",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_models", flags: .default, returnValue: _pmodels, arguments: [], function: Car._mproxy_get_models)
         classInfo.registerMethod (name: "set_models", flags: .default, returnValue: nil, arguments: [_pmodels], function: Car._mproxy_set_models)
         classInfo.registerProperty (_pmodels, getter: "get_models", setter: "set_models")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesVariantCollectionPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesVariantCollectionPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vins", vins) {
+    func _mproxy_set_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vins", vins) {
             vins = $0
         }
     }
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vins)
+    func _mproxy_get_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vins)
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "years", years) {
+    func _mproxy_set_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "years", years) {
             years = $0
         }
     }
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(years)
+    func _mproxy_get_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(years)
     }
 
     override open class var classInitializer: Void {
@@ -31,25 +31,25 @@ class Car: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pvins = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vins,
+            name: "vins",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
         classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
         classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
         classInfo.addPropertyGroup(name: "YMMS", prefix: "")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
+        let _pyears = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.years,
+            name: "years",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
         classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
         classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesVariantCollectionPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesVariantCollectionPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var vins: VariantCollection<String> = ["00000000000000000"]
 
-    func _mproxy_set_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vins", vins) {
+    func _mproxy_set_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vins", vins) {
             vins = $0
         }
     }
 
-    func _mproxy_get_vins(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vins)
+    func _mproxy_get_vins(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vins)
     }
     var years: VariantCollection<Int> = [1997]
 
-    func _mproxy_set_years(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "years", years) {
+    func _mproxy_set_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "years", years) {
             years = $0
         }
     }
 
-    func _mproxy_get_years(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(years)
+    func _mproxy_get_years(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(years)
     }
 
     override open class var classInitializer: Void {
@@ -31,24 +31,24 @@ class Car: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Car")
         assert(ClassDB.classExists(class: className))
-        let _pvins = PropInfo (
-            propertyType: .array,
-            propertyName: "vins",
-            className: StringName("Array[String]"),
-            hint: .arrayType,
-            hintStr: "String",
-            usage: .default)
+        let _pvins = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vins,
+            name: "vins",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.registerMethod (name: "get_vins", flags: .default, returnValue: _pvins, arguments: [], function: Car._mproxy_get_vins)
         classInfo.registerMethod (name: "set_vins", flags: .default, returnValue: nil, arguments: [_pvins], function: Car._mproxy_set_vins)
         classInfo.registerProperty (_pvins, getter: "get_vins", setter: "set_vins")
-        let _pyears = PropInfo (
-            propertyType: .array,
-            propertyName: "years",
-            className: StringName("Array[int]"),
-            hint: .arrayType,
-            hintStr: "int",
-            usage: .default)
+        let _pyears = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.years,
+            name: "years",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_years", flags: .default, returnValue: _pyears, arguments: [], function: Car._mproxy_get_years)
         classInfo.registerMethod (name: "set_years", flags: .default, returnValue: nil, arguments: [_pyears], function: Car._mproxy_set_years)
         classInfo.registerProperty (_pyears, getter: "get_years", setter: "set_years")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefix.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefix.swift
@@ -2,25 +2,25 @@
 class Car: Node {
     var vehicle_make: String = "Mazda"
 
-    func _mproxy_set_vehicle_make(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vehicle_make", vehicle_make) {
+    func _mproxy_set_vehicle_make(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vehicle_make", vehicle_make) {
             vehicle_make = $0
         }
     }
 
-    func _mproxy_get_vehicle_make(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vehicle_make)
+    func _mproxy_get_vehicle_make(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vehicle_make)
     }
     var vehicle_model: String = "RX7"
 
-    func _mproxy_set_vehicle_model(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vehicle_model", vehicle_model) {
+    func _mproxy_set_vehicle_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vehicle_model", vehicle_model) {
             vehicle_model = $0
         }
     }
 
-    func _mproxy_get_vehicle_model(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vehicle_model)
+    func _mproxy_get_vehicle_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vehicle_model)
     }
 
     override open class var classInitializer: Void {
@@ -33,25 +33,25 @@ class Car: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.addPropertyGroup(name: "Vehicle", prefix: "vehicle_")
-        let _pvehicle_make = PropInfo (
-            propertyType: .string,
-            propertyName: "vehicle_make",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pvehicle_make, arguments: [], function: Car._mproxy_get_vehicle_make)
-        classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pvehicle_make], function: Car._mproxy_set_vehicle_make)
-        classInfo.registerProperty (_pvehicle_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
-        let _pvehicle_model = PropInfo (
-            propertyType: .string,
-            propertyName: "vehicle_model",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pvehicle_model, arguments: [], function: Car._mproxy_get_vehicle_model)
-        classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pvehicle_model], function: Car._mproxy_set_vehicle_model)
-        classInfo.registerProperty (_pvehicle_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
+        let _pvehicle_make = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vehicle_make,
+            name: "vehicle_make",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_make", flags: .default, returnValue: _pvehicle_make, arguments: [], function: Car._mproxy_get_vehicle_make)
+        classInfo.registerMethod (name: "set_make", flags: .default, returnValue: nil, arguments: [_pvehicle_make], function: Car._mproxy_set_vehicle_make)
+        classInfo.registerProperty (_pvehicle_make, getter: "get_make", setter: "set_make")
+        let _pvehicle_model = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vehicle_model,
+            name: "vehicle_model",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pvehicle_model, arguments: [], function: Car._mproxy_get_vehicle_model)
+        classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pvehicle_model], function: Car._mproxy_set_vehicle_model)
+        classInfo.registerProperty (_pvehicle_model, getter: "get_model", setter: "set_model")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingCollectionExports.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingCollectionExports.swift
@@ -2,14 +2,14 @@
 class Garage: Node {
     var bar: VariantCollection<Bool> = [false]
 
-    func _mproxy_set_bar(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "bar", bar) {
+    func _mproxy_set_bar(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "bar", bar) {
             bar = $0
         }
     }
 
-    func _mproxy_get_bar(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(bar)
+    func _mproxy_get_bar(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(bar)
     }
 
     override open class var classInitializer: Void {
@@ -22,13 +22,13 @@ class Garage: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Garage> (name: className)
         classInfo.addPropertyGroup(name: "Example", prefix: "example")
-        let _pbar = PropInfo (
-            propertyType: .array,
-            propertyName: "bar",
-            className: StringName("Array[bool]"),
-            hint: .arrayType,
-            hintStr: "bool",
-            usage: .default)
+        let _pbar = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.bar,
+            name: "bar",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
         classInfo.registerMethod (name: "set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
         classInfo.registerProperty (_pbar, getter: "get_bar", setter: "set_bar")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingExports.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingExports.swift
@@ -2,14 +2,14 @@
 class Garage: Node {
     var bar: Bool = false
 
-    func _mproxy_set_bar(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "bar", bar) {
+    func _mproxy_set_bar(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "bar", bar) {
             bar = $0
         }
     }
 
-    func _mproxy_get_bar(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(bar)
+    func _mproxy_get_bar(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(bar)
     }
 
     override open class var classInitializer: Void {
@@ -22,15 +22,15 @@ class Garage: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Garage> (name: className)
         classInfo.addPropertyGroup(name: "Example", prefix: "example")
-        let _pbar = PropInfo (
-            propertyType: .bool,
-            propertyName: "bar",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
-        classInfo.registerMethod (name: "_mproxy_set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
-        classInfo.registerProperty (_pbar, getter: "_mproxy_get_bar", setter: "_mproxy_set_bar")
+        let _pbar = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Garage.bar,
+            name: "bar",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_bar", flags: .default, returnValue: _pbar, arguments: [], function: Garage._mproxy_get_bar)
+        classInfo.registerMethod (name: "set_bar", flags: .default, returnValue: nil, arguments: [_pbar], function: Garage._mproxy_set_bar)
+        classInfo.registerProperty (_pbar, getter: "get_bar", setter: "set_bar")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingCollectionExport.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingCollectionExport.swift
@@ -2,25 +2,25 @@
 public class Issue353: Node {
     var prefix1_prefixed_bool: VariantCollection<Bool> = [false]
 
-    func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "prefix1_prefixed_bool", prefix1_prefixed_bool) {
+    func _mproxy_set_prefix1_prefixed_bool(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "prefix1_prefixed_bool", prefix1_prefixed_bool) {
             prefix1_prefixed_bool = $0
         }
     }
 
-    func _mproxy_get_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(prefix1_prefixed_bool)
+    func _mproxy_get_prefix1_prefixed_bool(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(prefix1_prefixed_bool)
     }
     var non_prefixed_bool: VariantCollection<Bool> = [false]
 
-    func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "non_prefixed_bool", non_prefixed_bool) {
+    func _mproxy_set_non_prefixed_bool(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "non_prefixed_bool", non_prefixed_bool) {
             non_prefixed_bool = $0
         }
     }
 
-    func _mproxy_get_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(non_prefixed_bool)
+    func _mproxy_get_non_prefixed_bool(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(non_prefixed_bool)
     }
 
     override open class var classInitializer: Void {
@@ -33,23 +33,23 @@ public class Issue353: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Issue353> (name: className)
         classInfo.addPropertyGroup(name: "Group With a Prefix", prefix: "prefix1")
-        let _pprefix1_prefixed_bool = PropInfo (
-            propertyType: .array,
-            propertyName: "prefix1_prefixed_bool",
-            className: StringName("Array[bool]"),
-            hint: .arrayType,
-            hintStr: "bool",
-            usage: .default)
+        let _pprefix1_prefixed_bool = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Issue353.prefix1_prefixed_bool,
+            name: "prefix1_prefixed_bool",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
         classInfo.registerMethod (name: "set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
         classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "get__prefixed_bool", setter: "set__prefixed_bool")
-        let _pnon_prefixed_bool = PropInfo (
-            propertyType: .array,
-            propertyName: "non_prefixed_bool",
-            className: StringName("Array[bool]"),
-            hint: .arrayType,
-            hintStr: "bool",
-            usage: .default)
+        let _pnon_prefixed_bool = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Issue353.non_prefixed_bool,
+            name: "non_prefixed_bool",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         classInfo.registerMethod (name: "get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
         classInfo.registerMethod (name: "set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
         classInfo.registerProperty (_pnon_prefixed_bool, getter: "get_non_prefixed_bool", setter: "set_non_prefixed_bool")

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingExport.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingExport.swift
@@ -2,25 +2,25 @@
 public class Issue353: Node {
     var prefix1_prefixed_bool: Bool = true
 
-    func _mproxy_set_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "prefix1_prefixed_bool", prefix1_prefixed_bool) {
+    func _mproxy_set_prefix1_prefixed_bool(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "prefix1_prefixed_bool", prefix1_prefixed_bool) {
             prefix1_prefixed_bool = $0
         }
     }
 
-    func _mproxy_get_prefix1_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(prefix1_prefixed_bool)
+    func _mproxy_get_prefix1_prefixed_bool(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(prefix1_prefixed_bool)
     }
     var non_prefixed_bool: Bool = true
 
-    func _mproxy_set_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "non_prefixed_bool", non_prefixed_bool) {
+    func _mproxy_set_non_prefixed_bool(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "non_prefixed_bool", non_prefixed_bool) {
             non_prefixed_bool = $0
         }
     }
 
-    func _mproxy_get_non_prefixed_bool(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(non_prefixed_bool)
+    func _mproxy_get_non_prefixed_bool(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(non_prefixed_bool)
     }
 
     override open class var classInitializer: Void {
@@ -33,25 +33,25 @@ public class Issue353: Node {
         assert(ClassDB.classExists(class: className))
         let classInfo = ClassInfo<Issue353> (name: className)
         classInfo.addPropertyGroup(name: "Group With a Prefix", prefix: "prefix1")
-        let _pprefix1_prefixed_bool = PropInfo (
-            propertyType: .bool,
-            propertyName: "prefix1_prefixed_bool",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
-        classInfo.registerMethod (name: "_mproxy_set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
-        classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "_mproxy_get__prefixed_bool", setter: "_mproxy_set__prefixed_bool")
-        let _pnon_prefixed_bool = PropInfo (
-            propertyType: .bool,
-            propertyName: "non_prefixed_bool",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
-        classInfo.registerMethod (name: "_mproxy_set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
-        classInfo.registerProperty (_pnon_prefixed_bool, getter: "_mproxy_get_non_prefixed_bool", setter: "_mproxy_set_non_prefixed_bool")
+        let _pprefix1_prefixed_bool = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Issue353.prefix1_prefixed_bool,
+            name: "prefix1_prefixed_bool",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get__prefixed_bool", flags: .default, returnValue: _pprefix1_prefixed_bool, arguments: [], function: Issue353._mproxy_get_prefix1_prefixed_bool)
+        classInfo.registerMethod (name: "set__prefixed_bool", flags: .default, returnValue: nil, arguments: [_pprefix1_prefixed_bool], function: Issue353._mproxy_set_prefix1_prefixed_bool)
+        classInfo.registerProperty (_pprefix1_prefixed_bool, getter: "get__prefixed_bool", setter: "set__prefixed_bool")
+        let _pnon_prefixed_bool = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Issue353.non_prefixed_bool,
+            name: "non_prefixed_bool",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_non_prefixed_bool", flags: .default, returnValue: _pnon_prefixed_bool, arguments: [], function: Issue353._mproxy_get_non_prefixed_bool)
+        classInfo.registerMethod (name: "set_non_prefixed_bool", flags: .default, returnValue: nil, arguments: [_pnon_prefixed_bool], function: Issue353._mproxy_set_non_prefixed_bool)
+        classInfo.registerProperty (_pnon_prefixed_bool, getter: "get_non_prefixed_bool", setter: "set_non_prefixed_bool")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportSubroupTests.testGodotExportSubgroupWithAndWithoutPrefixWithGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportSubroupTests.testGodotExportSubgroupWithAndWithoutPrefixWithGroup.swift
@@ -1,58 +1,58 @@
 class Car: Node {
     var vin: String = ""
 
-    func _mproxy_set_vin(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "vin", vin) {
+    func _mproxy_set_vin(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "vin", vin) {
             vin = $0
         }
     }
 
-    func _mproxy_get_vin(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(vin)
+    func _mproxy_get_vin(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(vin)
     }
     var ymms_year: Int = 1998
 
-    func _mproxy_set_ymms_year(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "ymms_year", ymms_year) {
+    func _mproxy_set_ymms_year(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "ymms_year", ymms_year) {
             ymms_year = $0
         }
     }
 
-    func _mproxy_get_ymms_year(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(ymms_year)
+    func _mproxy_get_ymms_year(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(ymms_year)
     }
     var ymms_make: String = "Honda"
 
-    func _mproxy_set_ymms_make(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "ymms_make", ymms_make) {
+    func _mproxy_set_ymms_make(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "ymms_make", ymms_make) {
             ymms_make = $0
         }
     }
 
-    func _mproxy_get_ymms_make(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(ymms_make)
+    func _mproxy_get_ymms_make(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(ymms_make)
     }
     var ymms_model: String = "Odyssey"
 
-    func _mproxy_set_ymms_model(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "ymms_model", ymms_model) {
+    func _mproxy_set_ymms_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "ymms_model", ymms_model) {
             ymms_model = $0
         }
     }
 
-    func _mproxy_get_ymms_model(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(ymms_model)
+    func _mproxy_get_ymms_model(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(ymms_model)
     }
     var ymms_series: String = "LX"
 
-    func _mproxy_set_ymms_series(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "ymms_series", ymms_series) {
+    func _mproxy_set_ymms_series(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "ymms_series", ymms_series) {
             ymms_series = $0
         }
     }
 
-    func _mproxy_get_ymms_series(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(ymms_series)
+    func _mproxy_get_ymms_series(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(ymms_series)
     }
 
     override open class var classInitializer: Void {
@@ -66,56 +66,56 @@ class Car: Node {
         let classInfo = ClassInfo<Car> (name: className)
         classInfo.addPropertyGroup(name: "Vehicle", prefix: "")
         classInfo.addPropertySubgroup(name: "VIN", prefix: "")
-        let _pvin = PropInfo (
-            propertyType: .string,
-            propertyName: "vin",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
-        classInfo.registerMethod (name: "_mproxy_set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
-        classInfo.registerProperty (_pvin, getter: "_mproxy_get_vin", setter: "_mproxy_set_vin")
+        let _pvin = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.vin,
+            name: "vin",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_vin", flags: .default, returnValue: _pvin, arguments: [], function: Car._mproxy_get_vin)
+        classInfo.registerMethod (name: "set_vin", flags: .default, returnValue: nil, arguments: [_pvin], function: Car._mproxy_set_vin)
+        classInfo.registerProperty (_pvin, getter: "get_vin", setter: "set_vin")
         classInfo.addPropertySubgroup(name: "YMMS", prefix: "ymms_")
-        let _pymms_year = PropInfo (
-            propertyType: .int,
-            propertyName: "ymms_year",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_year", flags: .default, returnValue: _pymms_year, arguments: [], function: Car._mproxy_get_ymms_year)
-        classInfo.registerMethod (name: "_mproxy_set_year", flags: .default, returnValue: nil, arguments: [_pymms_year], function: Car._mproxy_set_ymms_year)
-        classInfo.registerProperty (_pymms_year, getter: "_mproxy_get_year", setter: "_mproxy_set_year")
-        let _pymms_make = PropInfo (
-            propertyType: .string,
-            propertyName: "ymms_make",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_make", flags: .default, returnValue: _pymms_make, arguments: [], function: Car._mproxy_get_ymms_make)
-        classInfo.registerMethod (name: "_mproxy_set_make", flags: .default, returnValue: nil, arguments: [_pymms_make], function: Car._mproxy_set_ymms_make)
-        classInfo.registerProperty (_pymms_make, getter: "_mproxy_get_make", setter: "_mproxy_set_make")
-        let _pymms_model = PropInfo (
-            propertyType: .string,
-            propertyName: "ymms_model",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_model", flags: .default, returnValue: _pymms_model, arguments: [], function: Car._mproxy_get_ymms_model)
-        classInfo.registerMethod (name: "_mproxy_set_model", flags: .default, returnValue: nil, arguments: [_pymms_model], function: Car._mproxy_set_ymms_model)
-        classInfo.registerProperty (_pymms_model, getter: "_mproxy_get_model", setter: "_mproxy_set_model")
-        let _pymms_series = PropInfo (
-            propertyType: .string,
-            propertyName: "ymms_series",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
-        classInfo.registerMethod (name: "_mproxy_get_series", flags: .default, returnValue: _pymms_series, arguments: [], function: Car._mproxy_get_ymms_series)
-        classInfo.registerMethod (name: "_mproxy_set_series", flags: .default, returnValue: nil, arguments: [_pymms_series], function: Car._mproxy_set_ymms_series)
-        classInfo.registerProperty (_pymms_series, getter: "_mproxy_get_series", setter: "_mproxy_set_series")
+        let _pymms_year = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.ymms_year,
+            name: "ymms_year",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_year", flags: .default, returnValue: _pymms_year, arguments: [], function: Car._mproxy_get_ymms_year)
+        classInfo.registerMethod (name: "set_year", flags: .default, returnValue: nil, arguments: [_pymms_year], function: Car._mproxy_set_ymms_year)
+        classInfo.registerProperty (_pymms_year, getter: "get_year", setter: "set_year")
+        let _pymms_make = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.ymms_make,
+            name: "ymms_make",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_make", flags: .default, returnValue: _pymms_make, arguments: [], function: Car._mproxy_get_ymms_make)
+        classInfo.registerMethod (name: "set_make", flags: .default, returnValue: nil, arguments: [_pymms_make], function: Car._mproxy_set_ymms_make)
+        classInfo.registerProperty (_pymms_make, getter: "get_make", setter: "set_make")
+        let _pymms_model = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.ymms_model,
+            name: "ymms_model",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_model", flags: .default, returnValue: _pymms_model, arguments: [], function: Car._mproxy_get_ymms_model)
+        classInfo.registerMethod (name: "set_model", flags: .default, returnValue: nil, arguments: [_pymms_model], function: Car._mproxy_set_ymms_model)
+        classInfo.registerProperty (_pymms_model, getter: "get_model", setter: "set_model")
+        let _pymms_series = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Car.ymms_series,
+            name: "ymms_series",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
+        classInfo.registerMethod (name: "get_series", flags: .default, returnValue: _pymms_series, arguments: [], function: Car._mproxy_get_ymms_series)
+        classInfo.registerMethod (name: "set_series", flags: .default, returnValue: nil, arguments: [_pymms_series], function: Car._mproxy_set_ymms_series)
+        classInfo.registerProperty (_pymms_series, getter: "get_series", setter: "set_series")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotMacro.swift
@@ -1,14 +1,14 @@
 class Hi: Node {
     var goodName: String = "Supertop"
 
-    func _mproxy_set_goodName(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "goodName", goodName) {
+    func _mproxy_set_goodName(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "goodName", goodName) {
             goodName = $0
         }
     }
 
-    func _mproxy_get_goodName(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(goodName)
+    func _mproxy_get_goodName(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(goodName)
     }
 
     override open class var classInitializer: Void {
@@ -19,16 +19,16 @@ class Hi: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Hi")
         assert(ClassDB.classExists(class: className))
-        let _pgoodName = PropInfo (
-            propertyType: .string,
-            propertyName: "goodName",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+        let _pgoodName = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Hi.goodName,
+            name: "good_name",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Hi> (name: className)
-        classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
-        classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
-        classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
+        classInfo.registerMethod (name: "get_good_name", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
+        classInfo.registerMethod (name: "set_good_name", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
+        classInfo.registerProperty (_pgoodName, getter: "get_good_name", setter: "set_good_name")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotUsage.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotUsage.swift
@@ -1,14 +1,14 @@
 class Hi: Node {
     var goodName: String = "Supertop"
 
-    func _mproxy_set_goodName(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "goodName", goodName) {
+    func _mproxy_set_goodName(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "goodName", goodName) {
             goodName = $0
         }
     }
 
-    func _mproxy_get_goodName(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(goodName)
+    func _mproxy_get_goodName(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(goodName)
     }
 
     override open class var classInitializer: Void {
@@ -19,16 +19,16 @@ class Hi: Node {
     private static let _initializeClass: Void = {
         let className = StringName("Hi")
         assert(ClassDB.classExists(class: className))
-        let _pgoodName = PropInfo (
-            propertyType: .string,
-            propertyName: "goodName",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: [.editor, .array])
+        let _pgoodName = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Hi.goodName,
+            name: "good_name",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Hi> (name: className)
-        classInfo.registerMethod (name: "_mproxy_get_goodName", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
-        classInfo.registerMethod (name: "_mproxy_set_goodName", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
-        classInfo.registerProperty (_pgoodName, getter: "_mproxy_get_goodName", setter: "_mproxy_set_goodName")
+        classInfo.registerMethod (name: "get_good_name", flags: .default, returnValue: _pgoodName, arguments: [], function: Hi._mproxy_get_goodName)
+        classInfo.registerMethod (name: "set_good_name", flags: .default, returnValue: nil, arguments: [_pgoodName], function: Hi._mproxy_set_goodName)
+        classInfo.registerProperty (_pgoodName, getter: "get_good_name", setter: "set_good_name")
     } ()
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportedInt64.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportedInt64.swift
@@ -2,14 +2,14 @@
 class Thing: SwiftGodot.Object {
     var value: Int64 = 0
 
-    func _mproxy_set_value(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "value", value) {
+    func _mproxy_set_value(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "value", value) {
             value = $0
         }
     }
 
-    func _mproxy_get_value(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(value)
+    func _mproxy_get_value(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(value)
     }
 
     func get_some() -> Int64 { 10 }
@@ -28,17 +28,17 @@ class Thing: SwiftGodot.Object {
     private static let _initializeClass: Void = {
         let className = StringName("Thing")
         assert(ClassDB.classExists(class: className))
-        let _pvalue = PropInfo (
-            propertyType: .int,
-            propertyName: "value",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+        let _pvalue = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \Thing.value,
+            name: "value",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<Thing> (name: className)
-        classInfo.registerMethod (name: "_mproxy_get_value", flags: .default, returnValue: _pvalue, arguments: [], function: Thing._mproxy_get_value)
-        classInfo.registerMethod (name: "_mproxy_set_value", flags: .default, returnValue: nil, arguments: [_pvalue], function: Thing._mproxy_set_value)
-        classInfo.registerProperty (_pvalue, getter: "_mproxy_get_value", setter: "_mproxy_set_value")
+        classInfo.registerMethod (name: "get_value", flags: .default, returnValue: _pvalue, arguments: [], function: Thing._mproxy_get_value)
+        classInfo.registerMethod (name: "set_value", flags: .default, returnValue: nil, arguments: [_pvalue], function: Thing._mproxy_set_value)
+        classInfo.registerProperty (_pvalue, getter: "get_value", setter: "set_value")
         let prop_0 = PropInfo (propertyType: .int, propertyName: "", className: StringName(""), hint: .none, hintStr: "", usage: .default)
         classInfo.registerMethod(name: StringName("get_some"), flags: .default, returnValue: prop_0, arguments: [], function: Thing._mproxy_get_some)
     } ()

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testWarningAvoidance.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testWarningAvoidance.swift
@@ -14,14 +14,14 @@ final class MyData: Resource {
 final class MyClass: Node {
     var data: MyData = .init()
 
-    func _mproxy_set_data(args: borrowing Arguments) -> Variant? {
-        _macroExportSet(args, "data", data) {
+    func _mproxy_set_data(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportSet(args, "data", data) {
             data = $0
         }
     }
 
-    func _mproxy_get_data(args: borrowing Arguments) -> Variant? {
-        _macroExportGet(data)
+    func _mproxy_get_data(args: borrowing SwiftGodot.Arguments) -> SwiftGodot.Variant? {
+        SwiftGodot._macroExportGet(data)
     }
 
     override public class var classInitializer: Void {
@@ -32,16 +32,16 @@ final class MyClass: Node {
     private static let _initializeClass: Void = {
         let className = StringName("MyClass")
         assert(ClassDB.classExists(class: className))
-        let _pdata = PropInfo (
-            propertyType: .object,
-            propertyName: "data",
-            className: className,
-            hint: .none,
-            hintStr: "",
-            usage: .default)
+        let _pdata = SwiftGodot._macroGodotGetVariablePropInfo(
+            at: \MyClass.data,
+            name: "data",
+            userHint: nil,
+            userHintStr: nil,
+            userUsage: nil
+        )
         let classInfo = ClassInfo<MyClass> (name: className)
-        classInfo.registerMethod (name: "_mproxy_get_data", flags: .default, returnValue: _pdata, arguments: [], function: MyClass._mproxy_get_data)
-        classInfo.registerMethod (name: "_mproxy_set_data", flags: .default, returnValue: nil, arguments: [_pdata], function: MyClass._mproxy_set_data)
-        classInfo.registerProperty (_pdata, getter: "_mproxy_get_data", setter: "_mproxy_set_data")
+        classInfo.registerMethod (name: "get_data", flags: .default, returnValue: _pdata, arguments: [], function: MyClass._mproxy_get_data)
+        classInfo.registerMethod (name: "set_data", flags: .default, returnValue: nil, arguments: [_pdata], function: MyClass._mproxy_set_data)
+        classInfo.registerProperty (_pdata, getter: "get_data", setter: "set_data")
     } ()
 }

--- a/Tests/SwiftGodotTests/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTests/MacroIntegrationTests.swift
@@ -22,17 +22,18 @@ final class MacroIntegrationTests: GodotTestCase {
             
             var wop = 42 as Int?
             
-            
-            static func inferGTypes() -> [Variant.GType] {
-                return [
-                    _macroGodotGetVariablePropInfo(at: \NoMacroExample.object, name: "object").propertyType,
-                    _macroGodotGetVariablePropInfo(at: \NoMacroExample.lala, name: "lala").propertyType,
-                    _macroGodotGetVariablePropInfo(at: \NoMacroExample.someNode, name: "someNode").propertyType,
-                    _macroGodotGetVariablePropInfo(at: \NoMacroExample.wop, name: "wop").propertyType
-                ]
-            }
+            var variantCollection = VariantCollection<Int>()
+            var objectCollection = ObjectCollection<MeshInstance2D>()
         }
+            
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.object, name: "").propertyType, .object)
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.lala, name: "").propertyType, .int)
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.someNode, name: "").propertyType, .object)
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.wop, name: "").propertyType, .nil)
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.variantCollection, name: "").className, "Array[int]")
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.objectCollection, name: "").className, "Array[MeshInstance2D]")
         
-        XCTAssertEqual(NoMacroExample.inferGTypes(), [.object, .int, .object, .nil /* Aka Variant */])
+        let a = _macroGodotGetVariablePropInfo(at: \NoMacroExample.objectCollection, name: "")
+        print(a)
     }
 }

--- a/Tests/SwiftGodotTests/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTests/MacroIntegrationTests.swift
@@ -1,0 +1,38 @@
+//
+//  MacroIntegrationTests.swift
+//  SwiftGodot
+//
+//  Created by Elijah Semyonov on 10/04/2025.
+//
+
+import XCTest
+import SwiftGodotTestability
+@testable import SwiftGodot
+
+final class MacroIntegrationTests: GodotTestCase {
+    func testCorrectPropInfoInferrenceWithoutMacro() {
+        class NoMacroExample {
+            var object = Object() as Object?
+            
+            var lala = [42, 31].min() ?? 10
+            
+            lazy var someNode = {
+                Node3D()
+            }()
+            
+            var wop = 42 as Int?
+            
+            
+            static func inferGTypes() -> [Variant.GType] {
+                return [
+                    _macroGodotGetVariablePropInfo(at: \NoMacroExample.object, name: "object").propertyType,
+                    _macroGodotGetVariablePropInfo(at: \NoMacroExample.lala, name: "lala").propertyType,
+                    _macroGodotGetVariablePropInfo(at: \NoMacroExample.someNode, name: "someNode").propertyType,
+                    _macroGodotGetVariablePropInfo(at: \NoMacroExample.wop, name: "wop").propertyType
+                ]
+            }
+        }
+        
+        XCTAssertEqual(NoMacroExample.inferGTypes(), [.object, .int, .object, .nil /* Aka Variant */])
+    }
+}

--- a/Tests/SwiftGodotTests/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTests/MacroIntegrationTests.swift
@@ -12,12 +12,15 @@ import SwiftGodotTestability
 final class MacroIntegrationTests: GodotTestCase {
     func testCorrectPropInfoInferrenceWithoutMacro() {
         enum EnumExample: Int, CaseIterable {
+            case zero = 0
             case one = 1
             case two = 2
-            case five = 5
         }
         
         class NoMacroExample {
+            var variant = 1.toVariant()
+            var optionalVariant: Variant?
+            var garray: GArray = GArray()
             var object = Object() as Object?
             var lala = [42, 31].min() ?? 10
             lazy var someNode = {
@@ -28,17 +31,19 @@ final class MacroIntegrationTests: GodotTestCase {
             var objectCollection = ObjectCollection<MeshInstance2D>()
             var enumExample = EnumExample.two
         }
-            
+        
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.variant, name: "").propertyType, .nil)
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.optionalVariant, name: "").propertyType, .nil)
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.garray, name: "").propertyType, .array)
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.object, name: "").propertyType, .object)
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.lala, name: "").propertyType, .int)
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.someNode, name: "").propertyType, .object)
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.wop, name: "").propertyType, .nil)
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.variantCollection, name: "").className, "Array[int]")
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.objectCollection, name: "").className, "Array[MeshInstance2D]")
-        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.enumExample, name: "").hintStr, "Array[MeshInstance2D]")
         
         let enumPropInfo = _macroGodotGetVariablePropInfo(at: \NoMacroExample.enumExample, name: "")
         XCTAssertEqual(enumPropInfo.propertyType, .int)
-        //XCTAssertEqual(enumPropInfo., .int)
+        XCTAssertEqual(enumPropInfo.hintStr, GString("zero:0,one:1,two:2"))
     }
 }

--- a/Tests/SwiftGodotTests/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTests/MacroIntegrationTests.swift
@@ -11,19 +11,22 @@ import SwiftGodotTestability
 
 final class MacroIntegrationTests: GodotTestCase {
     func testCorrectPropInfoInferrenceWithoutMacro() {
+        enum EnumExample: Int, CaseIterable {
+            case one = 1
+            case two = 2
+            case five = 5
+        }
+        
         class NoMacroExample {
             var object = Object() as Object?
-            
             var lala = [42, 31].min() ?? 10
-            
             lazy var someNode = {
                 Node3D()
             }()
-            
             var wop = 42 as Int?
-            
             var variantCollection = VariantCollection<Int>()
             var objectCollection = ObjectCollection<MeshInstance2D>()
+            var enumExample = EnumExample.two
         }
             
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.object, name: "").propertyType, .object)
@@ -32,8 +35,6 @@ final class MacroIntegrationTests: GodotTestCase {
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.wop, name: "").propertyType, .nil)
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.variantCollection, name: "").className, "Array[int]")
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.objectCollection, name: "").className, "Array[MeshInstance2D]")
-        
-        let a = _macroGodotGetVariablePropInfo(at: \NoMacroExample.objectCollection, name: "")
-        print(a)
+        XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.enumExample, name: "").hintStr, "Array[MeshInstance2D]")
     }
 }

--- a/Tests/SwiftGodotTests/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTests/MacroIntegrationTests.swift
@@ -36,5 +36,9 @@ final class MacroIntegrationTests: GodotTestCase {
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.variantCollection, name: "").className, "Array[int]")
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.objectCollection, name: "").className, "Array[MeshInstance2D]")
         XCTAssertEqual(_macroGodotGetVariablePropInfo(at: \NoMacroExample.enumExample, name: "").hintStr, "Array[MeshInstance2D]")
+        
+        let enumPropInfo = _macroGodotGetVariablePropInfo(at: \NoMacroExample.enumExample, name: "")
+        XCTAssertEqual(enumPropInfo.propertyType, .int)
+        //XCTAssertEqual(enumPropInfo., .int)
     }
 }

--- a/Tests/SwiftGodotTests/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTests/MacroIntegrationTests.swift
@@ -18,6 +18,7 @@ final class MacroIntegrationTests: GodotTestCase {
         }
         
         class NoMacroExample {
+            var meshInstance: MeshInstance3D? = nil
             var variant = 1.toVariant()
             var optionalVariant: Variant?
             var garray: GArray = GArray()
@@ -44,6 +45,10 @@ final class MacroIntegrationTests: GodotTestCase {
         
         let enumPropInfo = _macroGodotGetVariablePropInfo(at: \NoMacroExample.enumExample, name: "")
         XCTAssertEqual(enumPropInfo.propertyType, .int)
-        XCTAssertEqual(enumPropInfo.hintStr, GString("zero:0,one:1,two:2"))
+        XCTAssertEqual(enumPropInfo.hintStr, "zero:0,one:1,two:2")
+        
+        let meshInstancePropInfo = _macroGodotGetVariablePropInfo(at: \NoMacroExample.meshInstance, name: "")
+        XCTAssertEqual(meshInstancePropInfo.hint, .nodeType)
+        XCTAssertEqual(meshInstancePropInfo.hintStr, "MeshInstance3D")
     }
 }

--- a/Tests/SwiftGodotTests/ValidatePropertyTests.swift
+++ b/Tests/SwiftGodotTests/ValidatePropertyTests.swift
@@ -15,7 +15,7 @@ private class TestProp: Node {
     var changeThisVariable: Int = 1
 
     override func _validateProperty(_ prop: inout PropInfo) -> Bool {
-        if prop.propertyName == "changeThisVariable" {
+        if prop.propertyName == "change_this_variable" {
             prop.usage.insert(.group)
             return true
         }
@@ -38,7 +38,7 @@ final class TestProperty: GodotTestCase {
             guard let flagsV = prop["usage"], let iflags = Int(flagsV) else { continue }
             let flags = PropertyUsageFlags(rawValue: iflags)
 
-            if name == "changeThisVariable", flags.contains(.group) {
+            if name == "change_this_variable", flags.contains(.group) {
                 found = true
             }
         }


### PR DESCRIPTION
1. All macro logic related to `@Export` relies on static dispatch instead of syntax analysis.
2. `.enum` and `.nodeType` are filled automatically for `@Export` when eligible.
3. No explicit type information is needed for `@Export` anymore.