### PR TITLE
Changed the mac OS from 13 to 14 in the tutorial to make it work.

### DIFF
--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/Package-starter-3.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/Package-starter-3.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SimpleRunnerDriver",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/SwiftGodot/SwiftGodot.docc/Tutorials/Your First Extension.tutorial
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Tutorials/Your First Extension.tutorial
@@ -36,7 +36,7 @@
                       previousFile: "Package-starter-init.swift")
             }
             @Step {
-                Set the type of the SimpleRunnerDriver library to dynamic and set the minimum platform target to macOS 13.
+                Set the type of the SimpleRunnerDriver library to dynamic and set the minimum platform target to macOS 14.
                 
                 @Code(name: "Package.swift", file: "Package-starter-3.swift")
             }
@@ -203,7 +203,7 @@
         @Steps {
             @Step {
                 Open the SimpleRunner project in the Godot editor. When the project opens, you should see a dialog that
-                appears, asking to reloag Godot for extensions to take effect.
+                appears, asking to reload Godot for extensions to take effect.
                 
                 @Image(source: "GodotExtensionPrompt", alt: "The Godot editor open with a dialog in the center.")
             }


### PR DESCRIPTION
Looks like SwiftGodot the package is updated to macOS 14 but the tutorial still says macOS 13. This change updates the tutorial to match.

Also fixes a minor typo. 

Reference: https://github.com/migueldeicaza/SwiftGodot/blob/main/Package.swift


```
let package = Package(
    name: "SwiftGodot",
    platforms: [
        .macOS(.v14),
        .iOS (.v17)
    ],
    products: products,
    dependencies: [
        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.3.0"),
        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.1"),
    ],
    targets: targets
)
```