### PR TITLE
Automatic registration stage

### DIFF
--- a/Sources/SwiftGodot/Core/ClassServices.swift
+++ b/Sources/SwiftGodot/Core/ClassServices.swift
@@ -328,11 +328,19 @@ func bind_call_ptr () {
     fatalError("Not implemented")
 }
 
+/// Error indicating that a ``earlyChild`` is registered before ``lateParent`` due to ``classInitializationLevel`` requirement, despite ``lateParent`` is a super class of ``earlyChild``
+public struct IncorrectInitializationOrderError: Error {
+    public let earlyChild: Object.Type
+    public let lateParent: Object.Type
+}
+
 extension [Object.Type] {
     /// Returns a topologically sorted array of the classes.
     /// Classes depending on others will be strictly later in the sequence.
     /// Duplicating entries will be removed.    
-    public func topologicallySorted() -> [Object.Type] {
+    public func topologicallySorted(
+        onIncorrectInitializationOrder: (Object.Type, Object.Type) throws -> Void
+    ) rethrows -> [Object.Type] {
         guard !isEmpty else {
             return []
         }
@@ -357,6 +365,15 @@ extension [Object.Type] {
             for typeId in remaining {
                 let type = type(with: typeId)
                 if let superType = _getSuperclass(type) {
+                    guard let superType = superType as? Object.Type else {
+                        fatalError("Unreachable")
+                    }
+                    
+                    if superType.classInitializationLevel.rawValue > type.classInitializationLevel.rawValue {
+                        // Super type is registered later than the child
+                        try onIncorrectInitializationOrder(type, superType)
+                    }
+                    
                     let superTypeId = id(of: superType)
                     if !remaining.contains(superTypeId) {
                         pending.append(typeId)
@@ -374,5 +391,38 @@ extension [Object.Type] {
         }
         
         return sorted.map { type(with: $0) }
+    }
+    
+    /// Returns a topologically sorted array of the classes.
+    /// Classes depending on others will be strictly later in the sequence.
+    /// Duplicating entries will be removed.
+    public func topologicallySorted() -> [Object.Type] {
+        topologicallySorted(onIncorrectInitializationOrder: { _, _ in
+            // no-op
+        })
+    }
+    
+    /// Returns a topologically sorted array of the classes.
+    /// Classes depending on others will be strictly later in the sequence.
+    /// Duplicating entries will be removed.
+    /// If the sorted sequence doesn't contain a strictly ascending `classInitializationLevel`, throws ``IncorrectInitializationOrderError``
+    public func topologicallySortedCheckingInitializationOrder() throws -> [Object.Type] {
+        try topologicallySorted(
+            onIncorrectInitializationOrder: {
+                throw IncorrectInitializationOrderError(earlyChild: $0, lateParent: $1)
+            }
+        )
+    }
+        
+    /// Sort types topologically, ensuring that their initialization order is correct (see ``topologicallySortedCheckingInitializationOrder``)
+    public func prepareForRegistration() throws -> [GDExtension.InitializationLevel: [Object.Type]] {
+        let sorted = try topologicallySortedCheckingInitializationOrder()
+        var result: [GDExtension.InitializationLevel: [Object.Type]] = [:]
+        
+        for type in sorted {
+            result[type.classInitializationLevel, default: []].append(type)
+        }
+        
+        return result
     }
 }

--- a/Sources/SwiftGodot/Core/Wrapped.swift
+++ b/Sources/SwiftGodot/Core/Wrapped.swift
@@ -275,9 +275,6 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     
     /// For use by the framework, you should not need to call this.
     public required init(_ context: InitContext) {
-        // TODO: move this to `register`, we've got enough global mutexes during construction
-        let _ = Self.classInitializer
-        
         handle = context.handle
         extensionInterface.objectInited(object: self)
         bindSwiftObject(self, toGodot: context.handle)
@@ -319,6 +316,9 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     }
     
     open class var classInitializer: Void { () }
+    
+    /// Indicates during which engine initialization stage this class is registered. `.scene` is default. This value is taken into consideration when using `#initSwiftExtension(cdecl:types:)`  or `EntryPointGeneratorPlugin`.
+    open class var classInitializationLevel: GDExtension.InitializationLevel { .scene }
 }
 
 /// We can't simply extend `Wrapped`, because `convenience init` do not keep polymorphic `Self`.
@@ -429,6 +429,7 @@ func register<T: Object>(type name: StringName, parent: StringName, type: T.Type
     info.class_userdata = retained.toOpaque()
     
     gi.classdb_register_extension_class(extensionInterface.getLibrary(), &nameContent, &parent.content, &info)
+    _ = type.classInitializer
 }
 
 final class WrappedReference {

--- a/Sources/SwiftGodotMacroLibrary/InitSwiftExtensionMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/InitSwiftExtensionMacro.swift
@@ -19,36 +19,51 @@ public struct InitSwiftExtensionMacro: DeclarationMacro {
         guard let cDecl = node.arguments.first?.expression else {
             fatalError("compiler bug: the macro does not have any arguments")
         }
-
-        let sceneTypes: ExprSyntax
-        if let types = node.arguments.first(where: { $0.label?.text == "types" })?.expression {
-            sceneTypes = types
-        } else {
-            sceneTypes = node.arguments.first(where: { $0.label?.text == "sceneTypes" })?.expression ?? "[]"
-        }
-        let coreTypes = node.arguments.first(where: { $0.label?.text == "coreTypes" })?.expression ?? "[]"
-        let editorTypes = node.arguments.first(where: { $0.label?.text == "editorTypes" })?.expression ?? "[]"
-        let serverTypes = node.arguments.first(where: { $0.label?.text == "serverTypes" })?.expression ?? "[]"
-
-        let initModule: DeclSyntax = """
-        @_cdecl(\(raw: cDecl.trimmedDescription)) public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+        
+        let p = CodePrinter()
+        p("@_cdecl(\(cDecl.trimmedDescription)) public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8", .curly) {
+            p("""
             guard let library, let interface, let `extension` else {
                 print ("Error: Not all parameters were initialized.")
                 return 0
             }
-            var types: [GDExtension.InitializationLevel: [Object.Type]] = [:]
-            types[.core] = \(coreTypes).topologicallySorted()
-            types[.editor] = \(editorTypes).topologicallySorted()
-            types[.scene] = \(sceneTypes).topologicallySorted()
-            types[.servers] = \(serverTypes).topologicallySorted()
+            """)
+            
+            if let types = node.arguments.first(where: { $0.label?.text == "types" })?.expression.trimmedDescription {
+                p("""
+                let types: [GDExtension.InitializationLevel: [Object.Type]]
+                do {
+                    types = try \(types).prepareForRegistration()
+                } catch {
+                    GD.printErr("Error during GDExtension initialization: \\(error)")
+                    return 0
+                }
+                """)
+            } else {
+                let sceneTypes = node.arguments.first(where: { $0.label?.text == "sceneTypes" })?.expression ?? "[]"
+                let coreTypes = node.arguments.first(where: { $0.label?.text == "coreTypes" })?.expression ?? "[]"
+                let editorTypes = node.arguments.first(where: { $0.label?.text == "editorTypes" })?.expression ?? "[]"
+                let serverTypes = node.arguments.first(where: { $0.label?.text == "serverTypes" })?.expression ?? "[]"
+                
+                p("""
+                var types: [GDExtension.InitializationLevel: [Object.Type]] = [:]
+                types[.core] = \(coreTypes).topologicallySorted()
+                types[.editor] = \(editorTypes).topologicallySorted()
+                types[.scene] = \(sceneTypes).topologicallySorted()
+                types[.servers] = \(serverTypes).topologicallySorted()                
+                """)
+            }
+            
+            p("""
             initializeSwiftModule (interface, library, `extension`, initHook: { level in
                 types[level]?.forEach(register)
             }, deInitHook: { level in
                 types[level]?.reversed().forEach(unregister)
             })
             return 1
+            """)
         }
-        """
-        return [initModule]
+                
+        return ["\(raw: p.result)"]
     }
 }

--- a/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/InitSwiftExtensionMacroTests.swift
@@ -16,6 +16,13 @@ final class InitSwiftExtensionMacroTests: MacroGodotTestCase {
         ["initSwiftExtension": InitSwiftExtensionMacro.self]
     }
     
+    func testInitWithSwiftExtensionMacroWithTypes() {
+        assertExpansion(of: """
+            #initSwiftExtension(cdecl: "libchrysalis_entry_point", types: [ChrysalisNode.self, CaterpillarNode.self, ButterflyNode.self])            
+            """
+        )
+    }
+    
     func testInitSwiftExtensionMacroWithUnspecifiedTypes() {
         assertExpansion(of: """
             #initSwiftExtension(cdecl: "libchrysalis_entry_point")

--- a/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithAllTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithAllTypes.swift
@@ -1,4 +1,4 @@
-@_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+@_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
     guard let library, let interface, let `extension` else {
         print ("Error: Not all parameters were initialized.")
         return 0

--- a/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithCoreTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithCoreTypes.swift
@@ -1,4 +1,4 @@
-@_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+@_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
     guard let library, let interface, let `extension` else {
         print ("Error: Not all parameters were initialized.")
         return 0

--- a/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithEditorTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithEditorTypes.swift
@@ -1,4 +1,4 @@
-@_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+@_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
     guard let library, let interface, let `extension` else {
         print ("Error: Not all parameters were initialized.")
         return 0

--- a/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithEmptyTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithEmptyTypes.swift
@@ -1,13 +1,15 @@
-@_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+@_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
     guard let library, let interface, let `extension` else {
         print ("Error: Not all parameters were initialized.")
         return 0
     }
-    var types: [GDExtension.InitializationLevel: [Object.Type]] = [:]
-    types[.core] = [].topologicallySorted()
-    types[.editor] = [].topologicallySorted()
-    types[.scene] = [].topologicallySorted()
-    types[.servers] = [].topologicallySorted()
+    let types: [GDExtension.InitializationLevel: [Object.Type]]
+    do {
+        types = try [].prepareForRegistration()
+    } catch {
+        GD.printErr("Error during GDExtension initialization: \(error)")
+        return 0
+    }
     initializeSwiftModule (interface, library, `extension`, initHook: { level in
         types[level]?.forEach(register)
     }, deInitHook: { level in

--- a/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithServerTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithServerTypes.swift
@@ -1,4 +1,4 @@
-@_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+@_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
     guard let library, let interface, let `extension` else {
         print ("Error: Not all parameters were initialized.")
         return 0

--- a/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithUnspecifiedTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitSwiftExtensionMacroWithUnspecifiedTypes.swift
@@ -1,4 +1,4 @@
-@_cdecl("libchrysalis_entry_point") public func enterExtension (interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
+@_cdecl("libchrysalis_entry_point") public func enterExtension(interface: OpaquePointer?, library: OpaquePointer?, extension: OpaquePointer?) -> UInt8 {
     guard let library, let interface, let `extension` else {
         print ("Error: Not all parameters were initialized.")
         return 0

--- a/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitWithSwiftExtensionMacroWithTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/InitSwiftExtensionMacroTests.testInitWithSwiftExtensionMacroWithTypes.swift
@@ -3,15 +3,17 @@
         print ("Error: Not all parameters were initialized.")
         return 0
     }
-    var types: [GDExtension.InitializationLevel: [Object.Type]] = [:]
-    types[.core] = [].topologicallySorted()
-    types[.editor] = [].topologicallySorted()
-    types[.scene] = [ChrysalisNode.self].topologicallySorted()
-    types[.servers] = [].topologicallySorted()
+    let types: [GDExtension.InitializationLevel: [Object.Type]]
+    do {
+        types = try [ChrysalisNode.self, CaterpillarNode.self, ButterflyNode.self].prepareForRegistration()
+    } catch {
+        GD.printErr("Error during GDExtension initialization: \(error)")
+        return 0
+    }
     initializeSwiftModule (interface, library, `extension`, initHook: { level in
         types[level]?.forEach(register)
     }, deInitHook: { level in
         types[level]?.reversed().forEach(unregister)
     })
     return 1
-}
+}            

--- a/Tests/SwiftGodotTests/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTests/MacroIntegrationTests.swift
@@ -72,4 +72,74 @@ final class MacroIntegrationTests: GodotTestCase {
         
         XCTAssertEqual(_invokeGetter(closure)?.gtype, .callable)
     }
+    
+    func testCorrectRegistrationSequence() {
+        class A: Object {
+            override class var classInitializationLevel: GDExtension.InitializationLevel {
+                .core
+            }
+        }
+        
+        class B: A {
+            override class var classInitializationLevel: GDExtension.InitializationLevel {
+                .servers
+            }
+        }
+        
+        class C: B {
+            override class var classInitializationLevel: GDExtension.InitializationLevel {
+                .scene
+            }
+        }
+        
+        class D0: C {
+            override class var classInitializationLevel: GDExtension.InitializationLevel {
+                .editor
+            }
+        }
+        
+        class D1: C {
+            override class var classInitializationLevel: GDExtension.InitializationLevel {
+                .editor
+            }
+        }
+        
+        var types: [GDExtension.InitializationLevel: [Object.Type]] = [:]
+        do {
+            types = try [A.self, B.self, C.self, D0.self, D1.self].prepareForRegistration()
+        } catch {
+            XCTFail("\(error)")
+            return
+        }
+        
+        XCTAssertEqual(types[.core]?.contains(where: { $0 == A.self}), true)
+        XCTAssertEqual(types[.servers]?.contains(where: { $0 == B.self}), true)
+        XCTAssertEqual(types[.scene]?.contains(where: { $0 == C.self}), true)
+        XCTAssertEqual(types[.editor]?.contains(where: { $0 == D0.self}), true)
+        XCTAssertEqual(types[.editor]?.contains(where: { $0 == D1.self}), true)
+        
+        XCTAssertEqual(types[.core]?.count, 1)
+        XCTAssertEqual(types[.servers]?.count, 1)
+        XCTAssertEqual(types[.scene]?.count, 1)
+        XCTAssertEqual(types[.editor]?.count, 2)
+        
+        class E: Object {
+            override class var classInitializationLevel: GDExtension.InitializationLevel {
+                .scene
+            }
+        }
+        
+        class F: E {
+            override class var classInitializationLevel: GDExtension.InitializationLevel {
+                .core
+            }
+        }
+        
+        do {
+            let types = try [E.self, F.self].prepareForRegistration()
+            XCTFail()
+        } catch {
+            // expected error
+        }
+    }
 }


### PR DESCRIPTION
### DRAFT

### Automatic registration sorting

``open class var classInitializationLevel: GDExtension.InitializationLevel`` added to `Wrapped`, `.scene` by default (to be source-compatible addition)

When using `#initSwiftExtension(cdecl:types:)` directly or via `EntryPointGeneratorPlugin` this property will be used to properly sort the classes into initialisation level buckets. (similar to how it's manually done in `#initSwiftExtension` overload taking each initialisation level explicitly), and ensuring that they are both: 
1. Topologically sorted.
2. Topological order is not contradicting to initialisation level. (parent class can not be registered at the level after child class).

### Eager registration
`_ type.classInitializer` is now invoked in the `register` phase instead of being invoked lazily during instantiation of corresponding type.


