### PR TITLE
Support default arguments for @Callable functions

### DIFF
--- a/Sources/SwiftGodot/SwiftGodot.docc/CustomTypes.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/CustomTypes.md
@@ -189,6 +189,28 @@ floats, the Godot Object subclasses as well as ``TypedArray`` and ``TypedDiction
 The `@Callable` macro only works in your class definition, and will not work
 on Swift class extensions.
 
+#### Default arguments
+
+Parameters with default values are surfaced to Godot as optional arguments, so
+callers from the editor or other scripting languages may omit them:
+
+```swift
+@Callable
+func greet(_ name: String, greeting: String = "Hello", times: Int = 1) -> String {
+    Array(repeating: "\(greeting), \(name)", count: times).joined(separator: " ")
+}
+```
+
+From GDScript, all of `greet("World")`, `greet("World", "Hi")`, and
+`greet("World", "Hi", 2)` are valid; omitted trailing arguments use the Swift
+default values.
+
+Godot only supports default values for a contiguous run of *trailing*
+parameters (matching how default arguments work in GDScript). If a parameter
+with a default is followed by one without, only the trailing run is exposed to
+Godot as optional; the earlier defaults are treated as required when called from
+Godot, though they still apply when the method is called directly from Swift.
+
 ### Surfacing Properties and Variables
 
 To surface properties and variables, use the ``Export`` attribute on them.

--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -51,13 +51,31 @@ public struct GodotCallable: PeerMacro {
 
         let objectOrSelf = isStatic ? "self" : "object"
 
+        // Godot only fills in default values for a contiguous run of trailing arguments. When the
+        // variant call path is invoked with fewer arguments than declared, fall back to the Swift
+        // default expression for any omitted trailing parameter. The ptrcall path always receives a
+        // complete argument list, so it does not need the fallback.
+        let parameterArray = Array(parameters)
+        var trailingDefaultCount = 0
+        for parameter in parameterArray.reversed() {
+            guard parameter.defaultValueExpr != nil else { break }
+            trailingDefaultCount += 1
+        }
+        let firstDefaultIndex = parameterArray.count - trailingDefaultCount
+
         for (index, parameter) in parameters.enumerated() {
             let ptype = parameter.type.trimmedDescription
-            
-            body += """
-                    let arg\(index) = try arguments.argument(ofType: \(ptype).self, at: \(index))            
-            """
-                        
+
+            if index >= firstDefaultIndex, let defaultExpr = parameter.defaultValueExpr {
+                body += """
+                        let arg\(index) = arguments.count > \(index) ? try arguments.argument(ofType: \(ptype).self, at: \(index)) : (\(defaultExpr.trimmedDescription) as \(ptype))
+                """
+            } else {
+                body += """
+                        let arg\(index) = try arguments.argument(ofType: \(ptype).self, at: \(index))
+                """
+            }
+
             callArgsList.append("\(parameter.labelForCaller)arg\(index)")
 
             bodyPtr += """

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -114,7 +114,7 @@ class GodotMacroProcessor {
         }
         
         let p = classInitializerPrinter
-                        
+
         let arguments = funcDecl
             .parameters
             .map { parameter in
@@ -122,7 +122,27 @@ class GodotMacroProcessor {
                 return "SwiftGodotRuntime._argumentPropInfo(\(typename).self, name: \"\(parameter.internalName)\")"
             }
             .joined(separator: ",\n")
-                
+
+        // Godot only supports default values for a contiguous run of trailing arguments,
+        // matching the `default_arguments` array in `GDExtensionClassMethodInfo`. We expose
+        // the longest such trailing run; any earlier Swift defaults are treated as required
+        // by Godot (they remain usable when the function is called directly from Swift).
+        let parameterList = Array(funcDecl.parameters)
+        var trailingDefaultCount = 0
+        for parameter in parameterList.reversed() {
+            guard parameter.defaultValueExpr != nil else { break }
+            trailingDefaultCount += 1
+        }
+
+        let defaultArguments = parameterList
+            .suffix(trailingDefaultCount)
+            .compactMap { parameter -> String? in
+                guard let defaultExpr = parameter.defaultValueExpr else { return nil }
+                let typename = parameter.type.trimmedDescription
+                return "SwiftGodotRuntime._wrapDefaultArgument(SwiftGodotRuntime._wrapCallableResult(\(defaultExpr.trimmedDescription) as \(typename)))"
+            }
+            .joined(separator: ",\n")
+
         let returnTypename: String
         if let type = funcDecl.signature.returnClause?.type {
             returnTypename = type.trimmedDescription
@@ -146,6 +166,11 @@ class GodotMacroProcessor {
             """)
             p("arguments: ", .square, afterBlock: ",") {
                 p(arguments)
+            }
+            if trailingDefaultCount > 0 {
+                p("defaultArguments: ", .square, afterBlock: ",") {
+                    p(defaultArguments)
+                }
             }
             p(("function: \(className)._mproxy_\(funcName)") + (generatePtrCall ? "," : ""))
             if generatePtrCall {

--- a/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
@@ -78,6 +78,11 @@ extension FunctionParameterSyntax {
     var internalName: String {
         secondName?.text ?? firstName.text
     }
+
+    /// The default value expression, e.g. `5` in `(b: Int = 5)`, or `nil` if the parameter has no default.
+    var defaultValueExpr: ExprSyntax? {
+        defaultValue?.value
+    }
 }
 
 extension VariableDeclSyntax {

--- a/Sources/SwiftGodotRuntime/Core/FastFunctionBridging.swift
+++ b/Sources/SwiftGodotRuntime/Core/FastFunctionBridging.swift
@@ -78,6 +78,34 @@ public func _registerPropertyWithGetterSetter(
     _registerProperty(className: className, info: info, getter: getterName, setter: setterName)
 }
 
+/// Invokes `body` with a pointer to an array of `default_argument_count` `GDExtensionVariantPtr`s,
+/// matching the layout Godot expects for `GDExtensionClassMethodInfo.default_arguments`. The
+/// pointers (and the `Variant`s they reference) are only valid for the duration of `body`; Godot
+/// copies the default values into the method bind during registration. A `nil` entry is passed as a
+/// Godot `nil` `Variant`.
+private func withDefaultArgumentPointers<R>(
+    _ defaultArguments: [Variant?],
+    _ body: (UnsafeMutablePointer<GDExtensionVariantPtr?>?, UInt32) -> R
+) -> R {
+    let count = defaultArguments.count
+    guard count > 0 else {
+        return body(nil, 0)
+    }
+
+    return withExtendedLifetime(defaultArguments) {
+        withUnsafeTemporaryAllocation(of: VariantContent.self, capacity: count) { contentBuffer in
+            withUnsafeTemporaryAllocation(of: GDExtensionVariantPtr?.self, capacity: count) { ptrBuffer in
+                for (index, variant) in defaultArguments.enumerated() {
+                    contentBuffer.initializeElement(at: index, to: variant?.content ?? Variant.zero)
+                    ptrBuffer.initializeElement(at: index, to: UnsafeMutableRawPointer(contentBuffer.baseAddress! + index))
+                }
+
+                return body(ptrBuffer.baseAddress, UInt32(count))
+            }
+        }
+    }
+}
+
 /// Internal API.
 public func _registerMethod(
     className: StringName,
@@ -85,6 +113,7 @@ public func _registerMethod(
     flags: MethodFlags,
     returnValue: PropInfo?,
     arguments: [PropInfo],
+    defaultArguments: [Variant?] = [],
     function: @escaping BridgedFunction
 ) {
     let argPtr = UnsafeMutablePointer<GDExtensionPropertyInfo>.allocate(capacity: arguments.count)
@@ -102,11 +131,12 @@ public func _registerMethod(
     if let returnValue {
         retInfo = returnValue.makeNativeStruct()
     }
-    
+
     // TODO: leaks, never deallocated
     let userdata = UnsafeMutablePointer<BridgedFunctionInfo>.allocate(capacity: 1)
     userdata.initialize(to: .init(function: function, returnedType: returnValue?.propertyType))
-    
+
+    withDefaultArgumentPointers(defaultArguments) { defaultArgsPtr, defaultArgsCount in
     withUnsafeMutablePointer(to: &name.content) { namePtr in
         withUnsafeMutablePointer(to: &retInfo) { retInfoPtr in
         var info = GDExtensionClassMethodInfo (
@@ -121,12 +151,13 @@ public func _registerMethod(
             argument_count: UInt32(arguments.count),
             arguments_info: argPtr,
             arguments_metadata: argMeta, // GDExtensionClassMethodArgumentMetadata
-            default_argument_count: 0,
-            default_arguments: nil) // GDExtensionVariantPtr)
+            default_argument_count: defaultArgsCount,
+            default_arguments: defaultArgsPtr) // GDExtensionVariantPtr)
             withUnsafePointer(to: &className.content) { namePtr in
                 gi.classdb_register_extension_class_method (extensionInterface.getLibrary(), namePtr, &info)
             }
         }
+    }
     }
 }
 
@@ -136,6 +167,7 @@ public func _registerMethod(
     flags: MethodFlags,
     returnValue: PropInfo?,
     arguments: [PropInfo],
+    defaultArguments: [Variant?] = [],
     function: @escaping BridgedFunction,
     ptrFunction: @escaping GDExtensionClassMethodPtrCall
 ) {
@@ -158,6 +190,7 @@ public func _registerMethod(
     let userdata = UnsafeMutablePointer<BridgedFunctionInfo>.allocate(capacity: 1)
     userdata.initialize(to: .init(function: function, returnedType: returnValue?.propertyType))
 
+    withDefaultArgumentPointers(defaultArguments) { defaultArgsPtr, defaultArgsCount in
     withUnsafeMutablePointer(to: &name.content) { namePtr in
         withUnsafeMutablePointer(to: &retInfo) { retInfoPtr in
         var info = GDExtensionClassMethodInfo (
@@ -172,12 +205,13 @@ public func _registerMethod(
             argument_count: UInt32(arguments.count),
             arguments_info: argPtr,
             arguments_metadata: argMeta, // GDExtensionClassMethodArgumentMetadata
-            default_argument_count: 0,
-            default_arguments: nil) // GDExtensionVariantPtr)
+            default_argument_count: defaultArgsCount,
+            default_arguments: defaultArgsPtr) // GDExtensionVariantPtr)
             withUnsafePointer(to: &className.content) { namePtr in
                 gi.classdb_register_extension_class_method (extensionInterface.getLibrary(), namePtr, &info)
             }
         }
+    }
     }
 }
 

--- a/Sources/SwiftGodotRuntime/MacroIntegration/MacroCallableWrapResult.swift
+++ b/Sources/SwiftGodotRuntime/MacroIntegration/MacroCallableWrapResult.swift
@@ -78,3 +78,11 @@ public func _wrapCallableResult(_ value: Void) -> FastVariant? {
 public func _wrapCallableResult<T>(_ value: T?) -> FastVariant? {
     fatalError("Unreachable")
 }
+
+/// Internal API. Wraps a `@Callable` parameter's default value into a `Variant?` suitable for
+/// method registration. A `nil` result represents a Godot `nil` default argument.
+@inline(__always)
+@inlinable
+public func _wrapDefaultArgument(_ value: consuming FastVariant?) -> Variant? {
+    Variant(takingOver: value)
+}

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -229,6 +229,19 @@ final class MacroGodotTests: MacroGodotTestCase {
         )
     }
     
+    func testCallableWithDefaultArguments() {
+        assertExpansion(
+            of: """
+            @Godot class Greeter: Node {
+                @Callable func greet(_ name: String, greeting: String = "Hello", times: Int = 1) -> String {
+                    Array(repeating: "\\(greeting), \\(name)", count: times).joined(separator: " ")
+                }
+                @Callable func attach(to node: Node? = nil) {}
+            }
+            """
+        )
+    }
+
     func testNewSignalMacro() {
         assertExpansion(
             of: """

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableWithDefaultArguments.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableWithDefaultArguments.swift
@@ -1,0 +1,135 @@
+class Greeter: Node {
+    func greet(_ name: String, greeting: String = "Hello", times: Int = 1) -> String {
+        Array(repeating: "\(greeting), \(name)", count: times).joined(separator: " ")
+    }
+
+    static func _mproxy_greet(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodotRuntime.Arguments) -> SwiftGodotRuntime.FastVariant? {
+        do { // safe arguments access scope
+            guard let object = SwiftGodotRuntime._unwrap(self, pInstance: pInstance) else {
+                SwiftGodotRuntime.GD.printErr("Error calling `greet`: failed to unwrap instance \(String(describing: pInstance))")
+                return nil
+            }
+            let arg0 = try arguments.argument(ofType: String.self, at: 0)
+            let arg1 = arguments.count > 1 ? try arguments.argument(ofType: String.self, at: 1) : ("Hello" as String)
+            let arg2 = arguments.count > 2 ? try arguments.argument(ofType: Int.self, at: 2) : (1 as Int)
+            return SwiftGodotRuntime._wrapCallableResult(object.greet(arg0, greeting: arg1, times: arg2))
+
+        } catch {
+            SwiftGodotRuntime.GD.printErr("Error calling `greet`: \(error.description)")
+        }
+
+        return nil
+    }
+    static func _pproxy_greet(        
+    _ pInstance: UnsafeMutableRawPointer?,
+    _ rargs: SwiftGodotRuntime.RawArguments,
+    _ returnValue: UnsafeMutableRawPointer?) {
+        do { // safe arguments access scope
+                    guard let object = SwiftGodotRuntime._unwrap(self, pInstance: pInstance) else {
+                SwiftGodotRuntime.GD.printErr("Error calling `greet`: failed to unwrap instance \(String(describing: pInstance))")
+                return
+            }
+        let arg0: String = try rargs.fetchArgument(at: 0)
+        let arg1: String = try rargs.fetchArgument(at: 1)
+        let arg2: Int = try rargs.fetchArgument(at: 2)
+            SwiftGodotRuntime.RawReturnWriter.writeResult(returnValue, object.greet(arg0, greeting: arg1, times: arg2)) 
+
+        } catch {
+            SwiftGodotRuntime.GD.printErr("Error calling `greet`: \(String(describing: error))")                    
+        }
+    }
+    func attach(to node: Node? = nil) {}
+
+    static func _mproxy_attach(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodotRuntime.Arguments) -> SwiftGodotRuntime.FastVariant? {
+        do { // safe arguments access scope
+            guard let object = SwiftGodotRuntime._unwrap(self, pInstance: pInstance) else {
+                SwiftGodotRuntime.GD.printErr("Error calling `attach`: failed to unwrap instance \(String(describing: pInstance))")
+                return nil
+            }
+            let arg0 = arguments.count > 0 ? try arguments.argument(ofType: Node?.self, at: 0) : (nil as Node?)
+            return SwiftGodotRuntime._wrapCallableResult(object.attach(to: arg0))
+
+        } catch {
+            SwiftGodotRuntime.GD.printErr("Error calling `attach`: \(error.description)")
+        }
+
+        return nil
+    }
+    static func _pproxy_attach(        
+    _ pInstance: UnsafeMutableRawPointer?,
+    _ rargs: SwiftGodotRuntime.RawArguments,
+    _ returnValue: UnsafeMutableRawPointer?) {
+        do { // safe arguments access scope
+                    guard let object = SwiftGodotRuntime._unwrap(self, pInstance: pInstance) else {
+                SwiftGodotRuntime.GD.printErr("Error calling `attach`: failed to unwrap instance \(String(describing: pInstance))")
+                return
+            }
+        let arg0: Node? = try rargs.fetchArgument(at: 0)
+            SwiftGodotRuntime.RawReturnWriter.writeResult(returnValue, object.attach(to: arg0)) 
+
+        } catch {
+            SwiftGodotRuntime.GD.printErr("Error calling `attach`: \(String(describing: error))")                    
+        }
+    }
+
+    override open class var classInitializer: Void {
+        let _ = super.classInitializer
+        return _initializeClass()
+    }
+
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: Greeter.self) else {
+            return
+        }
+        let className = StringName("Greeter")
+        if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
+            // ClassDB singleton is not available prior to `.scene` level
+            assert(ClassDB.classExists(class: className))
+        }
+        SwiftGodotRuntime._registerMethod(
+            className: className,
+            name: "greet",
+            flags: .default,
+            returnValue: SwiftGodotRuntime._returnValuePropInfo(String.self),
+            arguments: [
+                SwiftGodotRuntime._argumentPropInfo(String.self, name: "name"),
+                SwiftGodotRuntime._argumentPropInfo(String.self, name: "greeting"),
+                SwiftGodotRuntime._argumentPropInfo(Int.self, name: "times")
+            ],
+            defaultArguments: [
+                SwiftGodotRuntime._wrapDefaultArgument(SwiftGodotRuntime._wrapCallableResult("Hello" as String)),
+                SwiftGodotRuntime._wrapDefaultArgument(SwiftGodotRuntime._wrapCallableResult(1 as Int))
+            ],
+            function: Greeter._mproxy_greet,
+            ptrFunction: { udata, classInstance, argsPtr, retValue in
+                guard let argsPtr else {
+                    GD.print("Godot is not passing the arguments");
+                    return
+                }
+                Greeter._pproxy_greet (classInstance, RawArguments(args: argsPtr), retValue)
+            }
+
+        )
+        SwiftGodotRuntime._registerMethod(
+            className: className,
+            name: "attach",
+            flags: .default,
+            returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
+            arguments: [
+                SwiftGodotRuntime._argumentPropInfo(Node?.self, name: "node")
+            ],
+            defaultArguments: [
+                SwiftGodotRuntime._wrapDefaultArgument(SwiftGodotRuntime._wrapCallableResult(nil as Node?))
+            ],
+            function: Greeter._mproxy_attach,
+            ptrFunction: { udata, classInstance, argsPtr, retValue in
+                guard let argsPtr else {
+                    GD.print("Godot is not passing the arguments");
+                    return
+                }
+                Greeter._pproxy_attach (classInstance, RawArguments(args: argsPtr), retValue)
+            }
+
+        )
+    }
+}

--- a/Tests/SwiftGodotTestExtension/MacroCallableIntegrationTests.swift
+++ b/Tests/SwiftGodotTestExtension/MacroCallableIntegrationTests.swift
@@ -31,10 +31,115 @@ fileprivate class TestObject: Object {
 fileprivate class TestObject2: TestObject { // for checking inheritance
 }
 
+@Godot
+fileprivate class DefaultArgObject: Object {
+    enum Mode: Int, CaseIterable {
+        case slow = 0
+        case fast = 7
+    }
+
+    @Callable
+    func greet(_ name: String, greeting: String = "Hello", times: Int = 2) -> String {
+        Array(repeating: "\(greeting), \(name)", count: times).joined(separator: " ")
+    }
+
+    @Callable
+    func attach(to node: Object? = nil) -> Bool {
+        node != nil
+    }
+
+    @Callable
+    func describe(prefix: String = "mode", mode: Mode = .fast) -> String {
+        "\(prefix):\(mode.rawValue)"
+    }
+}
+
 @SwiftGodotTestSuite
 final class MacroCallableIntegrationTests {
     public static var registeredTypes: [Object.Type] {
-        return [TestObject.self, TestObject2.self]
+        return [TestObject.self, TestObject2.self, DefaultArgObject.self]
+    }
+
+    public func testDefaultArgumentsOmitted() {
+        let object = DefaultArgObject()
+
+        // All defaults applied: greeting = "Hello", times = 2
+        assertEqual(object.call(method: "greet", Variant("World")), Variant("Hello, World Hello, World"))
+        // Trailing default applied: times = 2
+        assertEqual(object.call(method: "greet", Variant("World"), Variant("Hi")), Variant("Hi, World Hi, World"))
+        // No defaults applied
+        assertEqual(object.call(method: "greet", Variant("World"), Variant("Hi"), Variant(1)), Variant("Hi, World"))
+
+        object.free()
+    }
+
+    public func testDefaultArgumentNil() {
+        let object = DefaultArgObject()
+
+        // Omitted optional object argument defaults to nil
+        assertEqual(object.call(method: "attach"), Variant(false))
+        assertEqual(object.call(method: "attach", Variant(object)), Variant(true))
+
+        object.free()
+    }
+
+    public func testEnumDefaultArgument() {
+        let object = DefaultArgObject()
+
+        // Both defaults applied: prefix = "mode", mode = .fast (7)
+        assertEqual(object.call(method: "describe"), Variant("mode:7"))
+        // Trailing enum default applied: mode = .fast (7)
+        assertEqual(object.call(method: "describe", Variant("speed")), Variant("speed:7"))
+        // Enum supplied explicitly (as its raw Int value)
+        assertEqual(object.call(method: "describe", Variant("speed"), Variant(DefaultArgObject.Mode.slow.rawValue)), Variant("speed:0"))
+
+        object.free()
+    }
+
+    public func testDefaultEnumArgumentTranslatedViaClassDB() {
+        // Inspect the registered method metadata directly through Godot's ClassDB to prove the
+        // `.fast` enum default was evaluated to its raw value (7) — not its declaration order (1),
+        // not a zero literal — and that the argument slot is registered as the Mode enum, so the
+        // default genuinely lives in an enum-typed parameter rather than a bare integer.
+        let methods = ClassDB.classGetMethodList(class: "DefaultArgObject", noInheritance: true)
+
+        guard let describe = methods.first(where: { String($0["name"]) == "describe" }) else {
+            fail("Expected to find a 'describe' method on DefaultArgObject")
+            return
+        }
+
+        guard let defaultArgs = describe["default_args"]?.to(VariantArray.self) else {
+            fail("'describe' method is missing default_args")
+            return
+        }
+
+        // Trailing defaults only: prefix = "mode", mode = .fast
+        assertEqual(defaultArgs.count, 2)
+        assertEqual(defaultArgs[0], Variant("mode"))
+        // .fast.rawValue == 7, while its ordinal position is 1. A registered value of 7 proves the
+        // enum case was resolved to its raw value, not stored as a literal/ordinal.
+        assertEqual(defaultArgs[1], Variant(DefaultArgObject.Mode.fast.rawValue))
+        assertEqual(defaultArgs[1], Variant(7))
+
+        // The `mode` argument must be registered as the Mode enum (class_name + classIsEnum usage).
+        guard let args = describe["args"]?.to(VariantArray.self),
+              let modeArg = args[1]?.to(VariantDictionary.self) else {
+            fail("'describe' method is missing argument metadata")
+            return
+        }
+
+        if let classV = modeArg["class_name"] {
+            assertEqual(String(classV), "DefaultArgObject.Mode")
+        } else {
+            fail("'mode' argument is missing a class_name")
+        }
+
+        if let flagsV = modeArg["usage"], let iflags = Int(flagsV) {
+            assertTrue(PropertyUsageFlags(rawValue: iflags).contains(.classIsEnum),
+                       "'mode' argument should have the classIsEnum usage flag")
+        } else {
+            fail("'mode' argument is missing usage flags")
+        }
     }
 
     public func testImplicitTypingOfUntypedObjectArray() {


### PR DESCRIPTION
Parameters with default values on `@Callable` methods are now surfaced to Godot as optional arguments, so callers may omit trailing arguments.

- Extract the longest contiguous run of trailing defaulted parameters in the macro and register them via a new `defaultArguments:` parameter on `_registerMethod`, populating `GDExtensionClassMethodInfo`'s previously hardcoded `default_argument_count`/`default_arguments` fields.
- The variant-call proxy falls back to the Swift default expression for any omitted trailing argument; the ptrcall path always receives a full list.
- Default values are evaluated to real Variants (enum cases resolve to their raw values), verified directly against Godot's ClassDB metadata.

Covered by macro snapshot tests and Godot integration tests, including string, optional-object (nil), and Int-backed enum defaults.