### PR TITLE
Fix optional object argument unwrapping ambiguity

### DIFF
--- a/Sources/SwiftGodot/Core/Arguments.swift
+++ b/Sources/SwiftGodot/Core/Arguments.swift
@@ -345,6 +345,7 @@ public struct Arguments: ~Copyable {
     /// - `index` is out of bounds.
     @inline(__always)
     @inlinable
+    @_disfavoredOverload
     public func argument<T>(ofType type: T?.Type = T?.self, at index: Int) throws(ArgumentAccessError) -> T? where T: VariantConvertible {
         try withBorrowedFastVariant(at: index) { variantOrNil in
             extract(T?.self, from: variantOrNil)

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -200,7 +200,10 @@ class DebugThing: SwiftGodot.Object {
 }
 
 @Godot class MyThing: SwiftGodot.RefCounted {
-
+    @Callable
+    func nodeAddedToScene(node: Node?) {
+        
+    }
 }
 
 @Godot class ObjectWithCallableReturningOptionalObject: SwiftGodot.Node {

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -357,5 +357,28 @@ final class MarshalTests: GodotTestCase {
             2.toVariant()
         )
     }
+    
+    func testOptionalObjectArgument() {
+        let arguments = Arguments(from: [nil, Node().toVariant()])
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 3
+        do {
+            let a = try arguments.argument(ofType: Node?.self, at: 0)
+            XCTAssertNil(a)
+            let _ = try arguments.argument(ofType: Node.self, at: 1)
+            expectation.fulfill()
+            let _ = try arguments.argument(ofType: Node.self, at: 2)
+        } catch {
+            expectation.fulfill()
+            // no-op
+        }
+        
+        do {
+            _ = try arguments.argument(ofType: Node.self, at: 0)
+        } catch {
+            expectation.fulfill()
+            // no-op
+        }
+    }
 }
 

--- a/Tests/SwiftGodotTests/MarshalTests.swift
+++ b/Tests/SwiftGodotTests/MarshalTests.swift
@@ -361,24 +361,37 @@ final class MarshalTests: GodotTestCase {
     func testOptionalObjectArgument() {
         let arguments = Arguments(from: [nil, Node().toVariant()])
         let expectation = XCTestExpectation()
-        expectation.expectedFulfillmentCount = 3
+        expectation.expectedFulfillmentCount = 5
         do {
             let a = try arguments.argument(ofType: Node?.self, at: 0)
             XCTAssertNil(a)
             let _ = try arguments.argument(ofType: Node.self, at: 1)
-            expectation.fulfill()
+            expectation.fulfill() // 1
             let _ = try arguments.argument(ofType: Node.self, at: 2)
         } catch {
-            expectation.fulfill()
-            // no-op
+            expectation.fulfill() // 2
         }
         
         do {
             _ = try arguments.argument(ofType: Node.self, at: 0)
         } catch {
-            expectation.fulfill()
-            // no-op
+            expectation.fulfill() // 3
         }
+        
+        do {
+            _ = try arguments.argument(ofType: Int.self, at: 0)
+        } catch {
+            expectation.fulfill() // 4
+        }
+        
+        do {
+            _ = try arguments.argument(ofType: Int?.self, at: 0)
+            expectation.fulfill() // 5
+        } catch {
+            XCTFail()
+        }
+        
+        wait(for: [expectation], timeout: 0.0)
     }
 }
 


### PR DESCRIPTION
Fix cases like
```
@Callable
func nodeAddedToScene(node: Node?)
```
Resolved by making a `T?` overload a disfavoured one.