### PR TITLE
Adjust rawvalue init of GDExtensionVariantType to use Int32 instead o…

### DIFF
--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -279,7 +279,7 @@ public final class Variant: Hashable, Equatable, CustomDebugStringConvertible, _
     public static func construct(type: Variant.GType) -> Result<Variant?,CallErrorType> {
         var newContent: ContentType = Variant.zero
         var err = GDExtensionCallError()
-        gi.variant_construct(GDExtensionVariantType(rawValue: UInt32(type.rawValue)), &newContent, nil, 0, &err)
+        gi.variant_construct(GDExtensionVariantType(rawValue: Int32(type.rawValue)), &newContent, nil, 0, &err)
         if err.error != GDEXTENSION_CALL_OK {
             return .failure(toCallErrorType(err.error))
         }


### PR DESCRIPTION
Fixes 

```
S:\swift\.build\checkouts\SwiftGodot\Sources\SwiftGodot\Variant.swift:282:63: error: cannot convert value of type 'UInt32' to expected argument type 'Int32'      
280 |         var newContent: ContentType = Variant.zero

281 |         var err = GDExtensionCallError()

282 |         gi.variant_construct(GDExtensionVariantType(rawValue: UInt32(type.rawValue)), &newContent, nil, 0, &err)

    |                                                               `- error: cannot convert value of type 'UInt32' to expected argument type 'Int32'
283 |         if err.error != GDEXTENSION_CALL_OK {

284 |             return .failure(toCallErrorType(err.error))
```