### PR TITLE
Update default usage flags for Variant property info

### DIFF
--- a/Sources/SwiftGodotRuntime/Variant.swift
+++ b/Sources/SwiftGodotRuntime/Variant.swift
@@ -488,7 +488,7 @@ public final class Variant: Hashable, Equatable, CustomDebugStringConvertible, _
             name: name,
             hint: hint,
             hintStr: hintStr,
-            usage: usage ?? .nilIsVariant
+            usage: usage ?? [.nilIsVariant, .default]
         )
     }
     

--- a/Tests/SwiftGodotTestExtension/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTestExtension/MacroIntegrationTests.swift
@@ -50,7 +50,7 @@ final class MacroIntegrationTests {
         XCTAssertEqual(_propInfo(at: \NoMacroExample.wow, name: "").propertyType, .nil)
         XCTAssertEqual(_propInfo(at: \NoMacroExample.optionalWow, name: "").propertyType, .nil)
         XCTAssertEqual(_propInfo(at: \NoMacroExample.variant, name: "").propertyType, .nil)
-        XCTAssertEqual(_propInfo(at: \NoMacroExample.variant, name: "").usage, .nilIsVariant)
+        XCTAssertEqual(_propInfo(at: \NoMacroExample.variant, name: "").usage, [.nilIsVariant, .default])
         XCTAssertEqual(_propInfo(at: \NoMacroExample.optionalVariant, name: "").propertyType, .nil)
         XCTAssertEqual(_propInfo(at: \NoMacroExample.garray, name: "").propertyType, .array)
         XCTAssertEqual(_propInfo(at: \NoMacroExample.object, name: "").propertyType, .object)


### PR DESCRIPTION
Changed the default usage for Variant property info to include both .nilIsVariant and .default flags. Updated the corresponding test in MacroIntegrationTests to reflect this change.

Fixes `@Export`-ed optional builtin types and `Variant` not visible in Editor and not being serialized with scene.