### PR TITLE
Generator yml fix

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -49,6 +49,7 @@ jobs:
         filters: |
           generator:
             - 'Generator/**'
+            - '.github/workflows/generator.yml'
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:


### PR DESCRIPTION
The diff-generator workflow depends on older macos/xcode versions, and breaking as a result. This PR bumps the versions up to fix those breaks. 

I also set the workflow to trigger automatically when the `generator.yml` file changes so that the workflow is checked for future version bumps or similar maintenance efforts.