### PR TITLE
Make `initRef` unconditional

### DIFF
--- a/Generator/Generator/ClassGen.swift
+++ b/Generator/Generator/ClassGen.swift
@@ -606,9 +606,7 @@ func processClass (cdef: JGodotExtensionAPIClass, outputDir: String?) async {
             public override required init(_ context: InitContext) {
                 super.init(context)
             
-                if context.origin == .swift {
-                    _ = initRef()
-                }                
+                _ = initRef()             
             }
             """)
         }


### PR DESCRIPTION
This change fixes a [regression](https://github.com/migueldeicaza/SwiftGodot/issues/714) introduced by #700 due to a confusion of when `initRef` should be called in `Wrapped.init(nativePointer:)` and `Wrapped.init()` codepaths.