### PR TITLE
Traits! And Swift bump to 6.1

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -593,13 +593,14 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
                 }
             }
         }
-
-        if noStaticCaches {
-            p ("override open class var godotClassName: StringName { \"\(cdef.name)\" }")
-        } else {
-            p ("private static var className = StringName(\"\(cdef.name)\")")
-            p ("override open class var godotClassName: StringName { className }")
-        }
+        
+        
+        #if TRAIT_NO_STATIC_CACHES
+        p ("override open class var godotClassName: StringName { \"\(cdef.name)\" }")
+        #else
+        p ("private static var className = StringName(\"\(cdef.name)\")")
+        p ("override open class var godotClassName: StringName { className }")
+        #endif
 
         if cdef.name == "RefCounted" {
             p("""

--- a/Generator/Generator/Printer.swift
+++ b/Generator/Generator/Printer.swift
@@ -85,11 +85,15 @@ class Printer {
             visibility = "\(visibility) "
         }
         
-        if noStaticCaches || !isStored {
+        #if TRAIT_NO_STATIC_CACHES
+        b("\(visibility)static var \(name): \(type)", suffix: "", block: block)
+        #else
+        if !isStored {
             b("\(visibility)static var \(name): \(type)", suffix: "", block: block)
         } else {
             b("\(visibility)static let \(name): \(type) =", suffix: "()", block: block)
         }
+        #endif
     }
 
     // Prints a block, automatically indents the code in the closure

--- a/Generator/Generator/main.swift
+++ b/Generator/Generator/main.swift
@@ -41,9 +41,6 @@ var generatorOutput = args.count > 2 ? args[2] : defaultGeneratorOutputlUrl.path
 var docRoot = args.count > 3 ? args[3] : defaultDocRootUrl.path
 let outputDir = args.count > 2 ? args[2] : generatorOutput
 
-/// Special case for Xogot to avoid caching godot interface pointers
-let noStaticCaches = false
-
 // IF we want one file per type, or a smaller number of
 // files that are combined.
 var combineOutput = args.contains("--combined")

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 
 import CompilerPluginSupport
 import PackageDescription
@@ -88,9 +88,8 @@ var targets: [Target] = [
         path: "Generator",
         exclude: ["README.md"],
         swiftSettings: [
-            .swiftLanguageMode(.v5)
-            // Uncomment for using legacy array-based marshalling
-            //.define("LEGACY_MARSHALING")
+            .swiftLanguageMode(.v5),
+            .define("TRAIT_NO_STATIC_CACHES", .when(traits: ["NoStaticCaches"])),
         ]
     ),
 
@@ -127,7 +126,10 @@ var targets: [Target] = [
             .product(name: "SwiftSyntax", package: "swift-syntax"),
             .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
         ],
-        swiftSettings: [.swiftLanguageMode(.v5)]
+        swiftSettings: [
+            .swiftLanguageMode(.v5),
+            .define("TRAIT_USE_CAMEL_CASE_FOR_CALLABLE", .when(traits: ["UseCamelCaseForCallable"]))
+        ]
     ),
     // This contains sample code showing how to use the SwiftGodot API
     .target(
@@ -156,6 +158,7 @@ var targets: [Target] = [
         swiftSettings: [
             .swiftLanguageMode(.v5),
             .define("CUSTOM_BUILTIN_IMPLEMENTATIONS"),
+            .define("TRAIT_USE_CAMEL_CASE_FOR_CALLABLE", .when(traits: ["UseCamelCaseForCallable"])),
             .unsafeFlags(["-suppress-warnings"])
         ],
         plugins: ["CodeGeneratorPlugin", "SwiftGodotMacroLibrary"]
@@ -263,10 +266,15 @@ let package = Package(
         .iOS (.v17)
     ],
     products: products,
+    traits: [
+        .trait(name: "NoStaticCaches", description: "Disable caching reusable GDE interface pointers and instances"),
+        .trait(name: "UseCamelCaseForCallable", description: "If used, @Callable macro will export unction named `as is` instead of converting it to `snake_case` (legacy behavior)"),
+        .default(enabledTraits: [])
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.1"),
     ],
-    targets: targets
+    targets: targets,
 )

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ create a Swift Library Package that references the Swift Godot
 package, like this:
 
 ```swift
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 import PackageDescription
 
 let package = Package(

--- a/Sources/SwiftGodot/MacroDefs.swift
+++ b/Sources/SwiftGodot/MacroDefs.swift
@@ -25,6 +25,12 @@ public enum ClassBehavior: Int {
     case gameplay, tool
 }
 
+#if TRAIT_USE_CAMEL_CASE_FOR_CALLABLE
+public let autoSnakeCaseDefaultValue = false
+#else
+public let autoSnakeCaseDefaultValue = true
+#endif
+
 /// Exposes the function to the Godot runtime
 ///
 /// When this attribute is applied to a function, the function is exposed to the Godot engine, and it
@@ -34,7 +40,7 @@ public enum ClassBehavior: Int {
 ///
 /// - Parameter autoSnakeCase: if `true` (default value is `false`), the function name will be automatically translated from `camelCase` to `snake_case` when exposed to Godot
 @attached(peer, names: prefixed(_mproxy_))
-public macro Callable(autoSnakeCase: Bool = false) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
+public macro Callable(autoSnakeCase: Bool = autoSnakeCaseDefaultValue) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
 
 /// Exposes a property or variable to the Godot runtime
 ///

--- a/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
@@ -110,7 +110,11 @@ extension AttributeSyntax {
     var callableAutoSnakeCaseArgument: Bool {
         get throws {
             guard let exprSyntax = arguments?.argument(labeled: "autoSnakeCase") else {
+                #if TRAIT_USE_CAMEL_CASE_FOR_CALLABLE
                 return false
+                #else
+                return true
+                #endif
             }
             
             let expr = exprSyntax.expression.trimmedDescription

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTestCase.swift
@@ -30,8 +30,8 @@ class MacroGodotTestCase: XCTestCase {
     
     /// Set it to local path to regenerate expansions test data in case the macro was updated
     let regeneratedResourcesPath: String? =
-        nil
-//        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
+//        nil
+        URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("Resources").path()
         
     
     func regenerateExpansionResource(input: String, outputUrl: URL) {

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableAutoSnakeCase.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableAutoSnakeCase.swift
@@ -80,7 +80,7 @@ class TestClass: Node {
         )
         SwiftGodot._registerMethod(
             className: className,
-            name: "defaultIsLegacyCompatible",
+            name: "default_is_legacy_compatible",
             flags: .default,
             returnValue: SwiftGodot._returnValuePropInfo(Swift.Void.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithObjectParams.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithObjectParams.swift
@@ -106,7 +106,7 @@ class Castro: Node {
         assert(ClassDB.classExists(class: className))
         SwiftGodot._registerMethod(
             className: className,
-            name: "deleteEpisode",
+            name: "delete_episode",
             flags: .default,
             returnValue: SwiftGodot._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -126,7 +126,7 @@ class Castro: Node {
         )
         SwiftGodot._registerMethod(
             className: className,
-            name: "perhapsSubscribe",
+            name: "perhaps_subscribe",
             flags: .default,
             returnValue: SwiftGodot._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -136,7 +136,7 @@ class Castro: Node {
         )
         SwiftGodot._registerMethod(
             className: className,
-            name: "removeSilences",
+            name: "remove_silences",
             flags: .default,
             returnValue: SwiftGodot._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -146,7 +146,7 @@ class Castro: Node {
         )
         SwiftGodot._registerMethod(
             className: className,
-            name: "getLatestEpisode",
+            name: "get_latest_episode",
             flags: .default,
             returnValue: SwiftGodot._returnValuePropInfo(Episode.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithValueParams.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithValueParams.swift
@@ -86,7 +86,7 @@ class MathHelper: Node {
         )
         SwiftGodot._registerMethod(
             className: className,
-            name: "areBothTrue",
+            name: "are_both_true",
             flags: .default,
             returnValue: SwiftGodot._returnValuePropInfo(Bool.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayReturnType.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayReturnType.swift
@@ -24,7 +24,7 @@ class SomeNode: Node {
         assert(ClassDB.classExists(class: className))
         SwiftGodot._registerMethod(
             className: className,
-            name: "getIntegerCollection",
+            name: "get_integer_collection",
             flags: .default,
             returnValue: SwiftGodot._returnValuePropInfo(TypedArray<Int>.self),
             arguments: [

--- a/Tests/SwiftGodotTests/MacroCallableIntegrationTests.swift
+++ b/Tests/SwiftGodotTests/MacroCallableIntegrationTests.swift
@@ -52,7 +52,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         objectsArray.append(Variant(object2))
         objectsArray.append(nil)
                 
-        XCTAssertEqual(testObject.call(method: "countObjects", objectsArray.toVariant()).to(), 6)
+        XCTAssertEqual(testObject.call(method: "count_objects", objectsArray.toVariant()).to(), 6)
         testObject.free()
         object0.free()
         object1.free()
@@ -75,7 +75,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         objectsArray.append(nil)
         objectsArray.append(Variant(RefCounted())) // this one causes the failure
                 
-        XCTAssertEqual(testObject.call(method: "countObjects", Variant(objectsArray)), 0.toVariant())
+        XCTAssertEqual(testObject.call(method: "count_objects", Variant(objectsArray)), 0.toVariant())
         testObject.free()
         object0.free()
         object1.free()
@@ -100,7 +100,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         // this one won't be added, error is logged from Godot, RefCounted is not TestObject
         objectsArray.append(Variant(RefCounted()))
         
-        let result = testObject.call(method: "countObjects", objectsArray.toVariant())
+        let result = testObject.call(method: "count_objects", objectsArray.toVariant())
         XCTAssertEqual(result.to(), 6)
         
         testObject.free()
@@ -124,7 +124,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         objectsArray.append(object2) // 5
         objectsArray.append(nil) // 6
         
-        XCTAssertEqual(testObject.call(method: "countObjects", Variant(objectsArray)), Variant(6))
+        XCTAssertEqual(testObject.call(method: "count_objects", Variant(objectsArray)), Variant(6))
         testObject.free()
         object0.free()
         object1.free()
@@ -139,7 +139,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         builtinsArray.append(Variant(2))
         builtinsArray.append(Variant(3))
         
-        XCTAssertEqual(testObject.call(method: "countBuiltins", Variant(builtinsArray)), Variant(3))
+        XCTAssertEqual(testObject.call(method: "count_builtins", Variant(builtinsArray)), Variant(3))
         testObject.free()
     }
     
@@ -157,7 +157,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         array.append(Variant(4))
         
         // Fails, prints into console and returns nil due to typed builtin array not allowing nils
-        XCTAssertEqual(testObject.call(method: "countObjects", Variant(array)), 0.toVariant())
+        XCTAssertEqual(testObject.call(method: "count_objects", Variant(array)), 0.toVariant())
         testObject.free()
     }
     
@@ -171,7 +171,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         // this one won't be added, error is logged from Godot, nil Builtins are not allowed in typed Arrays
         builtinsArray.append(nil)
         
-        XCTAssertEqual(testObject.call(method: "countBuiltins", Variant(builtinsArray)), Variant(3))
+        XCTAssertEqual(testObject.call(method: "count_builtins", Variant(builtinsArray)), Variant(3))
         testObject.free()
     }
     
@@ -183,7 +183,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         builtinsArray.append(2)
         builtinsArray.append(3)
         
-        XCTAssertEqual(testObject.call(method: "countBuiltins", Variant(builtinsArray)), Variant(3))
+        XCTAssertEqual(testObject.call(method: "count_builtins", Variant(builtinsArray)), Variant(3))
         testObject.free()
     }
     
@@ -204,7 +204,7 @@ final class MacroCallableIntegrationTests: GodotTestCase {
         variants.append(Variant(true)) // 7
         
         
-        XCTAssertEqual(testObject.call(method: "countMixed", Variant(builtins), Variant(objects), Variant(variants), Variant("ignored")), Variant(7))
+        XCTAssertEqual(testObject.call(method: "count_mixed", Variant(builtins), Variant(objects), Variant(variants), Variant("ignored")), Variant(7))
         testObject.free()
     }
 }

--- a/Tests/SwiftGodotTests/SignalTests.swift
+++ b/Tests/SwiftGodotTests/SignalTests.swift
@@ -29,7 +29,7 @@ final class SignalTests: GodotTestCase {
     func testUserDefinedSignal() {
         let node = TestSignalNode()
 
-        node.connect (signal: TestSignalNode.mySignal, to: node, method: "receiveSignal")
+        node.connect (signal: TestSignalNode.mySignal, to: node, method: "receive_signal")
         node.emit (signal: TestSignalNode.mySignal, 22, "Joey")
 
         XCTAssertEqual (node.receivedInt, 22, "Integers should have been the same")


### PR DESCRIPTION
# Introduced Swift Package Manager Traits (requires Swift 6.1)

```
traits: [
        .trait(name: "NoStaticCaches", description: "Disable caching reusable GDE interface pointers and instances"),
        .trait(name: "UseCamelCaseForCallable", description: "If used, @Callable macro will export unction named `as is` instead of converting it to `snake_case` (legacy behavior)"),
        .default(enabledTraits: [])
],
```

Both of these are off by default.
`NoStaticCaches` is a desired behavior for `Xogot`. Now conditional compilation flag based on this trait can change this behavior in all places, where `Xogot` can't rely on unpruned static caches, while other projects win from caching everything.
`Generator` is using this flag now.

`UseCamelCaseForCallable` is a legacy behavior that exported `functionWithName` as `functionWithName` to Godot, which was inconsistent with @Export properties behavior, that converted `propertyWithName` to `property_with_name`.
New users can now have consistent behaviour by default while older ones relying on previous naming can opt-in this `Trait` in their package definition:

```
let package = Package(
    name: "MyFirstGame",
    products: [
        .library(name: "MyFirstGame", type: .dynamic, targets: ["MyFirstGame"]),
    ],
    dependencies: [
        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "main", traits: ["NoStaticCaches", "UseCamelCaseForCallable"])
    ],
    targets: [
        .target(
            name: "MyFirstGame",
            dependencies: ["SwiftGodot"])]
)
```