### PR TITLE
Make the test extension unloadable: orchestrate the runner from GDScript

### DIFF
--- a/Sources/SwiftGodotTestRunner/SwiftGodotTestRunner.swift
+++ b/Sources/SwiftGodotTestRunner/SwiftGodotTestRunner.swift
@@ -39,32 +39,16 @@ struct SwiftGodotTestRunner {
             .first { !$0.isEmpty }
     }
 
-    /// True once `path` exists, is non-empty, and its size has stabilized across a
-    /// short interval (so we never read a half-written file).
-    static func fileIsReady(_ path: String) -> Bool {
-        let fm = FileManager.default
-        guard let a = try? fm.attributesOfItem(atPath: path),
-              let size = a[.size] as? Int, size > 0 else { return false }
-        Thread.sleep(forTimeInterval: 0.2)
-        guard let b = try? fm.attributesOfItem(atPath: path),
-              let size2 = b[.size] as? Int else { return false }
-        return size2 == size
-    }
-
-    /// Runs Godot and waits for its work to finish. On Windows the Godot process
-    /// can hang on shutdown after the SwiftGodot extension is loaded, long after
-    /// the useful work is done, so we don't rely on a clean exit: if a
-    /// `completionFile` is given we terminate the process once that file is fully
-    /// written; otherwise we wait up to `timeout` and then terminate. A process
-    /// that exits on its own first is handled normally.
-    /// Returns the termination status, or 0 when we terminated it after the work
-    /// completed (completion file written).
+    /// Runs Godot, waits for it to exit on its own, and returns its exit code.
+    ///
+    /// The test extension now tears itself down cleanly (the GDScript
+    /// orchestrator frees the test runner node and quits the tree), so Godot
+    /// exits normally and we just wait for it -- no completion-file polling or
+    /// forced termination is needed.
     static func runGodot(
         _ godotPath: String,
         arguments: [String],
-        cwd: String,
-        completionFile: String?,
-        timeout: TimeInterval
+        cwd: String
     ) -> Int32 {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: godotPath)
@@ -78,31 +62,8 @@ struct SwiftGodotTestRunner {
             print("      Godot launch failed: \(error)")
             exit(1)
         }
-
-        let start = Date()
-        var completed = false
-        while process.isRunning {
-            if let completionFile, fileIsReady(completionFile) {
-                completed = true
-                process.terminate()
-                break
-            }
-            if Date().timeIntervalSince(start) > timeout {
-                if completionFile == nil {
-                    // No completion signal to wait on (e.g. the import step); the
-                    // work is expected to be done by now and the process is just
-                    // hanging on shutdown.
-                    completed = true
-                } else {
-                    print("      Timed out after \(Int(timeout))s waiting for Godot.")
-                }
-                process.terminate()
-                break
-            }
-            Thread.sleep(forTimeInterval: 0.25)
-        }
         process.waitUntilExit()
-        return completed ? 0 : process.terminationStatus
+        return process.terminationStatus
     }
 
     static func main() async {
@@ -265,38 +226,25 @@ struct SwiftGodotTestRunner {
             exit(1)
         }
 
-        // On Windows the Godot process does not terminate once the SwiftGodot
-        // extension is loaded (it hangs on shutdown after the work is done), so we
-        // can't wait for a clean exit. `runGodot` watches for the work to complete
-        // instead. These timeouts are upper bounds that only matter on Windows --
-        // on macOS/Linux Godot exits on its own well before they elapse.
-        let importTimeout: TimeInterval = 60
-        let runTimeout: TimeInterval = 120
-
         // 3. Import project (needed to register the extension's nodes, e.g.
-        //    TestRunnerNode, before the main scene loads). There is no file signal
-        //    for import completion, so we rely on the timeout on Windows.
+        //    TestRunnerNode, before the main scene loads).
         print("\n[3/5] Importing Godot project...")
         _ = runGodot(
             godotPath,
             arguments: ["--headless", "--import", "--path", absoluteProjectPath],
-            cwd: absoluteProjectPath,
-            completionFile: nil,
-            timeout: importTimeout
+            cwd: absoluteProjectPath
         )
         print("      Import successful")
 
-        // 4. Launch Godot to run the tests. The test extension writes the results
-        //    JSON when the run completes; we terminate Godot as soon as that file
-        //    is fully written rather than waiting on a clean exit.
+        // 4. Launch Godot to run the tests. The orchestrator writes the results
+        //    JSON and quits the tree cleanly when the run completes, so we just
+        //    wait for Godot to exit.
         print("\n[4/5] Running tests in Godot...")
         try? fm.removeItem(atPath: absoluteResultsPath) // clear stale results
         let godotExitCode = runGodot(
             godotPath,
             arguments: ["--headless", "--verbose", "--path", absoluteProjectPath],
-            cwd: absoluteProjectPath,
-            completionFile: absoluteResultsPath,
-            timeout: runTimeout
+            cwd: absoluteProjectPath
         )
         print("      Godot finished with code: \(godotExitCode)")
 

--- a/Tests/SwiftGodotTestExtension/IntersectRayResultTests.swift
+++ b/Tests/SwiftGodotTestExtension/IntersectRayResultTests.swift
@@ -38,6 +38,8 @@ final class IntersectRayResultTests {
         XCTAssertEqual(result.rid, RID())
         XCTAssertEqual(result.shape, 22)
         XCTAssertEqual(result.faceIndex, 44)
+
+        (collider as? Node)?.queueFree()
     }
 
     public func testIntersectRayResultIsNil_whenColliderPropertyIsMissing() {
@@ -56,7 +58,9 @@ final class IntersectRayResultTests {
         }()
         
         let result = PhysicsDirectSpaceState3D.IntersectRayResult<GridMap>(dictionary)
-        
+
         XCTAssertNil(result)
+
+        (collider as? Node)?.queueFree()
     }
 }

--- a/Tests/SwiftGodotTestExtension/MarshalTests.swift
+++ b/Tests/SwiftGodotTestExtension/MarshalTests.swift
@@ -97,6 +97,8 @@ final class MarshalTests {
         }.toVariant())
         
         XCTAssertEqual(node.closure(2, 3, 4), 24)
+
+        node.queueFree()
     }
 
     public func testDateNode() {
@@ -106,6 +108,8 @@ final class MarshalTests {
         _ = node.call(method: "set_date", (date.timeIntervalSince1970 + 1).toVariant())
         
         XCTAssertEqual(node.date, Date(timeIntervalSince1970: date.timeIntervalSince1970 + 1))
+
+        node.queueFree()
     }
 
     public func testClassesMethodsPerformance() {
@@ -128,6 +132,9 @@ final class MarshalTests {
             _ = node.call(method: removeChildName, Variant(child))
             XCTAssertEqual(node.call(method: getChildCountName), Variant(0))
         }
+
+        node.queueFree()
+        child.queueFree()
     }
 
     public func testSignals() {
@@ -143,6 +150,8 @@ final class MarshalTests {
         node.someSignal.connect(node.funcTakingInt)
         node.someSignal.emit(10)
         XCTAssertEqual(node.intTaken, 10)
+
+        node.queueFree()
     }
 
     public func testBuiltinsTypesMethodsPerformance() {
@@ -204,8 +213,10 @@ final class MarshalTests {
             55.toVariant(),
             22.toVariant()
         ).to(Int.self)
-        
+
         XCTAssertEqual(anotherResult, 33)
+
+        testNode.queueFree()
     }
 
     public func testSwiftArrays() {
@@ -216,11 +227,13 @@ final class MarshalTests {
         
         guard let variant = testNode.call(method: "double", array.toVariant()) else {
             XCTFail()
+            testNode.queueFree()
             return
         }
-        
+
         guard let collection = TypedArray<Double>(variant) else {
             XCTFail()
+            testNode.queueFree()
             return
         }
         
@@ -232,8 +245,10 @@ final class MarshalTests {
         XCTAssertEqual([9, 4, 8], testNode.swiftArray)
         
         _ = testNode.call(method: "set_swift_array", [12, 1, 9].toVariant())
-        
+
         XCTAssertEqual([12, 1, 9], testNode.swiftArray)
+
+        testNode.queueFree()
     }
 
     public func testSomeVariantConvertible() {
@@ -258,6 +273,8 @@ final class MarshalTests {
         XCTAssertEqual(testNode.call(method: "bar", Variant(42)), Variant(42))
         XCTAssertEqual(testNode.call(method: "bar", Variant("Foo")), Variant("Foo"))
         XCTAssertEqual(testNode.call(method: "bar", nil), nil)
+
+        testNode.queueFree()
     }
 
     public func testUnsafePointersNMemoryLayout() {
@@ -294,6 +311,8 @@ final class MarshalTests {
         
         XCTAssertNotNil(object0)
         XCTAssertTrue(object0 === object1)
+
+        node0?.queueFree()
     }
 
     public func testCallableViaSwiftClosure() {
@@ -386,6 +405,8 @@ final class MarshalTests {
         }
 
         XCTAssertEqual(fulfillmentCount, 5, "Expected 5 fulfillments")
+
+        testNode.queueFree()
     }
 }
 

--- a/Tests/SwiftGodotTestExtension/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTestExtension/MemoryLeakTests.swift
@@ -427,6 +427,8 @@ final class MemoryLeakTests {
                 oneIteration(object: object)
             }
         }
+
+        object.free()
     }
 
     public func testRefCountedLeak() {
@@ -579,6 +581,8 @@ final class MemoryLeakTests {
                 _ = object.emit(signal: signal)
             }
         }
+
+        object.free()
     }
 
     public func test_gstring_string_variant_leak() {

--- a/Tests/SwiftGodotTestExtension/PhysicsDirectSpaceState2DIntersectRayResultTests.swift
+++ b/Tests/SwiftGodotTestExtension/PhysicsDirectSpaceState2DIntersectRayResultTests.swift
@@ -36,6 +36,8 @@ final class PhysicsDirectSpaceState2DIntersectRayResultTests {
         XCTAssertEqual(result.colliderId, collider.id)
         XCTAssertEqual(result.rid, RID())
         XCTAssertEqual(result.shape, 22)
+
+        (collider as? Node)?.queueFree()
     }
 
     public func testIntersectRayResultIsNil_whenColliderPropertyIsMissing() {
@@ -53,7 +55,9 @@ final class PhysicsDirectSpaceState2DIntersectRayResultTests {
         }()
         
         let result = PhysicsDirectSpaceState2D.IntersectRayResult<GridMap>(dictionary)
-        
+
         XCTAssertNil(result)
+
+        (collider as? Node)?.queueFree()
     }
 }

--- a/Tests/SwiftGodotTestExtension/PhysicsDirectSpaceState3DIntersectRayResultTests.swift
+++ b/Tests/SwiftGodotTestExtension/PhysicsDirectSpaceState3DIntersectRayResultTests.swift
@@ -38,6 +38,8 @@ final class PhysicsDirectSpaceState3DIntersectRayResultTests {
         XCTAssertEqual(result.rid, RID())
         XCTAssertEqual(result.shape, 22)
         XCTAssertEqual(result.faceIndex, 44)
+
+        (collider as? Node)?.queueFree()
     }
 
     public func testIntersectRayResultIsNil_whenColliderPropertyIsMissing() {
@@ -56,7 +58,9 @@ final class PhysicsDirectSpaceState3DIntersectRayResultTests {
         }()
         
         let result = PhysicsDirectSpaceState3D.IntersectRayResult<GridMap>(dictionary)
-        
+
         XCTAssertNil(result)
+
+        (collider as? Node)?.queueFree()
     }
 }

--- a/Tests/SwiftGodotTestExtension/RawArgumentsFetchTests.swift
+++ b/Tests/SwiftGodotTestExtension/RawArgumentsFetchTests.swift
@@ -427,12 +427,14 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testInt", Variant(42))
         XCTAssertEqual(Int(result), 84)
+        node.queueFree()
     }
 
     func testFetchInt64() {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testInt64", Variant(Int64(100)))
         XCTAssertEqual(Int64(result), 200)
+        node.queueFree()
     }
 
     func testFetchBool() {
@@ -441,18 +443,21 @@ final class RawArgumentsFetchTests {
         let resultFalse = node.call(method: "testBool", Variant(false))
         XCTAssertEqual(Bool(resultTrue), false)
         XCTAssertEqual(Bool(resultFalse), true)
+        node.queueFree()
     }
 
     func testFetchString() {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testString", Variant("hello"))
         XCTAssertEqual(String(result), "hello_suffix")
+        node.queueFree()
     }
 
     func testFetchDouble() {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testDouble", Variant(3.14))
         XCTAssertEqual(Double(result)!, 6.28, accuracy: 0.001)
+        node.queueFree()
     }
 
     func testFetchFloat() {
@@ -460,6 +465,7 @@ final class RawArgumentsFetchTests {
         let result = node.call(method: "testFloat", Variant(Float(2.5)))
         XCTAssertEqual(result?.gtype, .float)
         XCTAssertEqual(Float(result)!, 5.0, accuracy: 0.001)
+        node.queueFree()
     }
 
     // MARK: - Generated builtin type tests
@@ -468,12 +474,14 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testStringName", Variant(StringName("test")))
         XCTAssertEqual(String(StringName(result)!), "test_modified")
+        node.queueFree()
     }
 
     func testFetchNodePath() {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testNodePath", Variant(NodePath("root/parent")))
         XCTAssertEqual(String(NodePath(result)!), "root/parent/child")
+        node.queueFree()
     }
 
     func testFetchVector2() {
@@ -482,6 +490,7 @@ final class RawArgumentsFetchTests {
         let vec = Vector2(result)!
         XCTAssertEqual(vec.x, 2)
         XCTAssertEqual(vec.y, 4)
+        node.queueFree()
     }
 
     func testFetchVector3() {
@@ -491,6 +500,7 @@ final class RawArgumentsFetchTests {
         XCTAssertEqual(vec.x, 2)
         XCTAssertEqual(vec.y, 4)
         XCTAssertEqual(vec.z, 6)
+        node.queueFree()
     }
 
     func testFetchVector4() {
@@ -501,6 +511,7 @@ final class RawArgumentsFetchTests {
         XCTAssertEqual(vec.y, 4)
         XCTAssertEqual(vec.z, 6)
         XCTAssertEqual(vec.w, 8)
+        node.queueFree()
     }
 
     func testFetchVector2i() {
@@ -509,6 +520,7 @@ final class RawArgumentsFetchTests {
         let vec = Vector2i(result)!
         XCTAssertEqual(vec.x, 6)
         XCTAssertEqual(vec.y, 8)
+        node.queueFree()
     }
 
     func testFetchVector3i() {
@@ -518,6 +530,7 @@ final class RawArgumentsFetchTests {
         XCTAssertEqual(vec.x, 2)
         XCTAssertEqual(vec.y, 4)
         XCTAssertEqual(vec.z, 6)
+        node.queueFree()
     }
 
     func testFetchVector4i() {
@@ -528,6 +541,7 @@ final class RawArgumentsFetchTests {
         XCTAssertEqual(vec.y, 4)
         XCTAssertEqual(vec.z, 6)
         XCTAssertEqual(vec.w, 8)
+        node.queueFree()
     }
 
     func testFetchColor() {
@@ -538,6 +552,7 @@ final class RawArgumentsFetchTests {
         XCTAssertEqual(color.green, 1.0, accuracy: 0.001)
         XCTAssertEqual(color.blue, 0.25, accuracy: 0.001)
         XCTAssertEqual(color.alpha, 1.0, accuracy: 0.001)
+        node.queueFree()
     }
 
     func testFetchRect2() {
@@ -548,6 +563,7 @@ final class RawArgumentsFetchTests {
         XCTAssertEqual(rect.position.y, 4)
         XCTAssertEqual(rect.size.x, 6)
         XCTAssertEqual(rect.size.y, 8)
+        node.queueFree()
     }
 
     func testFetchRect2i() {
@@ -558,6 +574,7 @@ final class RawArgumentsFetchTests {
         XCTAssertEqual(rect.position.y, 4)
         XCTAssertEqual(rect.size.x, 6)
         XCTAssertEqual(rect.size.y, 8)
+        node.queueFree()
     }
 
     func testFetchTransform2D() {
@@ -565,6 +582,7 @@ final class RawArgumentsFetchTests {
         let transform = Transform2D()
         let result = node.call(method: "testTransform2D", Variant(transform))
         XCTAssertNotNil(Transform2D(result))
+        node.queueFree()
     }
 
     func testFetchTransform3D() {
@@ -572,6 +590,7 @@ final class RawArgumentsFetchTests {
         let transform = Transform3D()
         let result = node.call(method: "testTransform3D", Variant(transform))
         XCTAssertNotNil(Transform3D(result))
+        node.queueFree()
     }
 
     func testFetchBasis() {
@@ -579,6 +598,7 @@ final class RawArgumentsFetchTests {
         let basis = Basis()
         let result = node.call(method: "testBasis", Variant(basis))
         XCTAssertNotNil(Basis(result))
+        node.queueFree()
     }
 
     func testFetchQuaternion() {
@@ -586,6 +606,7 @@ final class RawArgumentsFetchTests {
         let quat = Quaternion()
         let result = node.call(method: "testQuaternion", Variant(quat))
         XCTAssertNotNil(Quaternion(result))
+        node.queueFree()
     }
 
     func testFetchPlane() {
@@ -593,6 +614,7 @@ final class RawArgumentsFetchTests {
         let plane = Plane()
         let result = node.call(method: "testPlane", Variant(plane))
         XCTAssertNotNil(Plane(result))
+        node.queueFree()
     }
 
     func testFetchAABB() {
@@ -600,6 +622,7 @@ final class RawArgumentsFetchTests {
         let aabb = AABB()
         let result = node.call(method: "testAABB", Variant(aabb))
         XCTAssertNotNil(AABB(result))
+        node.queueFree()
     }
 
     func testFetchProjection() {
@@ -607,6 +630,7 @@ final class RawArgumentsFetchTests {
         let projection = Projection()
         let result = node.call(method: "testProjection", Variant(projection))
         XCTAssertNotNil(Projection(result))
+        node.queueFree()
     }
 
     func testFetchRID() {
@@ -614,6 +638,7 @@ final class RawArgumentsFetchTests {
         let rid = RID()
         let result = node.call(method: "testRID", Variant(rid))
         XCTAssertNotNil(RID(result))
+        node.queueFree()
     }
 
     func testFetchCallable() {
@@ -621,6 +646,7 @@ final class RawArgumentsFetchTests {
         let callable = Callable()
         let result = node.call(method: "testCallable", Variant(callable))
         XCTAssertNotNil(Callable(result))
+        node.queueFree()
     }
 
     func testFetchSignal() {
@@ -628,6 +654,7 @@ final class RawArgumentsFetchTests {
         let signal = Signal()
         let result = node.call(method: "testSignalArg", Variant(signal))
         XCTAssertNotNil(Signal(result))
+        node.queueFree()
     }
 
     // MARK: - Array type tests
@@ -640,6 +667,7 @@ final class RawArgumentsFetchTests {
         array.append(Variant(3))
         let result = node.call(method: "testVariantArray", Variant(array))
         XCTAssertEqual(Int(result), 3)
+        node.queueFree()
     }
 
     func testFetchVariantDictionary() {
@@ -649,6 +677,7 @@ final class RawArgumentsFetchTests {
         dict["b"] = Variant(2)
         let result = node.call(method: "testVariantDictionary", Variant(dict))
         XCTAssertEqual(Int(result), 2)
+        node.queueFree()
     }
 
     func testFetchPackedByteArray() {
@@ -659,6 +688,7 @@ final class RawArgumentsFetchTests {
         array.append(3)
         let result = node.call(method: "testPackedByteArray", Variant(array))
         XCTAssertEqual(Int(result), 3)
+        node.queueFree()
     }
 
     func testFetchPackedInt32Array() {
@@ -668,6 +698,7 @@ final class RawArgumentsFetchTests {
         array.append(2)
         let result = node.call(method: "testPackedInt32Array", Variant(array))
         XCTAssertEqual(Int(result), 2)
+        node.queueFree()
     }
 
     func testFetchPackedInt64Array() {
@@ -679,6 +710,7 @@ final class RawArgumentsFetchTests {
         array.append(4)
         let result = node.call(method: "testPackedInt64Array", Variant(array))
         XCTAssertEqual(Int(result), 4)
+        node.queueFree()
     }
 
     func testFetchPackedFloat32Array() {
@@ -688,6 +720,7 @@ final class RawArgumentsFetchTests {
         array.append(2.0)
         let result = node.call(method: "testPackedFloat32Array", Variant(array))
         XCTAssertEqual(Int(result), 2)
+        node.queueFree()
     }
 
     func testFetchPackedFloat64Array() {
@@ -698,6 +731,7 @@ final class RawArgumentsFetchTests {
         array.append(3.0)
         let result = node.call(method: "testPackedFloat64Array", Variant(array))
         XCTAssertEqual(Int(result), 3)
+        node.queueFree()
     }
 
     func testFetchPackedStringArray() {
@@ -707,6 +741,7 @@ final class RawArgumentsFetchTests {
         array.append("b")
         let result = node.call(method: "testPackedStringArray", Variant(array))
         XCTAssertEqual(Int(result), 2)
+        node.queueFree()
     }
 
     func testFetchPackedVector2Array() {
@@ -715,6 +750,7 @@ final class RawArgumentsFetchTests {
         array.append(Vector2(x: 1, y: 2))
         let result = node.call(method: "testPackedVector2Array", Variant(array))
         XCTAssertEqual(Int(result), 1)
+        node.queueFree()
     }
 
     func testFetchPackedVector3Array() {
@@ -724,6 +760,7 @@ final class RawArgumentsFetchTests {
         array.append(Vector3(x: 4, y: 5, z: 6))
         let result = node.call(method: "testPackedVector3Array", Variant(array))
         XCTAssertEqual(Int(result), 2)
+        node.queueFree()
     }
 
     func testFetchPackedVector4Array() {
@@ -732,6 +769,7 @@ final class RawArgumentsFetchTests {
         array.append(value: Vector4(x: 1, y: 2, z: 3, w: 4))
         let result = node.call(method: "testPackedVector4Array", Variant(array))
         XCTAssertEqual(Int(result), 1)
+        node.queueFree()
     }
 
     func testFetchPackedColorArray() {
@@ -742,6 +780,7 @@ final class RawArgumentsFetchTests {
         array.append(Color.blue)
         let result = node.call(method: "testPackedColorArray", Variant(array))
         XCTAssertEqual(Int(result), 3)
+        node.queueFree()
     }
 
     // MARK: - TypedArray and TypedDictionary tests
@@ -754,6 +793,7 @@ final class RawArgumentsFetchTests {
         array.append(3)
         let result = node.call(method: "testTypedArrayInt", Variant(array.array))
         XCTAssertEqual(Int(result), 3)
+        node.queueFree()
     }
 
     func testFetchTypedArrayString() {
@@ -763,6 +803,7 @@ final class RawArgumentsFetchTests {
         array.append("world")
         let result = node.call(method: "testTypedArrayString", Variant(array.array))
         XCTAssertEqual(Int(result), 2)
+        node.queueFree()
     }
 
     func testFetchTypedDictionaryIntString() {
@@ -772,6 +813,7 @@ final class RawArgumentsFetchTests {
         dict[2] = "two"
         let result = node.call(method: "testTypedDictionaryIntString", Variant(dict.dictionary))
         XCTAssertEqual(Int(result), 2)
+        node.queueFree()
     }
 
     func testFetchTypedDictionaryStringInt() {
@@ -782,6 +824,7 @@ final class RawArgumentsFetchTests {
         dict["c"] = 3
         let result = node.call(method: "testTypedDictionaryStringInt", Variant(dict.dictionary))
         XCTAssertEqual(Int(result), 3)
+        node.queueFree()
     }
 
     // MARK: - Swift Array and Dictionary tests
@@ -792,6 +835,7 @@ final class RawArgumentsFetchTests {
         let typedArray = TypedArray<Int>(swiftArray)
         let result = node.call(method: "testSwiftArrayInt", Variant(typedArray.array))
         XCTAssertEqual(Int(result), 15) // 1+2+3+4+5 = 15
+        node.queueFree()
     }
 
     func testFetchSwiftArrayString() {
@@ -800,6 +844,7 @@ final class RawArgumentsFetchTests {
         let typedArray = TypedArray<String>(swiftArray)
         let result = node.call(method: "testSwiftArrayString", Variant(typedArray.array))
         XCTAssertEqual(String(result), "a,b,c")
+        node.queueFree()
     }
 
     func testFetchSwiftDictionaryIntString() {
@@ -808,6 +853,7 @@ final class RawArgumentsFetchTests {
         let typedDict = TypedDictionary<Int, String>(swiftDict)
         let result = node.call(method: "testSwiftDictionaryIntString", Variant(typedDict.dictionary))
         XCTAssertEqual(Int(result), 2)
+        node.queueFree()
     }
 
     func testFetchSwiftDictionaryStringInt() {
@@ -816,6 +862,7 @@ final class RawArgumentsFetchTests {
         let typedDict = TypedDictionary<String, Int>(swiftDict)
         let result = node.call(method: "testSwiftDictionaryStringInt", Variant(typedDict.dictionary))
         XCTAssertEqual(Int(result), 60) // 10+20+30 = 60
+        node.queueFree()
     }
 
     // MARK: - Variant tests
@@ -824,12 +871,14 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testVariant", Variant(42))
         XCTAssertEqual(String(result), "42")
+        node.queueFree()
     }
 
     func testFetchVariantOptionalWithValue() {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testVariantOptional", Variant("hello"))
         XCTAssertEqual(String(result), "hello")
+        node.queueFree()
     }
 
     // MARK: - Object tests
@@ -840,6 +889,8 @@ final class RawArgumentsFetchTests {
         testNode.name = "TestNode"
         let result = node.call(method: "testNodeOptional", Variant(testNode))
         XCTAssertEqual(String(result), "TestNode")
+        testNode.queueFree()
+        node.queueFree()
     }
 
     func testFetchNode() {
@@ -848,6 +899,8 @@ final class RawArgumentsFetchTests {
         testNode.name = "MyTestNode"
         let result = node.call(method: "testNode", Variant(testNode))
         XCTAssertEqual(String(result), "MyTestNode")
+        testNode.queueFree()
+        node.queueFree()
     }
 
     func testFetchRefCountedOptional() {
@@ -855,6 +908,7 @@ final class RawArgumentsFetchTests {
         let refCounted = RefCounted()
         let result = node.call(method: "testRefCountedOptional", Variant(refCounted))
         XCTAssertEqual(Bool(result), true)
+        node.queueFree()
     }
 
     // MARK: - RawRepresentable enum tests
@@ -864,12 +918,14 @@ final class RawArgumentsFetchTests {
         // Pass the raw value since Godot doesn't know about our Swift enum
         let result = node.call(method: "testIntEnum", Variant(2)) // TestIntEnum.second
         XCTAssertEqual(Int(result), 20) // 2 * 10 = 20
+        node.queueFree()
     }
 
     func testFetchInt64Enum() {
         let node = RawArgumentsTestNode()
         let result = node.call(method: "testInt64Enum", Variant(200)) // TestInt64Enum.beta
         XCTAssertEqual(Int64(result), 2000) // 200 * 10 = 2000
+        node.queueFree()
     }
 
     // MARK: - GodotBuiltinConvertible custom type tests
@@ -879,6 +935,7 @@ final class RawArgumentsFetchTests {
         // CustomIntWrapper is backed by Int, so we pass an Int
         let result = node.call(method: "testCustomIntWrapper", Variant(7))
         XCTAssertEqual(Int(result), 21) // 7 * 3 = 21
+        node.queueFree()
     }
 
     func testFetchCustomStringWrapper() {
@@ -886,6 +943,7 @@ final class RawArgumentsFetchTests {
         // CustomStringWrapper is backed by String
         let result = node.call(method: "testCustomStringWrapper", Variant("hello"))
         XCTAssertEqual(String(result), "HELLO")
+        node.queueFree()
     }
 
     func testFetchCustomVector2Wrapper() {
@@ -895,6 +953,7 @@ final class RawArgumentsFetchTests {
         let vec = Vector2(result)!
         XCTAssertEqual(vec.x, 6) // 2 * 3 = 6
         XCTAssertEqual(vec.y, 9) // 3 * 3 = 9
+        node.queueFree()
     }
 
     // MARK: - Mixed parameter tests
@@ -909,6 +968,7 @@ final class RawArgumentsFetchTests {
             Variant(Vector2(x: 1.5, y: 2.5))
         )
         XCTAssertEqual(String(result), "42_test_true_1.5,2.5")
+        node.queueFree()
     }
 
     func testFetchMixedWithCustom() {
@@ -921,6 +981,7 @@ final class RawArgumentsFetchTests {
             Variant(10)      // normal Int
         )
         XCTAssertEqual(Int(result), 18)
+        node.queueFree()
     }
 
     func testFetchMixedWithArrays() {
@@ -943,6 +1004,7 @@ final class RawArgumentsFetchTests {
             Variant(packedArray)
         )
         XCTAssertEqual(Int(result), 6)
+        node.queueFree()
     }
 
     func testFetchMixedWithObjects() {
@@ -957,5 +1019,7 @@ final class RawArgumentsFetchTests {
             Variant(3) // TestIntEnum.third
         )
         XCTAssertEqual(String(result), "ObjNode_123_3")
+        testNode.queueFree()
+        node.queueFree()
     }
 }

--- a/Tests/SwiftGodotTestExtension/SignalTests.swift
+++ b/Tests/SwiftGodotTestExtension/SignalTests.swift
@@ -33,6 +33,7 @@ final class SignalTests {
 
         XCTAssertEqual (node.receivedInt, 22, "Integers should have been the same")
         XCTAssertEqual (node.receivedString, "Joey", "Strings should have been the same")
+        node.queueFree()
     }
 
     public func testNuSignal() {
@@ -46,6 +47,7 @@ final class SignalTests {
         }
         node.nuSignal.emit(22, "Sam")
         XCTAssertTrue (signalReceived, "signal should have been received")
+        node.queueFree()
     }
 
     public func testBuiltInSignalWithNoArgument() {
@@ -56,6 +58,7 @@ final class SignalTests {
         }
         node.ready.emit()
         XCTAssertTrue (signalReceived, "signal should have been received")
+        node.queueFree()
     }
 
     public func testBuiltInSignalWithArgument() {
@@ -67,6 +70,7 @@ final class SignalTests {
         }
         node.childExitingTree.emit(node)
         XCTAssertTrue (signalReceived, "signal should have been received")
+        node.queueFree()
     }
 
     public func testBuiltInSignalWithPrimitiveArguments() {
@@ -80,6 +84,7 @@ final class SignalTests {
         }
         node.animationNodeRenamed.emit(123, "old name", "new name")
         XCTAssertTrue (signalReceived, "signal should have been received")
+        // AnimationNode is a Resource (reference-counted) — no manual free needed.
     }
 }
 

--- a/Tests/SwiftGodotTestExtension/TestRunnerNode.swift
+++ b/Tests/SwiftGodotTestExtension/TestRunnerNode.swift
@@ -8,8 +8,13 @@
 import Foundation
 import SwiftGodot
 
-/// A Node that runs all registered tests when added to the scene tree.
-/// This is the entry point for test execution inside Godot.
+/// A Node that runs all registered tests on demand.
+///
+/// This type is **not** baked into the test scene. Instead a pure-GDScript
+/// orchestrator (`test_orchestrator.gd`) instantiates it at runtime, calls
+/// ``runTests()``, and frees it again before quitting. Keeping the only live
+/// instance short-lived and out of any saved resource is what lets the
+/// SwiftGodot extension be unloaded cleanly.
 @Godot
 public class TestRunnerNode: Node {
     /// Path where JSON results will be written
@@ -31,8 +36,30 @@ public class TestRunnerNode: Node {
     /// with @SwiftGodotTestSuite.
     private let suites: [any SwiftGodotTestSuiteProtocol] = TestRunnerNode.generatedSuites
 
-    public override func _ready() {
-        print("[TestRunnerNode] _ready() called")
+    /// Every Godot subclass registered for the run, in registration order.
+    ///
+    /// These are deregistered by ``deregisterTypes()`` — not per-suite — because
+    /// tests free their nodes with `queue_free`, so an instance is only actually
+    /// gone after the orchestrator pumps frames. Deregistering a class while a
+    /// pending-deletion instance still exists would be unsafe, so we hold the
+    /// list and tear it down only once everything has been freed.
+    private var registeredSubclasses: [Object.Type] = []
+
+    /// Emitted once all tests have finished, carrying the process exit code
+    /// (non-zero when any test failed). The GDScript orchestrator awaits this,
+    /// then frees this node and quits the tree.
+    @Signal var finished: SignalWithArguments<Int>
+
+    /// Runs every registered test, writes the JSON results, and emits ``finished``
+    /// with the resulting exit code.
+    ///
+    /// The orchestrator invokes this *deferred* (rather than relying on `_ready`)
+    /// so the signal can never fire before the orchestrator has started awaiting
+    /// it. `emit` is the final statement: an awaiting listener resumes inside the
+    /// emit call, so nothing must touch `self` afterwards.
+    @Callable
+    func runTests() {
+        print("[TestRunnerNode] runTests() called")
         GD.print("=".repeated(60))
         GD.print("SwiftGodot Test Runner")
         GD.print("=".repeated(60))
@@ -46,7 +73,22 @@ public class TestRunnerNode: Node {
         GD.print("=".repeated(60))
 
         let exitCode = results.summary.failed > 0 ? 1 : 0
-        getTree()?.quit(exitCode: Int32(exitCode))
+        finished.emit(exitCode)
+    }
+
+    /// Deregisters every Godot subclass that was registered during the run.
+    ///
+    /// The orchestrator calls this *after* it has pumped frames following
+    /// ``finished``, so the scene tree's deletion queue has flushed and no
+    /// instance of these classes is still alive. Deregistering only once
+    /// everything is freed is what keeps the extension safely unloadable.
+    @Callable
+    func deregisterTypes() {
+        releasePendingObjects()
+        for subclass in registeredSubclasses.reversed() {
+            unregister(type: subclass)
+        }
+        registeredSubclasses.removeAll()
     }
 
     // MARK: - Test Execution
@@ -83,9 +125,12 @@ public class TestRunnerNode: Node {
         let suiteName = suiteType.name
         GD.printRich("[color=blue][b]\(suiteName)[/b][/color]")
 
-        // Register Godot subclasses needed by this suite
+        // Register Godot subclasses needed by this suite. They are torn down
+        // later by deregisterTypes(), once every queue_free'd test instance has
+        // actually been freed — not here, where instances may still be pending.
         for subclass in suiteType.registeredTypes {
             register(type: subclass)
+            registeredSubclasses.append(subclass)
         }
 
         // Run test methods (filtered if specified)
@@ -102,12 +147,6 @@ public class TestRunnerNode: Node {
                 GD.printRich("[color=red][b]FAILED:[/b] \(failure.message)[/color]")
                 GD.printRich("[color=red]  at \(failure.file):\(failure.line)[/color]")
             }
-        }
-
-        // Unregister Godot subclasses
-        for subclass in suiteType.registeredTypes.reversed() {
-            releasePendingObjects()
-            unregister(type: subclass)
         }
 
         GD.print("")

--- a/Tests/SwiftGodotTestExtension/TypedArrayTests.swift
+++ b/Tests/SwiftGodotTestExtension/TypedArrayTests.swift
@@ -54,9 +54,11 @@ final class TypedArrayTests {
     func testObjectArrayInvariance() {
         let typed = TypedArray<Node?>()
         let anotherTyped = TypedArray<Object?>(from: typed.array)
-        typed.append(Node())
+        let node = Node()
+        typed.append(node)
         XCTAssert(typed.array !== anotherTyped.array)
         XCTAssert(typed.array != anotherTyped.array)
+        node.queueFree()
     }
     
     func testSequenceInitializer() {

--- a/Tests/SwiftGodotTestExtension/TypedDictionaryTests.swift
+++ b/Tests/SwiftGodotTestExtension/TypedDictionaryTests.swift
@@ -766,6 +766,8 @@ final class TypedDictionaryTests {
         // Dictionary should only have the valid entry
         XCTAssertEqual(typed.size(), 1)
         XCTAssertTrue(typed[1] === refCounted)
+
+        node.queueFree()
     }
 
     func testTypeMismatchMultipleInvalidInserts() {

--- a/Tests/SwiftGodotTestExtension/ValidatePropertyTests.swift
+++ b/Tests/SwiftGodotTestExtension/ValidatePropertyTests.swift
@@ -44,5 +44,6 @@ final class ValidatePropertyTests {
             }
         }
         XCTAssertTrue(found, "Should have found a property named hideThisVariable with the usage set to 'readOnly'")
+        node.queueFree()
     }
 }

--- a/Tests/SwiftGodotTestExtension/VariantTests.swift
+++ b/Tests/SwiftGodotTestExtension/VariantTests.swift
@@ -22,6 +22,7 @@ final class VariantTests {
     public func testWrap() {
         let x: Node? = Node()
         let _ = Variant(x)
+        x?.queueFree()
     }
     
     
@@ -137,6 +138,7 @@ final class VariantTests {
         XCTAssertEqual (variant.gtype, Variant.GType.string)
         let newString = String (variant)
         XCTAssertEqual (string, newString)
+        sprite.queueFree()
     }
     
     public func testOperatorEqualsEquals () {
@@ -153,6 +155,8 @@ final class VariantTests {
         let node2 = Node()
         XCTAssertTrue (Variant (node) == Variant (node))
         XCTAssertFalse (Variant (node) == Variant (node2))
+        node.queueFree()
+        node2.queueFree()
     }
     
     public func testUnwrappingApi() {

--- a/Tests/SwiftGodotTestProject/main.tscn
+++ b/Tests/SwiftGodotTestProject/main.tscn
@@ -1,5 +1,7 @@
-[gd_scene format=3 uid="uid://ctest_runner_scene"]
+[gd_scene format=3 uid="uid://0onbdtks1hu3"]
 
-[node name="Main" type="Node"]
+[ext_resource type="Script" uid="uid://b8uhwycgmueu4" path="res://test_orchestrator.gd" id="1_ig7tw"]
 
-[node name="TestRunner" type="TestRunnerNode" parent="."]
+[node name="TestOrchestrator" type="Node" unique_id=1317884604]
+script = ExtResource("1_ig7tw")
+metadata/_custom_type_script = "uid://b8uhwycgmueu4"

--- a/Tests/SwiftGodotTestProject/test_orchestrator.gd
+++ b/Tests/SwiftGodotTestProject/test_orchestrator.gd
@@ -1,0 +1,33 @@
+extends Node
+class_name TestOrchestrator
+
+# Pure-GDScript entry point for the test run.
+#
+# The TestRunnerNode is *not* baked into main.tscn (that would make the saved
+# scene depend on a SwiftGodot-provided type and keep the extension pinned).
+# Instead we instantiate it at runtime, drive it, and free it again before
+# quitting, so no extension instance survives to block a clean unload.
+func _ready() -> void:
+	var runner := TestRunnerNode.new()
+	add_child(runner)
+
+	# Run deferred so `runTests` can't emit `finished` before we await it below.
+	runner.call_deferred("runTests")
+	var exit_code: int = await runner.finished
+
+	# The tests free their nodes with queue_free, so the actual deletions only
+	# happen on a frame tick. Pump frames first so every test instance is gone...
+	for _i in 10: # Safe grace period for Swift objects to get cleaned up
+		await get_tree().process_frame
+
+	# ...then deregister the classes (must happen AFTER their instances are freed).
+	runner.deregisterTypes()
+
+	# Now tear down the runner itself and let its free settle before quitting,
+	# so no extension instance survives and the extension can be unloaded cleanly.
+	runner.queue_free()
+
+	for _i in 10:
+		await get_tree().process_frame
+
+	get_tree().quit(exit_code)

--- a/Tests/SwiftGodotTestProject/test_orchestrator.gd.uid
+++ b/Tests/SwiftGodotTestProject/test_orchestrator.gd.uid
@@ -1,0 +1,1 @@
+uid://b8uhwycgmueu4


### PR DESCRIPTION
The TestRunnerNode was baked into main.tscn and quit the tree from its own _ready, so the scene pinned a SwiftGodot type and a live extension instance survived to shutdown -- which is why Godot froze on exit and the runner had to forcibly terminate it.

Drive the run from a pure-GDScript orchestrator instead:
- main.tscn now holds a plain Node with test_orchestrator.gd. It instantiates TestRunnerNode at runtime, calls runTests (deferred), awaits a `finished` signal carrying the exit code, pumps frames, then frees the node and quits.
- TestRunnerNode loses its self-running _ready in favor of an @Callable runTests() + @Signal finished, and defers type deregistration: it tracks the registered subclasses and tears them down in a new deregisterTypes() callable the orchestrator invokes only AFTER frames have pumped, so no class is deregistered while a queue_free'd instance is still pending deletion.

Fix the node/object leaks this exposed: every test that created a Node/Object now frees it (queue_free for Nodes, free for plain Objects). Godot now reports zero leaked ObjectDB instances at exit.

With the extension unloading cleanly, Godot exits on its own, so drop the test runner's kill-on-exit workaround (completion-file polling, timeouts, and fileIsReady) and just wait for Godot's real exit code.