### PR TITLE
Fix bugs

### DIFF
--- a/Sources/EntryPointGenerator/GodotMacroSearchingVisitor.swift
+++ b/Sources/EntryPointGenerator/GodotMacroSearchingVisitor.swift
@@ -25,9 +25,9 @@ public class GodotMacroSearchingVisitor: SyntaxVisitor {
     public override func visit(_ classDecl: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
         for attribute in classDecl.attributes {
             if let attributeSyntax = attribute.as(AttributeSyntax.self) {
-                let attributeName = attributeSyntax.attributeName.description.trimmingCharacters(in: .whitespacesAndNewlines)
+                let attributeName = attributeSyntax.attributeName.trimmedDescription
                 if attributeName == "Godot" {
-                    let className = classDecl.name.text
+                    let className = classDecl.name.trimmedDescription
                     logger?("Found '\(className)' with @Godot macro.")
                     classes.append(className)
                     break // Found the @Godot macro, no need to check further

--- a/Sources/SwiftGodot/Extensions/VariantDictionaryExtensions.swift
+++ b/Sources/SwiftGodot/Extensions/VariantDictionaryExtensions.swift
@@ -6,7 +6,7 @@
 //
 
 @available(*, deprecated, renamed: "VariantDictionary", message: "GDictionary was renamed to `VariantDictionary` to better communicate its semantics")
-public typealias GDictionary = VariantArray
+public typealias GDictionary = VariantDictionary
 
 extension VariantDictionary: CustomDebugStringConvertible, CustomStringConvertible {
     

--- a/Sources/SwiftGodotMacroLibrary/InitSwiftExtensionMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/InitSwiftExtensionMacro.swift
@@ -31,7 +31,7 @@ public struct InitSwiftExtensionMacro: DeclarationMacro {
         let serverTypes = node.arguments.first(where: { $0.label?.text == "serverTypes" })?.expression ?? "[]"
 
         let initModule: DeclSyntax = """
-        @_cdecl(\(raw: cDecl.description)) public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+        @_cdecl(\(raw: cDecl.trimmedDescription)) public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
             guard let library, let interface, let `extension` else {
                 print ("Error: Not all parameters were initialized.")
                 return 0

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -42,7 +42,7 @@ public struct GodotCallable: PeerMacro {
         let objectOrSelf = isStatic ? "self" : "object"
         
         for (index, parameter) in parameters.enumerated() {
-            let ptype = parameter.type.description
+            let ptype = parameter.type.trimmedDescription
             
             body += """
                     let arg\(index) = try arguments.argument(ofType: \(ptype).self, at: \(index))            

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -91,14 +91,14 @@ class GodotMacroProcessor {
         let arguments = funcDecl
             .parameters
             .map { parameter in
-                let typename = parameter.type.description.trimmingCharacters(in: .whitespacesAndNewlines)                
+                let typename = parameter.type.trimmedDescription
                 return "SwiftGodot._argumentPropInfo(\(typename).self, name: \"\(parameter.internalName)\")"
             }
             .joined(separator: ",\n")
                 
         let returnTypename: String
         if let type = funcDecl.signature.returnClause?.type {
-            returnTypename = type.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            returnTypename = type.trimmedDescription
         } else {
             returnTypename = "Swift.Void"
         }
@@ -158,7 +158,7 @@ class GodotMacroProcessor {
         let hintStrExpr = hintExpr == nil ? nil : labeledExpressionList?.dropFirst().first
         
         let usageExpr = labeledExpressionList?.first { labelExpr in
-            labelExpr.description == "usage"
+            labelExpr.trimmedDescription == "usage"
         }
 
         for binding in varDecl.bindings {
@@ -182,19 +182,19 @@ class GodotMacroProcessor {
                 "name: \"\(varNameWithPrefix.camelCaseToSnakeCase())\""
             ]
             
-            if let hint = hintExpr?.description {
+            if let hint = hintExpr?.trimmedDescription {
                 args.append("userHint: .\(hint)")
             } else {
                 args.append("userHint: nil")
             }
             
-            if let hintStr = hintStrExpr?.description {
+            if let hintStr = hintStrExpr?.trimmedDescription {
                 args.append("userHintStr: \(hintStr)")
             } else {
                 args.append("userHintStr: nil")
             }
             
-            if let usage = usageExpr?.expression.description {
+            if let usage = usageExpr?.expression.trimmedDescription {
                 args.append("userUsage: \(usage)")
             } else {
                 args.append("userUsage: nil")
@@ -239,7 +239,7 @@ class GodotMacroProcessor {
                 throw GodotMacroError.signalMacroNoType(nameWithPrefix)
             }
             
-            let typeName = typeAnnotation.type.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            let typeName = typeAnnotation.type.trimmedDescription
             
             let godotName = name.camelCaseToSnakeCase()
             
@@ -364,7 +364,7 @@ public struct GodotMacro: MemberMacro {
                 
                 var isTool: Bool = false
                 if case let .argumentList (arguments) = node.arguments, let expression = arguments.first?.expression {
-                    isTool = expression.description.trimmingCharacters (in: .whitespacesAndNewlines) .hasSuffix(".tool")
+                    isTool = expression.trimmedDescription.hasSuffix(".tool")
                 }
                 
                 var implementedOverridesDecl = "override \(accessControlLevel) class func implementedOverrides () -> [StringName] {\n"

--- a/Sources/SwiftGodotMacroLibrary/SignalAttachmentMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SignalAttachmentMacro.swift
@@ -43,7 +43,7 @@ public struct SignalAttachmentMacro: AccessorMacro {
             }
             
             result.append("""
-            get { \(raw: type.description.trimmingCharacters(in: .whitespacesAndNewlines))(target: self, signalName: \"\(raw: identifier.camelCaseToSnakeCase())\") }
+            get { \(raw: type.trimmedDescription)(target: self, signalName: \"\(raw: identifier.camelCaseToSnakeCase())\") }
             """)
         }
     

--- a/Sources/SwiftGodotMacroLibrary/SignalMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SignalMacro.swift
@@ -25,7 +25,7 @@ public struct SignalMacro: DeclarationMacro {
                 signalName = argument.expression.signalName()
             }
             if index == 1 {
-                if argument.expression.description == ".init()" {
+                if argument.expression.trimmedDescription == ".init()" {
                     // its an empty dictionary, so no arguments
                     continue
                 }
@@ -47,7 +47,7 @@ public struct SignalMacro: DeclarationMacro {
                     guard let typeName = pair.value.typeName() else {
                         throw GodotMacroError.legacySignalMacroUnexpectedArgumentsSyntax
                     }
-                    arguments.append((pair.key.description, typeName))
+                    arguments.append((pair.key.trimmedDescription, typeName))
                 }
             }
         }

--- a/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
@@ -98,7 +98,7 @@ extension AttributeSyntax.Arguments {
     func argument(labeled label: String) -> LabeledExprSyntax? {
         if case let .argumentList(listSyntax) = self {
             return listSyntax.first { exprSyntax in
-                exprSyntax.label?.description == label
+                exprSyntax.label?.trimmedDescription == label
             }
         } else {
             return nil
@@ -113,7 +113,7 @@ extension AttributeSyntax {
                 return false
             }
             
-            let expr = exprSyntax.expression.description
+            let expr = exprSyntax.expression.trimmedDescription
             switch expr {
             case "true":
                 return true

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -234,3 +234,16 @@ class DebugThing: SwiftGodot.Object {
     @Callable
     func defaultIsLegacyCompatible() {}
 }
+
+@Godot(
+.tool) // like this
+class NodeWithCommentsInRandomPlaces: Node {
+    /* comment */@Signal/* comment */ var/* comment */ signal/* comment */: /* comment */ SimpleSignal // Comment
+    @Callable/* comment */
+    public func /* comment */foo/* comment */(
+        /* comment */lala: Int // COMMENT
+    ) -> /* comment */ Int // COMMENT
+    {
+        0
+    }
+}

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -235,7 +235,7 @@ class DebugThing: SwiftGodot.Object {
     func defaultIsLegacyCompatible() {}
 }
 
-/* comment */@Godot/* comment */(
+/* comment */@Godot(
 .tool/* comment */) // like this
 /* comment */class /* comment */NodeWithCommentsInRandomPlaces/* comment */: /* comment */Node /* comment */{
     /* comment */@Signal/* comment */ var/* comment */ signal/* comment */: /* comment */ SimpleSignal // Comment

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -235,15 +235,15 @@ class DebugThing: SwiftGodot.Object {
     func defaultIsLegacyCompatible() {}
 }
 
-@Godot(
-.tool) // like this
-class NodeWithCommentsInRandomPlaces: Node {
+/* comment */@Godot/* comment */(
+.tool/* comment */) // like this
+/* comment */class /* comment */NodeWithCommentsInRandomPlaces/* comment */: /* comment */Node /* comment */{
     /* comment */@Signal/* comment */ var/* comment */ signal/* comment */: /* comment */ SimpleSignal // Comment
     @Callable/* comment */
-    public func /* comment */foo/* comment */(
-        /* comment */lala: Int // COMMENT
-    ) -> /* comment */ Int // COMMENT
-    {
+    public /* comment */func /* comment */foo/* comment */(
+        /* comment */lala/* comment */:/* comment */ Int // COMMENT
+    )/* comment */ -> /* comment */ Int // COMMENT
+    /* comment */{/* comment */
         0
-    }
+    }/* comment */
 }

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -465,5 +465,24 @@ final class MacroGodotTests: MacroGodotTestCase {
             """
         )
     }
+    
+    func testNoTypeAnnotationTrivia() {
+        assertExpansion(
+            of: """
+            @Godot(
+            .tool) // like this
+            class TestClass: Node {     
+                /* comment */@Signal/* comment */ var/* comment */ signal/* comment */: /* comment */ SimpleSignal // Comment
+                @Callable/* comment */
+                public func /* comment */foo/* comment */(
+                    /* can do that too -> */var /* comment */lala: Int // COMMENT            
+                ) -> /* comment */ Int // COMMENT
+                {
+                    0
+                }            
+            }
+            """
+        )
+    }
 
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNoTypeAnnotationTrivia.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNoTypeAnnotationTrivia.swift
@@ -1,0 +1,52 @@
+// like this
+class TestClass: Node {     
+    /* comment *//* comment */ var/* comment */ signal/* comment */: /* comment */ SimpleSignal // Comment {
+        get {
+            SimpleSignal(target: self, signalName: "signal")
+        }
+    }
+    /* comment */
+    public func /* comment */foo/* comment */(
+        /* can do that too -> */var /* comment */lala: Int // COMMENT            
+    ) -> /* comment */ Int // COMMENT
+    {
+        0
+    }            
+
+    static func _mproxy_foo(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodot.Arguments) -> SwiftGodot.FastVariant? {
+        do { // safe arguments access scope
+            guard let object = SwiftGodot._unwrap(self, pInstance: pInstance) else {
+                SwiftGodot.GD.printErr("Error calling `foo`: failed to unwrap instance \(String(describing: pInstance))")
+                return nil
+            }
+            let arg0 = try arguments.argument(ofType: Int.self, at: 0)
+            return SwiftGodot._wrapCallableResult(object.foo(var: arg0))
+
+        } catch {
+            SwiftGodot.GD.printErr("Error calling `foo`: \(error.description)")
+        }
+
+        return nil
+    }
+
+    override open class var classInitializer: Void {
+        let _ = super.classInitializer
+        return _initializeClass
+    }
+
+    private static let _initializeClass: Void = {
+        let className = StringName("TestClass")
+        assert(ClassDB.classExists(class: className))
+        SimpleSignal.register(as: "signal", in: className)
+        SwiftGodot._registerMethod(
+            className: className,
+            name: "foo",
+            flags: .default,
+            returnValue: SwiftGodot._returnValuePropInfo(Int.self),
+            arguments: [
+                SwiftGodot._argumentPropInfo(Int.self, name: "lala")
+            ],
+            function: TestClass._mproxy_foo
+        )
+    }()
+}


### PR DESCRIPTION
1. Fix `GDictionary` typealiased to `VariantArray` instead of `VariantDictionary`. Mistyping happened.
2. Change (hopefully all) occurrence of `description` in macro to use `trimmedDescription` instead of manually (or not at all) trimming `description`. This effectively removes any sort of trivia (spaces, newlines, comments of all sorts) slipping into Macro-generated code.