### PR TITLE
Add WASM compilation support

### DIFF
--- a/Generator/Generator/Enums.swift
+++ b/Generator/Generator/Enums.swift
@@ -67,8 +67,8 @@ func generateEnums (_ p: Printer, cdef: JClassInfo?, values: [JGodotGlobalEnumEl
             let optionTypeName = getGodotType (SimpleType (type: enumDef.name))
             var optionNames: [String] = []
             p ("public struct \(optionTypeName): OptionSet, CustomDebugStringConvertible") {
-                p ("public let rawValue: Int")
-                p ("public init (rawValue: Int)") {
+                p ("public let rawValue: Int64")
+                p ("public init (rawValue: Int64)") {
                     p ("self.rawValue = rawValue")
                 }
                 for enumVal in enumDef.values {

--- a/Generator/Generator/Printer.swift
+++ b/Generator/Generator/Printer.swift
@@ -47,6 +47,8 @@ class Printer {
         import Glibc
         #elseif canImport(Musl)
         import Musl
+        #elseif canImport(WASILibc)
+        import WASILibc
         #else
         #error("Unable to identify your C library.")
         #endif

--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -879,7 +879,7 @@ func validatePropertyFunc(ptr: UnsafeMutableRawPointer?, _info: UnsafeMutablePoi
     let className = StringName(fromPtr: classNamePtr)
     let hint = PropertyHint(rawValue: Int64(info.hint)) ?? .none
     let hintStr = GString(content: infoHintPtr.load(as: Int64.self))
-    let usage = PropertyUsageFlags(rawValue: Int(info.usage))
+    let usage = PropertyUsageFlags(rawValue: Int64(info.usage))
 
     var pinfo = PropInfo(propertyType: ptype, propertyName: pname, className: className, hint: hint, hintStr: hintStr, usage: usage)
     if instance._validateProperty(&pinfo) {

--- a/Sources/SwiftGodotRuntime/FastVariant.swift
+++ b/Sources/SwiftGodotRuntime/FastVariant.swift
@@ -277,7 +277,7 @@ public struct FastVariant: ~Copyable {
     /// String description of this ``FastVariant``
     public var description: String {
         var content = content
-        var ret = GDExtensionStringPtr(bitPattern: 0xdeaddead)
+        var ret = GDExtensionStringPtr(bitPattern: 0)
         gi.variant_stringify(&content, &ret)
         
         let str = stringFromGodotString(&ret)

--- a/Sources/SwiftGodotRuntime/Variant.swift
+++ b/Sources/SwiftGodotRuntime/Variant.swift
@@ -260,7 +260,7 @@ public final class Variant: Hashable, Equatable, CustomDebugStringConvertible, _
     }
     
     public var description: String {
-        var ret = GDExtensionStringPtr (bitPattern: 0xdeaddead)
+        var ret = GDExtensionStringPtr (bitPattern: 0)
         gi.variant_stringify (&content, &ret)
         
         let str = stringFromGodotString(&ret)


### PR DESCRIPTION
This PR enables SwiftGodot to compile for WebAssembly target (wasm32-unknown-wasip1)

## Changes

1. **Add WASILibc import** - C library detection for WASI platform
2. **Fix OptionSet rawValue type** - `Int` → `Int64` to prevent overflow on 32-bit WASM
3. **Fix debug sentinel values** - `0xdeaddead` → `0` (overflows 32-bit Int)
4. **Fix PropertyUsageFlags init** - Match Int64 rawValue type

## Why

WASM32 has 32-bit `Int`, causing overflow when:
- Large enum flag values are used in OptionSet
- Debug sentinel `0xdeaddead` (3,735,936,685) is assigned to pointer

## Notes

- These changes don't affect existing platforms (macOS, iOS, Linux, Windows)
- Full runtime support requires toolchain-level work (Swift WASM SDK uses WASI ABI, Godot uses Emscripten ABI) - #447 for details

<details>
<summary><b>How to build SwiftGodot for WASM</b></summary>

### Setup

```bash
# Swift 6.2.3 via swiftly
curl -sL https://swiftlang.github.io/swiftly/swiftly-install.sh | bash
swiftly install 6.2.3
swift sdk install swift-6.2.3-RELEASE_wasm

# Emscripten 3.1.74 (Godot's version)
git clone https://github.com/emscripten-core/emsdk.git ~/emsdk
cd ~/emsdk && ./emsdk install 3.1.74 && ./emsdk activate 3.1.74
```

### Build

```bash
# Compile Swift to WASM
swift build --swift-sdk swift-6.2.3-RELEASE_wasm --target SwiftGodot

# Link with Emscripten as side module (adds dylink.0 section)
emcc -sSIDE_MODULE=2 -sEXPORTED_FUNCTIONS=_swift_entry_point \
    -sALLOW_MEMORY_GROWTH=1 -sERROR_ON_UNDEFINED_SYMBOLS=0 -O2 \
    .build/wasm32-unknown-wasip1/debug/*.build/*.o \
    ~/Library/org.swift.swiftpm/swift-sdks/swift-6.2.3-RELEASE_wasm.artifactbundle/swift-6.2.3-RELEASE_wasm/wasm32-unknown-wasip1/swift.xctoolchain/usr/lib/swift_static/wasi/libswiftCore.a \
    -o SwiftLogic.wasm
```

This produces a WASM binary with `dylink.0` section and `swift_entry_point` exported.

### Current limitation

The binary compiles but doesn't run in Godot's web export due to ABI mismatch between Swift WASM SDK (WASI) and Emscripten.

</details>