### PR TITLE
Various Tutorial Updates

### DIFF
--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-4.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-4.swift
@@ -18,6 +18,6 @@ class MainLevel: Node2D {
             GD.pushWarning("Player or spawnpoint is missing.")
             return
         }
-        
+
     }
 }

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-6.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/MainLevel-multiscript-6.swift
@@ -15,7 +15,7 @@ class MainLevel: Node2D {
 
     override func _ready() {
         teleportArea?.bodyEntered.connect { [self] enteredBody in
-            if enteredBody.isClass("\(PlayerController.self)") {
+            if enteredBody is PlayerController {
                 teleportPlayerToTop()
             }
         }

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/Package-starter-4.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/Package-starter-4.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SimpleRunnerDriver",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SimpleRunnerDriver-multiscript-2.swift
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Resources/Tutorials/Sources/SimpleRunnerDriver-multiscript-2.swift
@@ -3,6 +3,6 @@
 
 import SwiftGodot
 
-let allNodes: [Wrapped.Type] = [PlayerController.self, MainLevel.self]
+let allNodes: [Object.Type] = [PlayerController.self, MainLevel.self]
 
 #initSwiftExtension(cdecl: "swift_entry_point", types: allNodes)

--- a/Sources/SwiftGodot/SwiftGodot.docc/Tutorials/Your First Extension.tutorial
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Tutorials/Your First Extension.tutorial
@@ -118,8 +118,7 @@
                 @Code(name: "PlayerController.swift", file: "PlayerController-starter-7.swift")
             }
             @Step {
-                Finally, call `moveAndSlide` to move the player, sliding along any edges the player collides with, and
-                call the parent's `physicsProcess(delta:)` method.
+                Finally, call `moveAndSlide` to move the player, sliding along any edges the player collides with.
                 
                 @Code(name: "PlayerController.swift", file: "PlayerController-starter-8.swift")
             }


### PR DESCRIPTION
I did a runthrough of the [Your First Extension](https://migueldeicaza.github.io/SwiftGodotDocs/tutorials/swiftgodot/your-first-extension/) and [Writing Multiple Scripts](https://migueldeicaza.github.io/SwiftGodotDocs/tutorials/swiftgodot/writing-multiple-scripts/) tutorials. The documentation was updated recently, and thought I'd double-check that everything was in working order. I found a few bugs and typos, and am making this PR to address them. Let me know if any of the suggestions are unwelcome or unnecessary!

# File Changes

1. Update Subsequent `Package.swift` files in .v13 -> .v14 update
    - This was addressed in #732. The macOS version was updated from `.v13` to `.v14` in file 3, but remained as `.v13` in subsequent `Package.swift` files. I've updated `Package-starte-4.swift` accordingly.

2. Update Tutorial Step text to remove `physicsProcess reference`
    - This was addressed in #743 and #713. The code was updated, but the tutorial text still referenced the removed code. I updated `Your First Extension.tutorial` accordingly.

3. Minor edit - Whitespace removal
    - This was a small thing I noticed, but the tutorial highlighted a line as "new" when it was not because whitespace had been removed. I updated `MainLevel-multiscript-4.swift` to remove the highlight.

4. Optional `enteredBody` in teleportation function
    - In the Multiple Scripts tutorial, the `MainLevel.swift` code failed for me because the `enteredBody` variable in the teleportation function was optional, and needed to be unwrapped in some way. There were a couple of possible fixes. I opted to just check `if enteredBody is PlayerController`, though adding the line `guard let enteredBody else { return }` could have done the trick as well. Let me know if you'd prefer that alternative. This is in the `MainLevel-multiscript-6.swift` file.

5. Referencing `Object.swift` rather than `Wrapped.swift` in `#initSwiftExtension`
    - I changed the class types from `Wrapped` to `Object` in `SimpleRunnerDriver-multiscript-2.swift`. I was getting the following error when building, and this seemed to fix it. I am not sure, however, if this should be a long-term fix or not - reading through the code, I thought `Objects` all inherit from `Wrapped`, and thought I'd set up `PlayerController` and `MainLevel` appropriately, but something is amiss.

```bash
error: referencing instance method 'prepareForRegistration()' on 'Array' requires the types 'Wrapped.Type' and 'Object.Type' be equivalent
`- SimpleRunnerDriver/Sources/SimpleRunnerDriver/SimpleRunnerDriver.swift:8:65: note: expanded code originates here
6 | let allNodes: [Wrapped.Type] = [PlayerController.self, MainLevel.self]
7 | 
8 | #initSwiftExtension(cdecl: "swift_entry_point", types: allNodes)
  | `- note: in expansion of macro 'initSwiftExtension' here
   +--- macro expansion #initSwiftExtension ----------------------------
   | 7 |     let types: [ExtensionInitializationLevel: [Object.Type]]
   | 8 |     do {
   | 9 |         types = try allNodes.prepareForRegistration()
   |   |                              `- error: referencing instance method 'prepareForRegistration()' on 'Array' requires the types 'Wrapped.Type' and 'Object.Type' be equivalent
   |10 |     } catch {
   |11 |         GD.printErr("Error during GDExtension initialization: \(error)")
   +--------------------------------------------------------------------
9 | 
```

# Additional errors - Xcode and Godot

1. `Cannot find type` errors in Xcode
    - I don't recall this happening with the tutorial from earlier last year, but Xcode generates a plethora of `Cannot find type` errors in Xcode _specifically when remotely referencing SwiftGodot on GitHub, as used in the tutorial._ If I set it to a local instance of SwiftGodot, these errors do not appear. I'm having difficulty finding the root of the problem - I wondered if simply waiting for the project to be fully indexed would solve the problem naturally, but I haven't managed to get Xcode to recognize SwiftGodot code despite its presence. Ultimately, though, these errors are specific to Xcode - even with them present, you can build the package and use them in Godot just fine. Let me know if you have any suggestions for resolving this, if other new users see these errors it can take a minute to realize nothing is actually wrong. 

```swift
    dependencies: [
//        .package(url: "https://github.com/migueldeicaza/SwiftGodot", branch: "main") // Code results in errors
        .package(path: "../SwiftGodot") //No errors appear
    ],
```
<img width="927" height="610" alt="Screenshot 2026-01-05 at 10 13 46 AM" src="https://github.com/user-attachments/assets/23e67b8e-d91b-4c45-9b15-90571a640331" />

2. Node Configuration Warning - `TileMap` node is deprecated in Godot as of 4.3
    - This is more of a heads up, but the `TileMap` node used in the sample Godot project has been deprecated. It still works fine for the time being, and it provides instructions for solving the issue, but it may be good to update the provided example file to use individual `TileMapLayer` nodes rather than `TileMap`.