### PR TITLE
Prevent Godot API calls during shutdown cleanup

### DIFF
--- a/Sources/SwiftGodotRuntime/EntryPoint.swift
+++ b/Sources/SwiftGodotRuntime/EntryPoint.swift
@@ -137,11 +137,14 @@ func extension_initialize(userData: UnsafeMutableRawPointer?, l: GDExtensionInit
 
 // Extension deinitialization callback
 func extension_deinitialize(userData: UnsafeMutableRawPointer?, l: GDExtensionInitializationLevel) {
-    //print ("SWIFT: extension_deinitialize")
     guard let userData else { return }
     let key = OpaquePointer(userData)
     guard let callback = extensionDeInitCallbacks[key] else { return }
     guard let level = ExtensionInitializationLevel(rawValue: Int64(exactly: l.rawValue)!) else { return }
+
+    // Set shutdown flag to avoid calling callDeferred() during cleanup
+    prepareForShutdown()
+
     callback(level)
     if level == .core {
         // Last one, remove

--- a/Tests/SwiftGodotTestExtension/TestRunnerNode.swift
+++ b/Tests/SwiftGodotTestExtension/TestRunnerNode.swift
@@ -95,9 +95,6 @@ public class TestRunnerNode: Node {
         GD.print("=".repeated(60))
 
         let exitCode = results.summary.failed > 0 ? 1 : 0
-        // Prepare for shutdown to prevent crashes from Swift objects trying to call Godot API
-        // for deferred objects cleanup
-        prepareForShutdown()
         getTree()?.quit(exitCode: Int32(exitCode))
     }
 


### PR DESCRIPTION
Workaround Godot crash with code 6 during shut down