### PR TITLE
Remove duplicated "Tutorials" in tutorials page title

### DIFF
--- a/Sources/SwiftGodot/SwiftGodot.docc/SwiftGodot Tutorials.tutorial
+++ b/Sources/SwiftGodot/SwiftGodot.docc/SwiftGodot Tutorials.tutorial
@@ -1,4 +1,4 @@
-@Tutorials(name: "SwiftGodot Tutorials") {
+@Tutorials(name: "SwiftGodot") {
     @Intro(title: "Meet SwiftGodot") {
         SwiftGodot allows developers to take new and existing Swift packages and use them as extensions for the Godot game engine.
         


### PR DESCRIPTION
DocC automatically adds "Tutorials" to the end of the provided `@Tutorials` page title.

Right now it is rendered this way:
<img width="700" alt="Screenshot 2025-05-06 alle 16 10 55" src="https://github.com/user-attachments/assets/e273a19c-fd8c-488d-b5df-5b1fc5629b92" />

By removing the "Tutorials" at the end of the given name, the final rendered title is "SwiftGodot Tutorials".

This should not change the URL addresses of the tutorial pages.