### PR TITLE
Fix RefCounted leak: unreference Ref<> extra ref on new wrapper creation

### DIFF
--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -740,7 +740,7 @@ public func getOrInitSwiftObject<T: Object>(nativeHandle: GodotNativeObjectPoint
     }
     if let userType = userTypes[className] {
         let created = userType.init(InitContext(handle: nativeHandle, origin: .godot))
-        handleRef(staticType: T.self, object: created, ownsRef: ownsRef, unref: false)
+        handleRef(staticType: T.self, object: created, ownsRef: ownsRef, unref: ownsRef)
         if let result = created as? T {
             return result
         } else {
@@ -749,7 +749,7 @@ public func getOrInitSwiftObject<T: Object>(nativeHandle: GodotNativeObjectPoint
     }
     if let ctor = lookupGodotType(named: className) as? T.Type {
         let result = ctor.init(InitContext(handle: nativeHandle, origin: .godot))
-        handleRef(staticType: T.self, object: result, ownsRef: ownsRef, unref: false)
+        handleRef(staticType: T.self, object: result, ownsRef: ownsRef, unref: ownsRef)
         return result
     }
 
@@ -764,7 +764,7 @@ public func getOrInitSwiftObject<T: Object>(nativeHandle: GodotNativeObjectPoint
     // This comment here for future generations that end up in this line
     // the real error is likely a registration issue.
     let result = T(InitContext(handle: nativeHandle, origin: .godot))
-    handleRef(staticType: T.self, object: result, ownsRef: ownsRef, unref: false)
+    handleRef(staticType: T.self, object: result, ownsRef: ownsRef, unref: ownsRef)
     return result
 }
 


### PR DESCRIPTION
## Problem

When Godot methods return RefCounted objects via C++ `Ref<>` (519 methods including e.g. `StandardMaterial3D.duplicate()`, `Image.create()`, `ResourceLoader.load()`, property getters), the `Ref<>` wrapper adds an extra `reference()` call. For **existing** Swift wrappers, `handleRef` correctly drops this extra ref (`unref: true`). For **newly created** wrappers, `handleRef` was called with `unref: false`, leaving the refCount inflated by 1.

This caused `bindSwiftObject()` to create a STRONG `WrappedReference` (because `refCount > 1`). During shutdown, when Godot releases its reference, the reference callback's `weakify()` condition (`rc == 1`) was never met because the refCount was always 1 higher than expected. The wrapper stayed STRONG forever, leaking the Godot object and its resources.

## The Fix

```diff
// Wrapped.swift — getOrInitSwiftObject(), 3 new-wrapper paths:
- handleRef(staticType: T.self, object: created, ownsRef: ownsRef, unref: false)
+ handleRef(staticType: T.self, object: created, ownsRef: ownsRef, unref: ownsRef)
```

When `ownsRef: true` (returned via `Ref<>`), `handleRef` now calls `unreference()` to normalize the refCount — matching the existing-wrapper path's behavior. When `ownsRef: false`, behavior is unchanged.

Fixes #778