### PR TITLE
Add `autoSnakeCase` to @Callable

### DIFF
--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -30,9 +30,11 @@ public enum ClassBehavior: Int {
 /// When this attribute is applied to a function, the function is exposed to the Godot engine, and it
 /// can be called by scripts in other languages.
 ///
-/// The parameters to the function must be parameters that can be wrapped in a ``Variant`` structure
+/// The parameters and returns type of the function must be `_GodotBridgeable`.
+///
+/// - Parameter autoSnakeCase: if `true` (default value is `false`), the function name will be automatically translated from `camelCase` to `snake_case` when exposed to Godot
 @attached(peer, names: prefixed(_mproxy_))
-public macro Callable() = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
+public macro Callable(autoSnakeCase: Bool = false) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
 
 /// Exposes a property or variable to the Godot runtime
 ///

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -69,7 +69,7 @@ class GodotMacroProcessor {
     }
         
     func processFunction(_ funcDecl: FunctionDeclSyntax) throws {
-        if !funcDecl.hasCallableAttribute {
+        guard let callableAttribute = funcDecl.attributes.attribute(named: "Callable") else {
             return
         }
         
@@ -78,6 +78,13 @@ class GodotMacroProcessor {
         }
         
         let funcName = funcDecl.name.text
+        
+        let godotFuncName: String
+        if try callableAttribute.callableAutoSnakeCaseArgument {
+            godotFuncName = funcName.camelCaseToSnakeCase()
+        } else {
+            godotFuncName = funcName
+        }
         
         let p = classInitializerPrinter
                         
@@ -107,7 +114,7 @@ class GodotMacroProcessor {
         p("SwiftGodot._registerMethod", .parentheses) {
             p("""
             className: className,
-            name: "\(funcName)", 
+            name: "\(godotFuncName)", 
             flags: \(flags), 
             returnValue: SwiftGodot._returnValuePropInfo(\(returnTypename).self),    
             """)
@@ -117,7 +124,7 @@ class GodotMacroProcessor {
             p("function: \(className)._mproxy_\(funcName)")
         }
         
-        try checkNameCollision(funcName, for: DeclSyntax(funcDecl))
+        try checkNameCollision(godotFuncName, for: DeclSyntax(funcDecl))
     }
       
 

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -29,13 +29,16 @@ enum GodotMacroError: Error, DiagnosticMessage {
     case nameCollision(String)
     case legacySignalMacroUnexpectedArgumentsSyntax
     case legacySignalMacroTooManyArguments
+    case illegalCallableAutoSnakeCaseArgument(String)    
     
     var severity: DiagnosticSeverity {
         return .error
     }
 
     var message: String {
-        switch self {        
+        switch self {
+        case .illegalCallableAutoSnakeCaseArgument(let expr):
+            "`autoSnakeCase: \(expr)` is illegal. `true` or `false` expected."
         case .exportMacroOnReadonlyVariable:
             "@Export attribute can only be applied to mutable stored or computed { get set } property"
         case .godotMacroNotOnClass:

--- a/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
@@ -94,6 +94,38 @@ extension VariableDeclSyntax {
     }
 }
 
+extension AttributeSyntax.Arguments {
+    func argument(labeled label: String) -> LabeledExprSyntax? {
+        if case let .argumentList(listSyntax) = self {
+            return listSyntax.first { exprSyntax in
+                exprSyntax.label?.description == label
+            }
+        } else {
+            return nil
+        }
+    }
+}
+
+extension AttributeSyntax {
+    var callableAutoSnakeCaseArgument: Bool {
+        get throws {
+            guard let exprSyntax = arguments?.argument(labeled: "autoSnakeCase") else {
+                return false
+            }
+            
+            let expr = exprSyntax.expression.description
+            switch expr {
+            case "true":
+                return true
+            case "false":
+                return false
+            default:
+                throw GodotMacroError.illegalCallableAutoSnakeCaseArgument(expr)
+            }
+        }
+    }
+}
+
 extension AttributeListSyntax {
     func attribute(named name: String) -> AttributeSyntax? {
         for element in self {

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -173,7 +173,7 @@ final class Demo21: Node {
 class SomeNode: Node {
     @Callable
     func printNames(of nodes: TypedArray<Node?>) {
-        let node0 = nodes[0]
+        _ = nodes[0]
         
         nodes.forEach { print($0?.name ?? "") }
     }
@@ -219,4 +219,15 @@ class DebugThing: SwiftGodot.Object {
     func bar(_ value: Variant?) -> Variant? {
         return value
     }
+}
+
+@Godot class NodeWithNewCallableAutoSnakeCase: Node {
+    @Callable(autoSnakeCase: true)
+    func noNeedToSnakeCaseFunctionsNow() {}
+
+    @Callable(autoSnakeCase: false)
+    func or_is_there() {}
+
+    @Callable
+    func defaultIsLegacyCompatible() {}
 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
@@ -30,8 +30,8 @@ class MacroGodotTestCase: XCTestCase {
     
     /// Set it to local path to regenerate expansions test data in case the macro was updated
     let regeneratedResourcesPath: String? =
-//        nil
-        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
+        nil
+//        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
         
     
     func regenerateExpansionResource(input: String, outputUrl: URL) {

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
@@ -30,8 +30,8 @@ class MacroGodotTestCase: XCTestCase {
     
     /// Set it to local path to regenerate expansions test data in case the macro was updated
     let regeneratedResourcesPath: String? =
-        nil
-//        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
+//        nil
+        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
         
     
     func regenerateExpansionResource(input: String, outputUrl: URL) {

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -445,5 +445,25 @@ final class MacroGodotTests: MacroGodotTestCase {
             ]
         )
     }
+    
+    func testCallableAutoSnakeCase() {
+        assertExpansion(
+            of: """
+            @Godot class TestClass: Node {
+                @Callable(autoSnakeCase: true)
+                func noNeedToSnakeCaseFunctionsNow() {}
+            
+                @Callable(autoSnakeCase: false)
+                func or_is_there() {}
+            
+                @Callable(autoSnakeCase: false)
+                func thatIsHideous() {}
+
+                @Callable
+                func defaultIsLegacyCompatible() {}
+            }
+            """
+        )
+    }
 
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableAutoSnakeCase.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableAutoSnakeCase.swift
@@ -1,0 +1,92 @@
+class TestClass: Node {
+    func noNeedToSnakeCaseFunctionsNow() {}
+
+    static func _mproxy_noNeedToSnakeCaseFunctionsNow(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodot.Arguments) -> SwiftGodot.FastVariant? {
+        guard let object = SwiftGodot._unwrap(self, pInstance: pInstance) else {
+            SwiftGodot.GD.printErr("Error calling `noNeedToSnakeCaseFunctionsNow`: failed to unwrap instance \(String(describing: pInstance))")
+            return nil
+        }
+        return SwiftGodot._wrapCallableResult(object.noNeedToSnakeCaseFunctionsNow())
+
+    }
+    func or_is_there() {}
+
+    static func _mproxy_or_is_there(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodot.Arguments) -> SwiftGodot.FastVariant? {
+        guard let object = SwiftGodot._unwrap(self, pInstance: pInstance) else {
+            SwiftGodot.GD.printErr("Error calling `or_is_there`: failed to unwrap instance \(String(describing: pInstance))")
+            return nil
+        }
+        return SwiftGodot._wrapCallableResult(object.or_is_there())
+
+    }
+    func thatIsHideous() {}
+
+    static func _mproxy_thatIsHideous(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodot.Arguments) -> SwiftGodot.FastVariant? {
+        guard let object = SwiftGodot._unwrap(self, pInstance: pInstance) else {
+            SwiftGodot.GD.printErr("Error calling `thatIsHideous`: failed to unwrap instance \(String(describing: pInstance))")
+            return nil
+        }
+        return SwiftGodot._wrapCallableResult(object.thatIsHideous())
+
+    }
+    func defaultIsLegacyCompatible() {}
+
+    static func _mproxy_defaultIsLegacyCompatible(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodot.Arguments) -> SwiftGodot.FastVariant? {
+        guard let object = SwiftGodot._unwrap(self, pInstance: pInstance) else {
+            SwiftGodot.GD.printErr("Error calling `defaultIsLegacyCompatible`: failed to unwrap instance \(String(describing: pInstance))")
+            return nil
+        }
+        return SwiftGodot._wrapCallableResult(object.defaultIsLegacyCompatible())
+
+    }
+
+    override open class var classInitializer: Void {
+        let _ = super.classInitializer
+        return _initializeClass
+    }
+
+    private static let _initializeClass: Void = {
+        let className = StringName("TestClass")
+        assert(ClassDB.classExists(class: className))
+        SwiftGodot._registerMethod(
+            className: className,
+            name: "no_need_to_snake_case_functions_now",
+            flags: .default,
+            returnValue: SwiftGodot._returnValuePropInfo(Swift.Void.self),
+            arguments: [
+
+            ],
+            function: TestClass._mproxy_noNeedToSnakeCaseFunctionsNow
+        )
+        SwiftGodot._registerMethod(
+            className: className,
+            name: "or_is_there",
+            flags: .default,
+            returnValue: SwiftGodot._returnValuePropInfo(Swift.Void.self),
+            arguments: [
+
+            ],
+            function: TestClass._mproxy_or_is_there
+        )
+        SwiftGodot._registerMethod(
+            className: className,
+            name: "thatIsHideous",
+            flags: .default,
+            returnValue: SwiftGodot._returnValuePropInfo(Swift.Void.self),
+            arguments: [
+
+            ],
+            function: TestClass._mproxy_thatIsHideous
+        )
+        SwiftGodot._registerMethod(
+            className: className,
+            name: "defaultIsLegacyCompatible",
+            flags: .default,
+            returnValue: SwiftGodot._returnValuePropInfo(Swift.Void.self),
+            arguments: [
+
+            ],
+            function: TestClass._mproxy_defaultIsLegacyCompatible
+        )
+    }()
+}


### PR DESCRIPTION
Add `autoSnakeCase` parameter to `@Callable`. It will allow customising how function name is exported to Godot.
Swift common convention is `camelCase` while Godot uses `snake_case` for functions.
Default value is `false`. In the future I expect to make it depend on SPM trait, so that default value is `true` for new projects, and `false` for projects that opt-in the legacy behavior.
That behavior will align with `@Export` macro, which I believe is the most convenient one.