### PR TITLE
Relinquish framework RefCounted references on extension unload

### DIFF
--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -757,6 +757,57 @@ public func printSwiftGodotStats() {
 
 }
 
+/// Relinquishes SwiftGodot's references to the framework ``RefCounted`` objects
+/// it still holds, as part of the extension being unloaded.
+///
+/// SwiftGodot normally guarantees that the Swift wrapper destroys a RefCounted
+/// eventually: the wrapper keeps a reference and is pinned alive while Godot
+/// co-owns the object, so our release (and `object_destroy`) only runs once
+/// Godot's refcount falls to "just us". For objects Godot keeps alive until it
+/// shuts down — e.g. a `reload()`-ed `GDScript`, cached by the GDScript language
+/// until teardown — that release is forced into `Main::cleanup`, where Godot
+/// flushes its deferred-call queue *after* finalizing subsystems. Destroying a
+/// GDScript there crashes (`~GDScript` locks the already-gone language mutex).
+///
+/// Godot calls `extension_deinitialize` while those subsystems are still alive,
+/// which is the last safe point to act. Here we drop our reference to each held
+/// framework RefCounted and detach its wrapper, so:
+/// - objects Godot still co-owns are left for Godot to destroy in its own order;
+/// - objects we solely own are destroyed now, in the safe window;
+/// - no wrapper deinit re-enters the deferred queue afterwards.
+///
+/// It operates only on currently-live objects and holds no persistent state, so
+/// it is safe to call on every unload, including the editor's load/scan/unload
+/// cycle and subsequent reloads.
+func relinquishFrameworkReferencesForUnload() {
+    // Anything already queued is safe to release now while the engine is alive.
+    releasePendingObjects()
+
+    let snapshot: [(GodotNativeObjectPointer, WrappedReference)] = tableLock.withLock {
+        liveFrameworkObjects.map { ($0.key, $0.value) }
+    }
+    for (handle, reference) in snapshot {
+        // Only RefCounted participate in our reference bookkeeping; other
+        // framework objects (singletons, etc.) are owned by Godot.
+        guard let wrapped = reference.value, wrapped is RefCounted, wrapped.handle == handle else {
+            continue
+        }
+
+        // Detach the wrapper first so its eventual deinit becomes a no-op and
+        // cannot re-queue this handle, and drop it from the pending queue.
+        wrapped.handle = nil
+        removePendingReleaseHandle(handle)
+
+        var result = false
+        gi.object_method_bind_ptrcall(RefCounted.method_unreference, handle, nil, &result)
+        // result == true means we held the last reference; destroying here is
+        // safe because the engine has not yet finalized its subsystems.
+        if result {
+            gi.object_destroy(handle)
+        }
+    }
+}
+
 // Lock for accessing the above
 var tableLock = NIOLock()
 

--- a/Sources/SwiftGodotRuntime/EntryPoint.swift
+++ b/Sources/SwiftGodotRuntime/EntryPoint.swift
@@ -197,7 +197,11 @@ func extension_initialize(userData: UnsafeMutableRawPointer?, l: GDExtensionInit
 
 // Extension deinitialization callback
 func extension_deinitialize(userData: UnsafeMutableRawPointer?, l: GDExtensionInitializationLevel) {
-    //print ("SWIFT: extension_deinitialize")
+    // The extension is being unloaded while the engine's subsystems are still
+    // alive. Relinquish our references to held framework RefCounted objects now,
+    // so the engine reclaims them in its own ordered teardown and we never run
+    // object destruction during the later, unsafe `Main::cleanup` flush.
+    relinquishFrameworkReferencesForUnload()
     guard let userData else { return }
     let key = OpaquePointer(userData)
     guard let callback = extensionDeInitCallbacks[key] else { return }


### PR DESCRIPTION
A GDScript created and reload()-ed from Swift is cached by the GDScript language until engine shutdown, so it stays at refcount >= 2 for the whole run. That pins its Swift wrapper alive (strongify), which means SwiftGodot's own reference is only released once Godot's refcount falls to "just us" — which, for these engine-pinned objects, happens during Main::cleanup. There, Godot flushes its deferred-call queue after finalizing subsystems, so our deferred object_destroy runs ~GDScript against the already-gone GDScript language mutex and crashes (SIGSEGV). The CallScriptTests suite was the first to create GDScripts and so surfaced it, but any app that creates+reloads a GDScript and quits hits the same crash.

Fix it at the authoritative signal: when Godot calls extension_deinitialize the engine subsystems are still alive, so relinquish our references to the framework RefCounted objects we still hold there. Objects Godot co-owns are left for the engine to destroy in its own order; objects we solely own are destroyed now, in the safe window; detaching each wrapper first keeps its later deinit from re-queueing the handle. This operates only on live state and holds no persistent flag, so it is correct across the editor's load/scan/unload cycle and reloads.