### PR TITLE
Swift 6.3 compatibility: fix ambiguous operator overloads and bump to…

### DIFF
--- a/Generator/Generator/BuiltinGen.swift
+++ b/Generator/Generator/BuiltinGen.swift
@@ -384,7 +384,12 @@ func generateBuiltinOperators (_ p: Printer,
             if let desc = op.description, desc != "" {
                 doc (p, bc, desc)
             }
-            
+
+            let disfavored = right == "float" && operators.contains(where: { $0.name == op.name && $0.rightType == "int" })
+            if disfavored {
+                p ("@_disfavoredOverload")
+            }
+
             p ("public static func \(swiftOperator)(lhs: \(lhsTypeName), rhs: \(rhsTypeName)) -> \(retType) "){
                 if customImplementation != nil {
                     p("#if !CUSTOM_BUILTIN_IMPLEMENTATIONS")

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.3
 
 import CompilerPluginSupport
 import PackageDescription

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArrayIntGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArrayIntGodotMacro.swift
@@ -24,10 +24,13 @@ class SomeNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: SomeNode.self) else {
+            return
+        }
         let className = StringName("SomeNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -47,5 +50,5 @@ class SomeNode: Node {
             getterFunction: SomeNode._mproxy_get_someNumbers,
             setterFunction: SomeNode._mproxy_set_someNumbers
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArraysIntGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArraysIntGodotMacro.swift
@@ -46,10 +46,13 @@ class SomeNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: SomeNode.self) else {
+            return
+        }
         let className = StringName("SomeNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -83,5 +86,5 @@ class SomeNode: Node {
             getterFunction: SomeNode._mproxy_get_someOtherNumbers,
             setterFunction: SomeNode._mproxy_set_someOtherNumbers
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGenericArrayStringGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGenericArrayStringGodotMacro.swift
@@ -24,10 +24,13 @@ class SomeNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: SomeNode.self) else {
+            return
+        }
         let className = StringName("SomeNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -47,5 +50,5 @@ class SomeNode: Node {
             getterFunction: SomeNode._mproxy_get_greetings,
             setterFunction: SomeNode._mproxy_set_greetings
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportVariantArray.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportVariantArray.swift
@@ -24,10 +24,13 @@ class SomeNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: SomeNode.self) else {
+            return
+        }
         let className = StringName("SomeNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -47,5 +50,5 @@ class SomeNode: Node {
             getterFunction: SomeNode._mproxy_get_someArray,
             setterFunction: SomeNode._mproxy_set_someArray
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTwoStringArrays.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTwoStringArrays.swift
@@ -47,10 +47,13 @@ class ArrayTest: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: ArrayTest.self) else {
+            return
+        }
         let className = StringName("ArrayTest")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ class ArrayTest: Node {
             getterFunction: ArrayTest._mproxy_get_lastNames,
             setterFunction: ArrayTest._mproxy_set_lastNames
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTypedArray.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTypedArray.swift
@@ -24,10 +24,13 @@ class SomeNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: SomeNode.self) else {
+            return
+        }
         let className = StringName("SomeNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -47,5 +50,5 @@ class SomeNode: Node {
             getterFunction: SomeNode._mproxy_get_greetings,
             setterFunction: SomeNode._mproxy_set_greetings
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportEnumTests.testExportEnumGodot.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportEnumTests.testExportEnumGodot.swift
@@ -52,10 +52,13 @@ class SomeNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: SomeNode.self) else {
+            return
+        }
         let className = StringName("SomeNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -89,5 +92,5 @@ class SomeNode: Node {
             getterFunction: SomeNode._mproxy_get_demo64,
             setterFunction: SomeNode._mproxy_set_demo64
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
@@ -46,10 +46,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ class Car: Node {
             getterFunction: Car._mproxy_get_year,
             setterFunction: Car._mproxy_set_year
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesTypedArrayPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesTypedArrayPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
@@ -46,10 +46,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ class Car: Node {
             getterFunction: Car._mproxy_get_years,
             setterFunction: Car._mproxy_set_years
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenMixingTypedArrayTypedArrayAndNormalVariableProperties.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenMixingTypedArrayTypedArrayAndNormalVariableProperties.swift
@@ -178,10 +178,13 @@ class Garage: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Garage.self) else {
+            return
+        }
         let className = StringName("Garage")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -302,5 +305,5 @@ class Garage: Node {
             getterFunction: Garage._mproxy_get_insuranceProvidersAccepted,
             setterFunction: Garage._mproxy_set_insuranceProvidersAccepted
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
@@ -90,10 +90,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -157,6 +160,6 @@ class Car: Node {
             getterFunction: Car._mproxy_get_model,
             setterFunction: Car._mproxy_set_model
         )
-    }()
+    }
     
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -46,10 +46,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ class Car: Node {
             getterFunction: Car._mproxy_get_model,
             setterFunction: Car._mproxy_set_model
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -46,10 +46,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ class Car: Node {
             setterFunction: Car._mproxy_set_year
         )
         SwiftGodotRuntime._addPropertyGroup(className: className, name: "Pointless", prefix: "")
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
@@ -90,10 +90,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -157,6 +160,6 @@ class Car: Node {
             getterFunction: Car._mproxy_get_models,
             setterFunction: Car._mproxy_set_models
         )
-    }()
+    }
     
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -46,10 +46,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ class Car: Node {
             getterFunction: Car._mproxy_get_years,
             setterFunction: Car._mproxy_set_years
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -46,10 +46,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ class Car: Node {
             setterFunction: Car._mproxy_set_years
         )
         SwiftGodotRuntime._addPropertyGroup(className: className, name: "Pointless", prefix: "")
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefix.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefix.swift
@@ -46,10 +46,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ class Car: Node {
             getterFunction: Car._mproxy_get_vehicle_model,
             setterFunction: Car._mproxy_set_vehicle_model
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingCollectionExports.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingCollectionExports.swift
@@ -24,10 +24,13 @@ class Garage: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Garage.self) else {
+            return
+        }
         let className = StringName("Garage")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -48,5 +51,5 @@ class Garage: Node {
             getterFunction: Garage._mproxy_get_bar,
             setterFunction: Garage._mproxy_set_bar
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingExports.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingExports.swift
@@ -24,10 +24,13 @@ class Garage: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Garage.self) else {
+            return
+        }
         let className = StringName("Garage")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -48,5 +51,5 @@ class Garage: Node {
             getterFunction: Garage._mproxy_get_bar,
             setterFunction: Garage._mproxy_set_bar
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingCollectionExport.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingCollectionExport.swift
@@ -46,10 +46,13 @@ public class Issue353: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Issue353.self) else {
+            return
+        }
         let className = StringName("Issue353")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ public class Issue353: Node {
             getterFunction: Issue353._mproxy_get_non_prefixed_bool,
             setterFunction: Issue353._mproxy_set_non_prefixed_bool
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingExport.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingExport.swift
@@ -46,10 +46,13 @@ public class Issue353: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Issue353.self) else {
+            return
+        }
         let className = StringName("Issue353")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -84,5 +87,5 @@ public class Issue353: Node {
             getterFunction: Issue353._mproxy_get_non_prefixed_bool,
             setterFunction: Issue353._mproxy_set_non_prefixed_bool
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportSubroupTests.testGodotExportSubgroupWithAndWithoutPrefixWithGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportSubroupTests.testGodotExportSubgroupWithAndWithoutPrefixWithGroup.swift
@@ -112,10 +112,13 @@ class Car: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Car.self) else {
+            return
+        }
         let className = StringName("Car")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -194,5 +197,5 @@ class Car: Node {
             getterFunction: Car._mproxy_get_ymms_series,
             setterFunction: Car._mproxy_set_ymms_series
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableAutoSnakeCase.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableAutoSnakeCase.swift
@@ -86,10 +86,13 @@ class TestClass: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: TestClass.self) else {
+            return
+        }
         let className = StringName("TestClass")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -167,5 +170,5 @@ class TestClass: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableReturningOptionalObject.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableReturningOptionalObject.swift
@@ -2,16 +2,19 @@ class MyThing: SwiftGodot.RefCounted {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MyThing.self) else {
+            return
+        }
         let className = StringName("MyThing")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-    }()
+    }
 
 }
 
@@ -42,10 +45,13 @@ class OtherThing: SwiftGodot.Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: OtherThing.self) else {
+            return
+        }
         let className = StringName("OtherThing")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -69,5 +75,5 @@ class OtherThing: SwiftGodot.Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableTakingOptionalBuiltin.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableTakingOptionalBuiltin.swift
@@ -2,16 +2,19 @@ class MyThing: SwiftGodot.RefCounted {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MyThing.self) else {
+            return
+        }
         let className = StringName("MyThing")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-    }()
+    }
 
 }
 
@@ -110,10 +113,13 @@ class OtherThing: SwiftGodot.Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: OtherThing.self) else {
+            return
+        }
         let className = StringName("OtherThing")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -173,5 +179,5 @@ class OtherThing: SwiftGodot.Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testDebugThing.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testDebugThing.swift
@@ -42,10 +42,13 @@ class DebugThing: SwiftGodot.Object {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: DebugThing.self) else {
+            return
+        }
         let className = StringName("DebugThing")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -70,5 +73,5 @@ class DebugThing: SwiftGodot.Object {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotMacro.swift
@@ -24,10 +24,13 @@ class Hi: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Hi.self) else {
+            return
+        }
         let className = StringName("Hi")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -47,5 +50,5 @@ class Hi: Node {
             getterFunction: Hi._mproxy_get_goodName,
             setterFunction: Hi._mproxy_set_goodName
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotUsage.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotUsage.swift
@@ -24,10 +24,13 @@ class Hi: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Hi.self) else {
+            return
+        }
         let className = StringName("Hi")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -47,5 +50,5 @@ class Hi: Node {
             getterFunction: Hi._mproxy_get_goodName,
             setterFunction: Hi._mproxy_set_goodName
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportedInt64.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportedInt64.swift
@@ -46,10 +46,13 @@ class Thing: SwiftGodot.Object {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Thing.self) else {
+            return
+        }
         let className = StringName("Thing")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -87,5 +90,5 @@ class Thing: SwiftGodot.Object {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacro.swift
@@ -2,14 +2,17 @@ class Hi: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Hi.self) else {
+            return
+        }
         let className = StringName("Hi")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroStaticSignal.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroStaticSignal.swift
@@ -6,10 +6,13 @@ class Hi: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Hi.self) else {
+            return
+        }
         let className = StringName("Hi")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -35,5 +38,5 @@ class Hi: Node {
             in: className,
             arguments: Hi.differentInit2.arguments
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncHavingVariantsInSignature.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncHavingVariantsInSignature.swift
@@ -37,10 +37,13 @@ private class TestNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: TestNode.self) else {
+            return
+        }
         let className = StringName("TestNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -64,5 +67,5 @@ private class TestNode: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithObjectParams.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithObjectParams.swift
@@ -190,10 +190,13 @@ class Castro: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Castro.self) else {
+            return
+        }
         let className = StringName("Castro")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -308,5 +311,5 @@ class Castro: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithValueParams.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithValueParams.swift
@@ -107,10 +107,13 @@ class MathHelper: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MathHelper.self) else {
+            return
+        }
         let className = StringName("MathHelper")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -173,5 +176,5 @@ class MathHelper: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithArrayParam.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithArrayParam.swift
@@ -37,10 +37,13 @@ class MultiplierNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MultiplierNode.self) else {
+            return
+        }
         let className = StringName("MultiplierNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -64,5 +67,5 @@ class MultiplierNode: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithArrayReturnTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithArrayReturnTypes.swift
@@ -48,10 +48,13 @@ class CallableCollectionsNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: CallableCollectionsNode.self) else {
+            return
+        }
         let className = StringName("CallableCollectionsNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -93,5 +96,5 @@ class CallableCollectionsNode: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithGenericArrayParam.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithGenericArrayParam.swift
@@ -37,10 +37,13 @@ class MultiplierNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MultiplierNode.self) else {
+            return
+        }
         let className = StringName("MultiplierNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -64,5 +67,5 @@ class MultiplierNode: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithGenericArrayReturnTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithGenericArrayReturnTypes.swift
@@ -48,10 +48,13 @@ class CallableCollectionsNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: CallableCollectionsNode.self) else {
+            return
+        }
         let className = StringName("CallableCollectionsNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -93,5 +96,5 @@ class CallableCollectionsNode: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayParam.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayParam.swift
@@ -37,10 +37,13 @@ class SomeNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: SomeNode.self) else {
+            return
+        }
         let className = StringName("SomeNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -64,5 +67,5 @@ class SomeNode: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayReturnType.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayReturnType.swift
@@ -26,10 +26,13 @@ class SomeNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: SomeNode.self) else {
+            return
+        }
         let className = StringName("SomeNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -53,5 +56,5 @@ class SomeNode: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithFinalClass.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithFinalClass.swift
@@ -3,16 +3,19 @@ final class Hi: Node {
 
     override public class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Hi.self) else {
+            return
+        }
         let className = StringName("Hi")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-    }()
+    }
 
     override public class func implementedOverrides () -> [StringName] {
         guard !Engine.isEditorHint () else {

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithNonCallableFunc.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithNonCallableFunc.swift
@@ -4,14 +4,17 @@ class Hi: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Hi.self) else {
+            return
+        }
         let className = StringName("Hi")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotVirtualMethodsMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotVirtualMethodsMacro.swift
@@ -3,16 +3,19 @@ class Hi: Control {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Hi.self) else {
+            return
+        }
         let className = StringName("Hi")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-    }()
+    }
 
     override open class func implementedOverrides () -> [StringName] {
         return super.implementedOverrides () + [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testMultipleSignalBindings.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testMultipleSignalBindings.swift
@@ -3,10 +3,13 @@ class OtherThing: SwiftGodot.Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: OtherThing.self) else {
+            return
+        }
         let className = StringName("OtherThing")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -14,5 +17,5 @@ class OtherThing: SwiftGodot.Node {
         }
         SimpleSignal.register(as: "signal0", in: className, names: [])
         SimpleSignal.register(as: "signal1", in: className, names: [])
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNewSignalMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNewSignalMacro.swift
@@ -13,10 +13,13 @@ class Demo: Node3D {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Demo.self) else {
+            return
+        }
         let className = StringName("Demo")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -24,5 +27,5 @@ class Demo: Node3D {
         }
         SimpleSignal.register(as: "burp", in: className, names: [])
         SignalWithArguments<Int>.register(as: "lives_changed", in: className, names: [])
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNoTypeAnnotationTrivia.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNoTypeAnnotationTrivia.swift
@@ -47,10 +47,13 @@ class TestClass: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: TestClass.self) else {
+            return
+        }
         let className = StringName("TestClass")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -75,5 +78,5 @@ class TestClass: Node {
             }
 
         )
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testRpcMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testRpcMacro.swift
@@ -85,10 +85,13 @@ class MultiplayerNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MultiplayerNode.self) else {
+            return
+        }
         let className = StringName("MultiplayerNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -148,7 +151,7 @@ class MultiplayerNode: Node {
             }
 
         )
-    }()
+    }
 
     /// Called automatically before `_ready()`. Configures RPC for methods marked with `@Rpc`.
     override open func _before_ready() {

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testRpcMacroNotOnFunction.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testRpcMacroNotOnFunction.swift
@@ -3,14 +3,17 @@ class MultiplayerNode: Node {
 
     override open class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MultiplayerNode.self) else {
+            return
+        }
         let className = StringName("MultiplayerNode")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-    }()
+    }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testWarningAvoidance.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testWarningAvoidance.swift
@@ -2,16 +2,19 @@ final class MyData: Resource {
 
     override public class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MyData.self) else {
+            return
+        }
         let className = StringName("MyData")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-    }()
+    }
 }
 final class MyClass: Node {
     var data: MyData = .init()
@@ -39,10 +42,13 @@ final class MyClass: Node {
 
     override public class var classInitializer: Void {
         let _ = super.classInitializer
-        return _initializeClass
+        return _initializeClass()
     }
 
-    private static let _initializeClass: Void = {
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: MyClass.self) else {
+            return
+        }
         let className = StringName("MyClass")
         if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
             // ClassDB singleton is not available prior to `.scene` level
@@ -62,5 +68,5 @@ final class MyClass: Node {
             getterFunction: MyClass._mproxy_get_data,
             setterFunction: MyClass._mproxy_set_data
         )
-    }()
+    }
 }


### PR DESCRIPTION
…ols version

It seems 6.3 has become stricter about literal type conversion.
From: https://developer.apple.com/documentation/swift/expressiblebyintegerliteral

> The standard library integer and floating-point types, such as Int and Double, conform to the ExpressibleByIntegerLiteral protocol. You can initialize a variable or constant of any of these types by assigning an integer literal.

Adds @_disfavoredOverload to generated Double-parameter operator overloads when an Int-parameter overload also exists for the same operator. This resolves "ambiguous use of operator" errors in Swift 6.3 where numeric literals could match either overload. Also bump swift-tools-version to 6.3.

The alternative here is to force consumers to be explicit about the literal type however this would be a breaking change.

Also bump swift-tools-version to 6.3 and regenerate macro test expected outputs to match Swift 6.3 formatting.