### PR TITLE
Remove unsafe flags save for debug

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -156,7 +156,7 @@ var targets: [Target] = [
         swiftSettings: [
             .swiftLanguageMode(.v5),
             .define("CUSTOM_BUILTIN_IMPLEMENTATIONS"),
-            .unsafeFlags(["-suppress-warnings"])
+            .unsafeFlags(["-suppress-warnings"], .when(configuration: .debug))
         ],
         plugins: ["CodeGeneratorPlugin", "SwiftGodotMacroLibrary"]
     ),


### PR DESCRIPTION
I get this error using SwiftGodot via CLI. Not sure if anyone else is seeing it but using unsafeFlags in non-debug is a FatalError. In the long term having no errors at all is great but I think there really a bunch of warnings. Will see what I can do in future PRs.