### PR TITLE
Implement single init chain

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -115,11 +115,11 @@ func generateVirtualProxy (_ p: Printer,
                 // This idiom guarantees that: if this is a known object, we surface this
                 // object, but if it is not known, then we create the instance
                 //
-                argPrep += "let resolved_\(i) = args [\(i)]!.load (as: UnsafeRawPointer?.self)\n"
+                argPrep += "let resolved_\(i) = args [\(i)]!.load (as: GodotNativeObjectPointer?.self)\n"
                 if isMethodArgumentOptional(className: cdef.name, method: methodName, arg: arg.name) {
-                    argCall += "resolved_\(i) == nil ? nil : lookupObject (nativeHandle: resolved_\(i)!, ownsRef: false) as? \(arg.type)"
+                    argCall += "resolved_\(i) == nil ? nil : getOrInitSwiftObject (nativeHandle: resolved_\(i)!, ownsRef: false) as? \(arg.type)"
                 } else {
-                    argCall += "lookupObject (nativeHandle: resolved_\(i)!, ownsRef: false) as! \(arg.type)"
+                    argCall += "getOrInitSwiftObject (nativeHandle: resolved_\(i)!, ownsRef: false) as! \(arg.type)"
                 }
             } else if let storage = builtinClassStorage [arg.type] {
                 argCall += "\(mapTypeName (arg.type)) (content: args [\(i)]!.assumingMemoryBound (to: \(storage).self).pointee)"
@@ -162,7 +162,7 @@ func generateVirtualProxy (_ p: Printer,
                     derefType = "type (of: ret.array.content)"
                 } else if classMap [ret.type] != nil {
                     derefField = "handle"
-                    derefType = "UnsafeRawPointer?.self"
+                    derefType = " GodotNativeObjectPointer?.self"
                 } else {
                     derefField = "content"
                     derefType = "type (of: ret.content)"
@@ -589,7 +589,7 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
             p ("/// The shared instance of this class")
             p.staticProperty(visibility: "public", isStored: false, name: "shared", type: cdef.name) {
                 p ("return withUnsafePointer(to: &\(cdef.name).godotClassName.content)", arg: " ptr in") {
-                    p ("lookupObject(nativeHandle: gi.global_get_singleton(ptr)!, ownsRef: false)!")
+                    p ("getOrInitSwiftObject(nativeHandle: gi.global_get_singleton(ptr)!, ownsRef: false)!")
                 }
             }
         }
@@ -602,13 +602,15 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
         }
 
         if cdef.name == "RefCounted" {
-            p ("public required init ()") {
-                p ("super.init ()")
-                p ("_ = initRef()")
+            p("""
+            public override required init(_ context: InitContext) {
+                super.init(context)
+            
+                if context.origin == .swift {
+                    _ = initRef()
+                }                
             }
-            p ("public required init(nativeHandle: UnsafeRawPointer)") {
-                p ("super.init (nativeHandle: nativeHandle)")
-            }
+            """)
         }
         
         var referencedMethods = Set<String>()

--- a/Generator/Generator/MethodGen.swift
+++ b/Generator/Generator/MethodGen.swift
@@ -580,7 +580,7 @@ func generateMethod(_ p: Printer, method: MethodDefinition, className: String, c
             } else {
                 if godotReturnTypeIsReferenceType {
                     // frameworkType = true
-                    return "var _result = UnsafeRawPointer (bitPattern: 0)"
+                    return "var _result = GodotNativeObjectPointer(bitPattern: 0)"
                 } else {
                     if godotReturnType == "Variant" {
                         return "var _result: Variant.ContentType = Variant.zero"
@@ -676,7 +676,7 @@ func generateMethod(_ p: Printer, method: MethodDefinition, className: String, c
             return "return Variant(takingOver: _result)"
         } else if frameworkType {
             //print ("OBJ RETURN: \(className) \(method.name)")
-            return "guard let _result else { \(returnOptional ? "return nil" : "fatalError (\"Unexpected nil return from a method that should never return nil\")") } ; return lookupObject (nativeHandle: _result, ownsRef: true)\(returnOptional ? "" : "!")"
+            return "guard let _result else { \(returnOptional ? "return nil" : "fatalError (\"Unexpected nil return from a method that should never return nil\")") } ; return getOrInitSwiftObject (nativeHandle: _result, ownsRef: true)\(returnOptional ? "" : "!")"
         } else if godotReturnType?.starts(with: "typedarray::") ?? false {
             let defaultInit = makeDefaultInit(godotType: godotReturnType!, initCollection: "takingOver: _result")
             return "return \(defaultInit)"
@@ -770,14 +770,12 @@ func generateMethod(_ p: Printer, method: MethodDefinition, className: String, c
             let instanceArg: String
             if method.isStatic {
                 instanceArg = "nil"
-            } else {
-                let accessor: String
+            } else {                
                 if asSingleton {
-                    accessor = "shared.handle"
+                    instanceArg = "shared.handle"
                 } else {
-                    accessor = "handle"
+                    instanceArg = "handle"
                 }
-                instanceArg = "UnsafeMutableRawPointer(mutating: \(accessor))"
             }
             
             func getMethodNameArgument() -> String {

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -92,7 +92,7 @@ var classMap: [String: JGodotExtensionAPIClass] = [:]
 
 // Tracks whether a Godot type has subclasses, we want to use this
 // to determine whether we want to perform the more expensive lookup
-// for handle -> Swift type using `lookupObject` rather than creating
+// for handle -> Swift type using `getOrInitSwiftObject` rather than creating
 // a plain wrapper directly from the handle
 var hasSubclasses = Set<String>()
 

--- a/Sources/ManualExtension/ManualExtension.swift
+++ b/Sources/ManualExtension/ManualExtension.swift
@@ -52,19 +52,12 @@ class SwiftSprite: Sprite2D {
         classInfo.registerProperty(foodProp, getter: "demo_get_favorite_food", setter: "demo_set_favorite_food")
     }()
     
-    required init (nativeHandle: UnsafeRawPointer) {
-        _ = SwiftSprite.initClass
-        time_passed = 0
-        count = sequence
-        super.init (nativeHandle: nativeHandle)
-    }
-    
-    required init () {
+    required init(_ context: InitContext) {
         _ = SwiftSprite.initClass
         count = sequence
         sequence += 1
         time_passed = 0
-        super.init ()
+        super.init(context)
     }
     
     deinit {

--- a/Sources/SwiftGodot/Core/SignalProxy.swift
+++ b/Sources/SwiftGodot/Core/SignalProxy.swift
@@ -33,12 +33,8 @@ public class SignalProxy: Object {
     public typealias Proxy = (borrowing Arguments) -> ()
     public var proxy: Proxy?
     
-    public required init () {
-        super.init()
-    }
-
-    public required init(nativeHandle: UnsafeRawPointer) {
-        super.init(nativeHandle: nativeHandle)
+    public required init(_ context: InitContext) {
+        super.init(context)
     }
 
     func proxyFunc(args: borrowing Arguments) -> Variant? {

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -968,8 +968,8 @@ struct CallableWrapper {
 // This is a temporary hack until we get proper WeakReference support
 // so we can clear the internal dictionaries when a domain is shut down.
 ///
-public func getActiveHandles() -> ([UnsafeRawPointer]) {
-    var handles: [UnsafeRawPointer] = []
+public func getActiveHandles() -> [GodotNativeObjectPointer] {
+    var handles: [GodotNativeObjectPointer] = []
     for x in liveFrameworkObjects {
         handles.append(x.key)
     }

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -675,11 +675,11 @@ func createFunc(_ userData: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer
         fatalError("SWIFT: It was not possible to construct a \(type.godotClassName.description)")
     }
 
-    let o = type.init(InitContext(handle: handle, origin: .godot))
+    let object = type.init(InitContext(handle: handle, origin: .godot))
     
     // We are the createFunc, and we have no other owner to this object but ourselves
     // we need to make this a strong reference, or it dies before we return
-    guard let wrapper = liveSubtypedObjects[handle] else {
+    guard let wrapper = object.wrapper else {
         fatalError("SwiftGodot.createFunc: wrapper should have been created during binding")
     }
     
@@ -704,11 +704,11 @@ func recreateFunc(_ userData: UnsafeMutableRawPointer?, godotObjectHandle: Unsaf
         print ("SwiftGodot.recreateFunc: The wrapped value did not contain a type: \(typeAny)")
         return nil
     }
-    let o = type.init(InitContext(handle: godotObjectHandle, origin: .godot))
+    let object = type.init(InitContext(handle: godotObjectHandle, origin: .godot))
     
     // Just line in the createFunc
     // we need to make this a strong reference, or it dies before we return
-    guard let wrapper = liveSubtypedObjects[godotObjectHandle] else {
+    guard let wrapper = object.wrapper else {
         fatalError("SwiftGodot.createFunc: wrapper should have been created during binding")
     }
     

--- a/Sources/SwiftGodot/FastVariant.swift
+++ b/Sources/SwiftGodot/FastVariant.swift
@@ -291,12 +291,12 @@ public struct FastVariant: ~Copyable {
             return nil
         }
 
-        var objectHandle: UnsafeRawPointer? = UnsafeRawPointer(bitPattern: 1)!
+        var objectHandle: GodotNativeObjectPointer? = GodotNativeObjectPointer(bitPattern: 1)!
         constructType(into: &objectHandle, constructor: Object.selfFromVariant)
         guard let objectHandle else {
             return nil
         }
-        let ret: T? = lookupObject(nativeHandle: objectHandle, ownsRef: false)
+        let ret: T? = getOrInitSwiftObject(nativeHandle: objectHandle, ownsRef: false)
         return ret
     }
     

--- a/Sources/SwiftGodot/Variant.swift
+++ b/Sources/SwiftGodot/Variant.swift
@@ -253,12 +253,12 @@ public final class Variant: Hashable, Equatable, CustomDebugStringConvertible, _
             return nil
         }
 
-        var objectHandle: UnsafeRawPointer? = UnsafeRawPointer(bitPattern: 1)!
+        var objectHandle: GodotNativeObjectPointer? = GodotNativeObjectPointer(bitPattern: 1)!
         constructType(into: &objectHandle, constructor: Object.selfFromVariant)
         guard let objectHandle else {
             return nil
         }
-        let ret: T? = lookupObject(nativeHandle: objectHandle, ownsRef: false)
+        let ret: T? = getOrInitSwiftObject(nativeHandle: objectHandle, ownsRef: false)
         return ret
     }
     

--- a/Tests/SwiftGodotEngineTests/Math/AStarTests.swift
+++ b/Tests/SwiftGodotEngineTests/Math/AStarTests.swift
@@ -12,8 +12,8 @@ private final class ABCX: AStar3D {
     static let C: Int = 2
     static let X: Int = 3
     
-    required init () {
-        super.init ()
+    required init(_ context: InitContext) {
+        super.init(context)
         
         addPoint (id: Self.A, position: Vector3 (x: 0, y: 0, z: 0))
         addPoint (id: Self.B, position: Vector3 (x: 1, y: 0, z: 0))
@@ -23,10 +23,6 @@ private final class ABCX: AStar3D {
         connectPoints (id: Self.A, toId: Self.C)
         connectPoints (id: Self.B, toId: Self.C)
         connectPoints (id: Self.X, toId: Self.A)
-    }
-    
-    required init (nativeHandle: UnsafeRawPointer) {
-        super.init (nativeHandle: nativeHandle)
     }
     
     // Disable heuristic completely.

--- a/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotBuildTest.swift
@@ -34,18 +34,11 @@ class Demo5: Node {
     @Export(.enum) var foo: Demo3
     @Export(.enum) var bar: Demo4
     
-    required init() {
+    required init(_ context: InitContext) {
         foo = .first
         bar = .second
         
-        super.init()
-    }
-    
-    required init(nativeHandle: UnsafeRawPointer) {
-        foo = .first
-        bar = .second
-        
-        super.init(nativeHandle: nativeHandle)
+        super.init(context)
     }
 }
 


### PR DESCRIPTION
### Single `required init` chain

There is only one `required init` chain now, that takes `InitContext`. In case users _do_ need a custom `init` they will have only:

```
    required init(_ context: InitContext) {
        super.init(context)
        
        addPoint (id: Self.A, position: Vector3 (x: 0, y: 0, z: 0))
        addPoint (id: Self.B, position: Vector3 (x: 1, y: 0, z: 0))
        addPoint (id: Self.C, position: Vector3 (x: 0, y: 1, z: 0))
        addPoint (id: Self.X, position: Vector3 (x: 0, y: 0, z: 1))
        connectPoints (id: Self.A, toId: Self.B)
        connectPoints (id: Self.A, toId: Self.C)
        connectPoints (id: Self.B, toId: Self.C)
        connectPoints (id: Self.X, toId: Self.A)
    }
 
```

They can't construct their own, it's required for `super.init`, so it's almost impossible to get wrong.

At the same time default initialiser `init()` is accessible for all `Object`-derived types, it will go through the same path but supply the newly constructed native object.

Initialiser `init(nativeHandle:)` is left, but now takes UnsafeMutableRawPointer

### Internal improvements

Global `bindingObject` is gone. Scope responsible for creation of `bindingObject` supplies it directly to the `required init` instead.

Opaque `Object *` is kept as `UnsafeMutableRawPointer` instead of `UnsafeRawPointer` to align with the GDExtension API. No more awkward `UnsafeMutableRawPointer(mutating: constRawPointer)`.

Minor renames.
`GodotNativeObjectPointer` typealias for `UnsafeMutableRawPointer`.