### PR TITLE
change names of variables in tests to '_' to remove warning errors

### DIFF
--- a/Tests/SwiftGodotTestExtension/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTestExtension/MemoryLeakTests.swift
@@ -61,7 +61,7 @@ class GodotEncoder: Encoder {
     }
 
     func encode(key codingKey: [CodingKey], value: Variant) {
-        let key = codingKey.map { $0.stringValue }.joined(separator: ".")
+        let _ = codingKey.map { $0.stringValue }.joined(separator: ".") //rename '_' to 'key' when using commented-out code below
         fatalError()
         //dict [key] = value
 //        _ = key
@@ -81,7 +81,7 @@ class GodotEncoder: Encoder {
 
     class GodotKeyedContainer<Key:CodingKey>: KeyedEncodingContainerProtocol, GodotEncodingContainer {
         func encodeNil(forKey key: Key) throws {
-            let container = self.nestedSingleValueContainer(forKey: key)
+            let _ = self.nestedSingleValueContainer(forKey: key) //rename '_' to 'container' when using commented-out code below
             fatalError()
             //try container.encode(Variant())
 //            _ = container
@@ -434,7 +434,7 @@ final class MemoryLeakTests {
     @SwiftGodotTest
     public func testRefCountedLeak() {
         func oneIteration() {
-            let image0 = SwiftGodot.RefCounted()
+            let _ = SwiftGodot.RefCounted()
         }
 
         // Warm-up the code path in case it performs any one-time permanent allocations.


### PR DESCRIPTION
When building SwiftGodot, Swift advises changing the names of several variables in the `MemoryLeakTests.swift` tests to `_`, as they are unused. It appears that a few of them had commented-out code in their vicinity that would require those variables to be named, but are not used at this time. In case that commented-out code is useful in the future, line comments were included to advise changing the name back in such instances.

There remain deprecation warning errors in `Tests/SwiftGodotTestExtension/SignalTests.swift`  tests, advising the user to use the `@Signal` macro instead. It wasn't clear to me if these tests were designed to specifically ensure the old code is still working, or if the tests should be updated to reflect the macro usage.