### PR TITLE
Auto-convert Swift names to Godot convention via SPM trait

### DIFF
--- a/.github/workflows/docc.yml
+++ b/.github/workflows/docc.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Xcode 26.5 bundles Swift 6.3.2, which satisfies the package's
+      # swift-tools-version 6.3 (Xcode 26.2/26.3 only ship Swift 6.2.x).
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.0"
+          xcode-version: "26.5"
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import CompilerPluginSupport
 import PackageDescription
 
 let withMultiProcessTrait = "with_multi_process"
+let automaticGodotNamingConventionTrait = "automatic_godot_naming_convention"
 
 // Products define the executables and libraries a package produces, and make them visible to other packages.
 var products: [Product] = [
@@ -220,6 +221,7 @@ var targets: [Target] = [
         swiftSettings: [
             .define("CUSTOM_BUILTIN_IMPLEMENTATIONS"),
             .define("SWIFTGODOT_WITH_MULTI_PROCESS", .when(traits: [withMultiProcessTrait])),
+            .define("SWIFTGODOT_GODOT_NAMING", .when(traits: [automaticGodotNamingConventionTrait])),
             .unsafeFlags(
                 [
                     "-suppress-warnings",
@@ -242,6 +244,7 @@ var targets: [Target] = [
             .swiftLanguageMode(.v5),
             .define("CUSTOM_BUILTIN_IMPLEMENTATIONS"),
             .define("SWIFTGODOT_WITH_MULTI_PROCESS", .when(traits: [withMultiProcessTrait])),
+            .define("SWIFTGODOT_GODOT_NAMING", .when(traits: [automaticGodotNamingConventionTrait])),
             .unsafeFlags(["-suppress-warnings"])
         ],
         plugins: ["CodeGeneratorPlugin"]
@@ -318,6 +321,11 @@ let package = Package(
             name: withMultiProcessTrait,
             description: "Use multi-process-safe code generation with reinitialization support."
         ),
+        .trait(
+            name: automaticGodotNamingConventionTrait,
+            description: "Automatically convert Swift identifiers registered with Godot to Godot's naming convention (snake_case members, UPPER_SNAKE_CASE enum constants)."
+        ),
+        .default(enabledTraits: [automaticGodotNamingConventionTrait]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),

--- a/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
@@ -16,6 +16,12 @@ In Swift, function definitions take parameter names, and sometimes this
 parameter name is omitted for the first argument. Instead of
 `myNode.add_child(box)`, you would use `myNode.addChild (node: box)`.
 
+The reverse also applies to the symbols *you* expose to Godot: the methods,
+properties, signals, arguments, and enum cases you register with `@Callable`,
+`@Export`, `@Signal`, and friends are automatically translated to Godot's
+naming convention. See <doc:NamingConvention> for the details and for how to
+turn this off.
+
 ## Global Scope
 
 Global functions and some constants had to be moved to classes to avoid

--- a/Sources/SwiftGodot/SwiftGodot.docc/NamingConvention.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/NamingConvention.md
@@ -1,0 +1,90 @@
+# Godot Naming Convention
+
+How SwiftGodot exposes your Swift symbols to Godot, and how to turn the
+automatic conversion off.
+
+## Overview
+
+Swift and Godot use different naming conventions. Swift uses `camelCase` for
+methods, properties, and enum cases; Godot uses `snake_case` for methods,
+properties, signals, and arguments, and `UPPER_SNAKE_CASE` for enum constants.
+(Class names are `PascalCase` in both, so they are never changed.)
+
+By default SwiftGodot bridges this gap for you: every symbol you register with
+the engine is exposed under Godot's convention. This is controlled by the
+`automatic_godot_naming_convention` package trait, which is **enabled by
+default**.
+
+### What gets converted
+
+With the trait enabled (the default), the names Godot sees are:
+
+| Swift declaration | Exposed to Godot as |
+| --- | --- |
+| `@Callable func computeSpeedValue(targetNode:)` | method `compute_speed_value`, argument `target_node` |
+| `@Export var maxHealthPoints: Int` | property `max_health_points` (+ `get_max_health_points` / `set_max_health_points`) |
+| `@Signal var playerDidJump: SignalWithArguments<Int>` | signal `player_did_jump` |
+| `@Rpc func syncWorldState()` | RPC method `sync_world_state` |
+| `enum DamageKind: Int { case fireDamage }` | constant `FIRE_DAMAGE` |
+| `class PlayerShip: Node` | class `PlayerShip` (unchanged) |
+
+Single-word identifiers are unchanged (`func run()` stays `run`), and the
+conversion is idempotent, so names that are already in Godot style (such as
+`get_health` or `_ready`) are left as-is.
+
+This matters whenever you reference a symbol by its string name — for example
+calling it from GDScript, or via ``Object/call(method:_:)``,
+``Object/connect(signal:callable:flags:)``, or ``Node/rpc(method:)``. Use the
+Godot name in those cases:
+
+```gdscript
+# GDScript calling a Swift @Callable `func computeSpeedValue(...)`
+node.compute_speed_value(target)
+```
+
+## Disabling the conversion
+
+If you are upgrading an existing project that already exposes Swift names
+verbatim (the behavior before this trait existed), or you simply prefer to
+control every Godot name yourself, disable the trait in the package that
+depends on SwiftGodot.
+
+Specify the `traits:` argument on the dependency and omit the defaults. Because
+`automatic_godot_naming_convention` is SwiftGodot's only default trait, an empty
+trait set turns it off:
+
+```swift
+// Package.swift
+.package(
+    url: "https://github.com/migueldeicaza/SwiftGodot",
+    from: "0.0.0",
+    traits: []            // opt out of default traits -> no automatic conversion
+)
+```
+
+To keep some traits while disabling the naming conversion, list exactly the ones
+you want (still omitting `automatic_godot_naming_convention`):
+
+```swift
+.package(
+    url: "https://github.com/migueldeicaza/SwiftGodot",
+    from: "0.0.0",
+    traits: ["with_multi_process"]
+)
+```
+
+In Xcode, open the package dependency's settings and toggle **Package Traits**;
+from the command line you can build with `swift build --disable-default-traits`
+(or `--traits …` to choose an explicit set).
+
+With the trait disabled, **all** of the conversions above are turned off and
+your Swift identifiers are registered with Godot exactly as written
+(`computeSpeedValue`, `maxHealthPoints`, `playerDidJump`, `fireDamage`, …). This
+is a single, package-wide switch — it is not configurable per declaration.
+
+## Deprecated: `@Callable(autoSnakeCase:)`
+
+Before this trait, ``Callable`` accepted an `autoSnakeCase` argument to opt a
+single method into `snake_case` conversion. Naming is now governed entirely by
+the `automatic_godot_naming_convention` trait, so the argument is ignored and
+deprecated. Use plain `@Callable` and control naming with the trait instead.

--- a/Sources/SwiftGodot/SwiftGodot.docc/RemoteProcedureCalls.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/RemoteProcedureCalls.md
@@ -169,7 +169,9 @@ rpcId(peerId, StringName("take_damage"), Variant(10))
 ```
 
 Note that method names are converted to snake_case when exposed to Godot,
-so `syncPosition` becomes `sync_position` in RPC calls.
+so `syncPosition` becomes `sync_position` in RPC calls. This is governed by the
+`automatic_godot_naming_convention` package trait (on by default); see
+<doc:NamingConvention> to change it.
 
 ## Requirements
 

--- a/Sources/SwiftGodot/SwiftGodot.docc/Signals.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Signals.md
@@ -90,7 +90,9 @@ Godot signals using snake-case.
 
 So for example if you were to declare a signal called 'livesChanged' it
 would be exposed to Godot as 'lives_changed', and to your Swift code as
-'livesChanged'.
+'livesChanged'. This conversion is governed by the
+`automatic_godot_naming_convention` package trait (on by default); see
+<doc:NamingConvention> for details and how to disable it.
 
 ### Signals with parameters
 

--- a/Sources/SwiftGodot/SwiftGodot.docc/SwiftGodot.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/SwiftGodot.md
@@ -33,6 +33,7 @@ Visual Studio on Linux, Mac and Windows:
 Going in depth with SwiftGodot:
 
 - <doc:Differences>
+- <doc:NamingConvention>
 - <doc:Variants>
 - <doc:Exports>
 - <doc:Signals>

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -89,7 +89,7 @@ class GodotMacroProcessor {
     }
 
     func processFunction(_ funcDecl: FunctionDeclSyntax) throws {
-        guard let callableAttribute = funcDecl.attributes.attribute(named: "Callable") else {
+        guard funcDecl.attributes.attribute(named: "Callable") != nil else {
             return
         }
 
@@ -104,22 +104,17 @@ class GodotMacroProcessor {
             generatePtrCall = true
         }
         
+        // The Swift identifier is emitted verbatim; the runtime applies the Godot
+        // naming convention (gated by the `automatic_godot_naming_convention` trait).
         let funcName = funcDecl.name.text
-        
-        let godotFuncName: String
-        if try callableAttribute.callableAutoSnakeCaseArgument {
-            godotFuncName = funcName.camelCaseToSnakeCase()
-        } else {
-            godotFuncName = funcName
-        }
-        
+
         let p = classInitializerPrinter
 
         let arguments = funcDecl
             .parameters
             .map { parameter in
                 let typename = parameter.type.trimmedDescription
-                return "SwiftGodotRuntime._argumentPropInfo(\(typename).self, name: \"\(parameter.internalName)\")"
+                return "SwiftGodotRuntime._argumentPropInfo(\(typename).self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention(\"\(parameter.internalName)\"))"
             }
             .joined(separator: ",\n")
 
@@ -160,8 +155,8 @@ class GodotMacroProcessor {
         p("SwiftGodotRuntime._registerMethod", .parentheses) {
             p("""
             className: className,
-            name: "\(godotFuncName)", 
-            flags: \(flags), 
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("\(funcName)")),
+            flags: \(flags),
             returnValue: SwiftGodotRuntime._returnValuePropInfo(\(returnTypename).self),    
             """)
             p("arguments: ", .square, afterBlock: ",") {
@@ -184,7 +179,7 @@ class GodotMacroProcessor {
             }
         }
         
-        try checkNameCollision(godotFuncName, for: DeclSyntax(funcDecl))
+        try checkNameCollision(funcName, for: DeclSyntax(funcDecl))
     }
 
     /// Processes a function marked with @Rpc to extract RPC configuration
@@ -193,7 +188,6 @@ class GodotMacroProcessor {
         guard let rpcAttribute = funcDecl.attributes.attribute(named: "Rpc") else { return }
 
         let funcName = funcDecl.name.text
-        let godotFuncName = funcName.camelCaseToSnakeCase()
 
         // Parse @Rpc arguments with defaults
         var mode = ".authority"
@@ -223,7 +217,7 @@ class GodotMacroProcessor {
 
         rpcConfigurations.append(RpcConfiguration(
             methodName: funcName,
-            godotMethodName: godotFuncName,
+            godotMethodName: funcName,
             mode: mode,
             callLocal: callLocal,
             transferMode: transferMode,
@@ -243,16 +237,16 @@ class GodotMacroProcessor {
 
         """
 
-        for config in rpcConfigurations {
+        for (index, config) in rpcConfigurations.enumerated() {
             result += """
+                let rpcConfigDictionary\(index) = GDictionary()
+                rpcConfigDictionary\(index)[Variant("rpc_mode")] = Variant(MultiplayerAPI.RPCMode\(config.mode).rawValue)
+                rpcConfigDictionary\(index)[Variant("call_local")] = Variant(\(config.callLocal))
+                rpcConfigDictionary\(index)[Variant("transfer_mode")] = Variant(MultiplayerPeer.TransferMode\(config.transferMode).rawValue)
+                rpcConfigDictionary\(index)[Variant("channel")] = Variant(\(config.transferChannel))
                 rpcConfig(
-                    method: StringName("\(config.godotMethodName)"),
-                    config: Variant([
-                        "rpc_mode": Variant(MultiplayerAPI.RPCMode\(config.mode).rawValue),
-                        "call_local": Variant(\(config.callLocal)),
-                        "transfer_mode": Variant(MultiplayerPeer.TransferMode\(config.transferMode).rawValue),
-                        "channel": Variant(\(config.transferChannel))
-                    ] as GDictionary)
+                    method: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("\(config.godotMethodName)")),
+                    config: Variant(rpcConfigDictionary\(index))
                 )
 
             """
@@ -307,14 +301,17 @@ class GodotMacroProcessor {
             // For the case where there is no setter, set the proxySetterName to the empty string
             let proxySetterName = needsSetter ? "_mproxy_set_\(varNameWithPrefix)" : ""
             let proxyGetterName = "_mproxy_get_\(varNameWithPrefix)"
-            let setterName = "set_\(varNameWithoutPrefix.camelCaseToSnakeCase())"
-            let getterName = "get_\(varNameWithoutPrefix.camelCaseToSnakeCase())"
-            
+            // Raw (pre-conversion) getter/setter identifiers. The runtime applies the
+            // Godot naming convention; these raw forms are used only for compile-time
+            // collision checks, which are unique within a type regardless of the trait.
+            let setterName = "set_\(varNameWithoutPrefix)"
+            let getterName = "get_\(varNameWithoutPrefix)"
+
             // Do not throw for read-only properties anymore; allow registration to proceed.
             // Keep building the args list as before.
             var args: [String] = [
                 "at: \\\(className).\(varNameWithPrefix)",
-                "name: \"\(varNameWithPrefix.camelCaseToSnakeCase())\""
+                "name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention(\"\(varNameWithPrefix)\")"
             ]
             
             if let hint = hintExpr?.trimmedDescription {
@@ -345,10 +342,13 @@ class GodotMacroProcessor {
                     p(argsStr)
                 }
                 let setterFunction = needsSetter ? "\(className).\(proxySetterName)" : "nil"
-                let setterNameArg = needsSetter ? "\"\(setterName)\"" : "StringName()"
+                // The Godot naming convention is applied to the property base name, then
+                // the standard get_/set_ prefix is added — keeping the prefix out of the
+                // converter so it never sees a mixed `get_camelCase` string.
+                let setterNameArg = needsSetter ? "StringName(\"set_\" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention(\"\(varNameWithoutPrefix)\"))" : "StringName()"
 
                 p("""
-                getterName: "\(getterName)\",
+                getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("\(varNameWithoutPrefix)")),
                 setterName: \(setterNameArg),
                 getterFunction: \(className).\(proxyGetterName),
                 setterFunction: \(setterFunction)
@@ -374,7 +374,6 @@ class GodotMacroProcessor {
             
             let nameWithPrefix = ips.identifier.text
             let name = String(nameWithPrefix.trimmingPrefix(prefix ?? ""))
-            let godotName = name.camelCaseToSnakeCase()
 
             guard let typeAnnotation = binding.typeAnnotation else {
                 throw GodotMacroError.signalMacroNoType(nameWithPrefix)
@@ -393,19 +392,19 @@ class GodotMacroProcessor {
                             if let s = seg.as(StringSegmentSyntax.self) { return s.content.text }
                             return nil
                         }.joined()
-                        parts.append("\"\(text)\"")
+                        parts.append("SwiftGodotRuntime._convertMemberNameToMatchGodotConvention(\"\(text)\")")
                     } else {
-                        parts.append(expr.trimmedDescription)
+                        parts.append("SwiftGodotRuntime._convertMemberNameToMatchGodotConvention(\(expr.trimmedDescription))")
                     }
                 }
                 namesExpr = "[" + parts.joined(separator: ", ") + "]"
             }
 
             classInitializerPrinter("""
-            \(typeName).register(as: \"\(godotName)\", in: className, names: \(namesExpr))
+            \(typeName).register(as: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention(\"\(name)\")), in: className, names: \(namesExpr))
             """)
-            
-            try checkNameCollision(godotName, for: DeclSyntax(varDecl))
+
+            try checkNameCollision(name, for: DeclSyntax(varDecl))
         }
     }
 

--- a/Sources/SwiftGodotMacroLibrary/SignalAttachmentMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SignalAttachmentMacro.swift
@@ -43,7 +43,7 @@ public struct SignalAttachmentMacro: AccessorMacro {
             }
             
             result.append("""
-            get { \(raw: type.trimmedDescription)(target: self, signalName: \"\(raw: identifier.camelCaseToSnakeCase())\") }
+            get { \(raw: type.trimmedDescription)(target: self, signalName: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention(\"\(raw: identifier)\")) }
             """)
         }
     

--- a/Sources/SwiftGodotRuntime/Core/ClassServices.swift
+++ b/Sources/SwiftGodotRuntime/Core/ClassServices.swift
@@ -30,10 +30,18 @@ import GDExtension
 /// ```
 public class ClassInfo<T:Object> {
     var name: StringName
-    
+
     /// Initializes a ClassInfo structure to register operations with Godot
     public init (name: StringName) {
         self.name = name
+    }
+
+    /// Applies the Godot naming convention to a symbol name (gated by the
+    /// `automatic_godot_naming_convention` trait). Idempotent for names that already follow the
+    /// convention, so manual registrations that pass snake_case names are
+    /// unaffected.
+    private func godotConventionName(_ name: StringName) -> StringName {
+        StringName(_convertMemberNameToMatchGodotConvention(String(name)))
     }
     
     /// Registers a signal on this type with the specified name and with the specified arguments.  To trigger
@@ -47,6 +55,7 @@ public class ClassInfo<T:Object> {
     ///  - name: the name we want to use to register the signal
     ///  - arguments: an array of PropInfo structures that describe each argument that must be passed to the signal
     public func registerSignal (name signalName: StringName, arguments: [PropInfo] = []) {
+        var signalName = godotConventionName(signalName)
         withUnsafeTemporaryAllocation(of: GDExtensionPropertyInfo.self, capacity: arguments.count) { bufferPtr in
             guard let ptr = bufferPtr.baseAddress else {
                 GD.print("Swift.withUnsafeTemporaryAllocation failed at `ClassInfo.registerSignal`")
@@ -127,6 +136,7 @@ public class ClassInfo<T:Object> {
     ///  - arguments: an array describing the parameters that this method takes
     ///  - function: this is a curried function that will be registered.   It will be invoked on the instance of your object
     public func registerMethod (name: StringName, flags: MethodFlags, returnValue: PropInfo?, arguments: [PropInfo], function: @escaping (T) -> (borrowing Arguments) -> Variant?) {
+        var name = godotConventionName(name)
         let argPtr = UnsafeMutablePointer<GDExtensionPropertyInfo>.allocate(capacity: arguments.count)
         defer { argPtr.deallocate() }
         let argMeta = UnsafeMutablePointer<GDExtensionClassMethodArgumentMetadata>.allocate(capacity: arguments.count)
@@ -198,9 +208,13 @@ public class ClassInfo<T:Object> {
     ///  - getter: the name of the method you have already registered and will provide the getter functionality
     ///  - setter: the name of the method you have already registered and will provide the setter functionality
     public func registerProperty (_ info: PropInfo, getter: StringName, setter: StringName) {
+        var info = info
+        info.propertyName = godotConventionName(info.propertyName)
+        var getter = godotConventionName(getter)
+        var setter = godotConventionName(setter)
         var pinfo = GDExtensionPropertyInfo ()
         pinfo = info.makeNativeStruct()
-        
+
         gi.classdb_register_extension_class_property (extensionInterface.getLibrary(), &self.name.content, &pinfo, &setter.content, &getter.content)
     }
     

--- a/Sources/SwiftGodotRuntime/Core/GodotNaming.swift
+++ b/Sources/SwiftGodotRuntime/Core/GodotNaming.swift
@@ -1,0 +1,106 @@
+//
+//  GodotNaming.swift
+//  SwiftGodot
+//
+//  Converts Swift identifiers to the naming convention Godot expects when a
+//  symbol is registered with the engine (methods, properties, signals,
+//  arguments, enum constants).
+//
+//  Behavior is controlled by the `automatic_godot_naming_convention` package trait, which
+//  defines `SWIFTGODOT_GODOT_NAMING`. These functions are intentionally NOT
+//  `@inlinable`: macro-expanded code in client modules always *calls* them, but
+//  the trait-dependent branch is resolved when this runtime is compiled, so a
+//  single switch in the package manifest flips behavior for every consumer.
+//
+
+// MARK: - Public, trait-gated entry points (called from macro-expanded code)
+
+#if SWIFTGODOT_GODOT_NAMING
+
+/// Internal API. Converts a Swift member identifier (method, property, signal,
+/// argument, getter/setter) to Godot's `snake_case` convention.
+public func _convertMemberNameToMatchGodotConvention(_ name: String) -> String {
+    _godotMemberCase(name)
+}
+
+/// Internal API. Converts a Swift enum case identifier to Godot's
+/// `UPPER_SNAKE_CASE` constant convention.
+public func _convertEnumCaseNameToMatchGodotConvention(_ name: String) -> String {
+    _godotEnumCase(name)
+}
+
+#else
+
+/// Internal API. With the `automatic_godot_naming_convention` trait disabled, names are passed
+/// through verbatim.
+public func _convertMemberNameToMatchGodotConvention(_ name: String) -> String {
+    name
+}
+
+/// Internal API. With the `automatic_godot_naming_convention` trait disabled, names are passed
+/// through verbatim.
+public func _convertEnumCaseNameToMatchGodotConvention(_ name: String) -> String {
+    name
+}
+
+#endif
+
+// MARK: - Conversion implementation (Foundation-free, always compiled, testable)
+
+/// camelCase / PascalCase → `snake_case`.
+///
+/// Reproduces the legacy regex behavior used by the generator and the macro
+/// library (`camelCaseToSnakeCase()` followed by the `2_D`/`3_D` fix-ups):
+///   acronym rule:   `([A-Z]+)([A-Z][a-z]|[0-9])` → `$1_$2`
+///   normal rule:    `([a-z0-9])([A-Z])`           → `$1_$2`
+///   then lowercase, then collapse `2_d`/`3_d` back to `2d`/`3d`.
+///
+/// Leading underscores are preserved (`_ready` stays `_ready`) and the function
+/// is idempotent on already-snake input (`get_my_prop` stays `get_my_prop`).
+func _godotMemberCase(_ s: String) -> String {
+    let chars = Array(s)
+    let n = chars.count
+    guard n > 0 else { return s }
+
+    func isUpper(_ c: Character) -> Bool { c >= "A" && c <= "Z" }
+    func isLower(_ c: Character) -> Bool { c >= "a" && c <= "z" }
+    func isDigit(_ c: Character) -> Bool { c >= "0" && c <= "9" }
+
+    var out: [Character] = []
+    out.reserveCapacity(n + n / 2)
+
+    for i in 0 ..< n {
+        let c = chars[i]
+        if i > 0 {
+            let prev = chars[i - 1]
+            if isUpper(c), isLower(prev) || isDigit(prev) {
+                // normal rule: lower/digit followed by an uppercase
+                out.append("_")
+            } else if isUpper(c), isUpper(prev), i + 1 < n, isLower(chars[i + 1]) {
+                // acronym rule (a): caps run then the cap that starts a new word
+                out.append("_")
+            } else if isDigit(c), isUpper(prev) {
+                // acronym rule (b): caps run immediately followed by a digit
+                out.append("_")
+            }
+        }
+        out.append(c)
+    }
+
+    var lowered = String(out.map { c -> Character in
+        if let ascii = c.asciiValue, ascii >= 65, ascii <= 90 {
+            return Character(UnicodeScalar(ascii + 32))
+        }
+        return c
+    })
+
+    // After lowercasing, both "2_D" and "2_d" are "2_d"; collapse the spurious split.
+    lowered = lowered.replacing("2_d", with: "2d")
+    lowered = lowered.replacing("3_d", with: "3d")
+    return lowered
+}
+
+/// camelCase / PascalCase → `UPPER_SNAKE_CASE` (Godot enum constant convention).
+func _godotEnumCase(_ s: String) -> String {
+    _godotMemberCase(s).uppercased()
+}

--- a/Sources/SwiftGodotRuntime/Core/SignalRegistration.swift
+++ b/Sources/SwiftGodotRuntime/Core/SignalRegistration.swift
@@ -13,7 +13,7 @@ public struct SignalWithNoArguments {
     public let arguments: [PropInfo] = [] // needed for registration in macro, but always []
     
     public init(_ signalName: String) {
-        name = StringName(signalName)
+        name = StringName(_convertMemberNameToMatchGodotConvention(signalName))
     }
 }
 
@@ -28,9 +28,9 @@ public struct SignalWith1Argument<Argument: _GodotBridgeable> {
         _ signalName: String,
         argument1Name: String? = nil
     ) {
-        name = StringName(signalName)
+        name = StringName(_convertMemberNameToMatchGodotConvention(signalName))
         arguments = [
-            PropInfo(propertyType: Argument.self, propertyName: .init(argument1Name ?? "arg1"))
+            PropInfo(propertyType: Argument.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument1Name ?? "arg1")))
         ]
     }
 }
@@ -50,10 +50,10 @@ public struct SignalWith2Arguments<
         argument1Name: String? = nil,
         argument2Name: String? = nil
     ) {
-        name = StringName(signalName)
+        name = StringName(_convertMemberNameToMatchGodotConvention(signalName))
         arguments = [
-            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
-            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
+            PropInfo(propertyType: Argument1.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument1Name ?? "arg1"))),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument2Name ?? "arg2"))),
         ]
     }
 }
@@ -75,11 +75,11 @@ public struct SignalWith3Arguments<
         argument2Name: String? = nil,
         argument3Name: String? = nil
     ) {
-        name = StringName(signalName)
+        name = StringName(_convertMemberNameToMatchGodotConvention(signalName))
         arguments = [
-            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
-            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
-            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
+            PropInfo(propertyType: Argument1.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument1Name ?? "arg1"))),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument2Name ?? "arg2"))),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument3Name ?? "arg3"))),
         ]
     }
 }
@@ -103,12 +103,12 @@ public struct SignalWith4Arguments<
         argument3Name: String? = nil,
         argument4Name: String? = nil
     ) {
-        name = StringName(signalName)
+        name = StringName(_convertMemberNameToMatchGodotConvention(signalName))
         arguments = [
-            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
-            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
-            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
-            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4"))
+            PropInfo(propertyType: Argument1.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument1Name ?? "arg1"))),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument2Name ?? "arg2"))),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument3Name ?? "arg3"))),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument4Name ?? "arg4")))
         ]
     }
 }
@@ -134,13 +134,13 @@ public struct SignalWith5Arguments<
         argument4Name: String? = nil,
         argument5Name: String? = nil
     ) {
-        name = StringName(signalName)
+        name = StringName(_convertMemberNameToMatchGodotConvention(signalName))
         arguments = [
-            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
-            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
-            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
-            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4")),
-            PropInfo(propertyType: Argument5.self, propertyName: .init(argument5Name ?? "arg5"))
+            PropInfo(propertyType: Argument1.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument1Name ?? "arg1"))),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument2Name ?? "arg2"))),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument3Name ?? "arg3"))),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument4Name ?? "arg4"))),
+            PropInfo(propertyType: Argument5.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument5Name ?? "arg5")))
         ]
     }
 }
@@ -168,14 +168,14 @@ public struct SignalWith6Arguments<
         argument5Name: String? = nil,
         argument6Name: String? = nil
     ) {
-        name = StringName(signalName)
+        name = StringName(_convertMemberNameToMatchGodotConvention(signalName))
         arguments = [
-            PropInfo(propertyType: Argument1.self, propertyName: .init(argument1Name ?? "arg1")),
-            PropInfo(propertyType: Argument2.self, propertyName: .init(argument2Name ?? "arg2")),
-            PropInfo(propertyType: Argument3.self, propertyName: .init(argument3Name ?? "arg3")),
-            PropInfo(propertyType: Argument4.self, propertyName: .init(argument4Name ?? "arg4")),
-            PropInfo(propertyType: Argument5.self, propertyName: .init(argument5Name ?? "arg5")),
-            PropInfo(propertyType: Argument6.self, propertyName: .init(argument6Name ?? "arg6"))
+            PropInfo(propertyType: Argument1.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument1Name ?? "arg1"))),
+            PropInfo(propertyType: Argument2.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument2Name ?? "arg2"))),
+            PropInfo(propertyType: Argument3.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument3Name ?? "arg3"))),
+            PropInfo(propertyType: Argument4.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument4Name ?? "arg4"))),
+            PropInfo(propertyType: Argument5.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument5Name ?? "arg5"))),
+            PropInfo(propertyType: Argument6.self, propertyName: .init(_convertMemberNameToMatchGodotConvention(argument6Name ?? "arg6")))
         ]
     }
 }

--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -636,7 +636,8 @@ where T: RawRepresentable & CaseIterable, T.RawValue == Int64 {
     withUnsafePointer(to: &className.content) { classPtr in
         withUnsafePointer(to: &enumName.content) { enumPtr in
             for v in type.allCases {
-                let keyString = String(describing: v)          // e.g. "foo", "bar"
+                // The Godot naming convention is applied (gated by the `automatic_godot_naming_convention` trait).
+                let keyString = _convertEnumCaseNameToMatchGodotConvention(String(describing: v))
                 var key   = StringName(keyString)
                 let value = v.rawValue                         // Int64
 
@@ -670,7 +671,8 @@ where T: RawRepresentable & CaseIterable, T.RawValue == Int {
     withUnsafePointer(to: &className.content) { classPtr in
         withUnsafePointer(to: &enumName.content) { enumPtr in
             for v in type.allCases {
-                let keyString = String(describing: v)          // e.g. "foo", "bar"
+                // The Godot naming convention is applied (gated by the `automatic_godot_naming_convention` trait).
+                let keyString = _convertEnumCaseNameToMatchGodotConvention(String(describing: v))
                 var key   = StringName(keyString)
                 let value = v.rawValue                         // Int64
 
@@ -710,7 +712,8 @@ where T: RawRepresentable & CaseIterable, T.RawValue: BinaryInteger {
     withUnsafePointer(to: &className.content) { classPtr in
         withUnsafePointer(to: &enumName.content) { enumPtr in
             for v in type.allCases {
-                let keyString = String(describing: v)          // e.g. "foo", "bar"
+                // The Godot naming convention is applied (gated by the `automatic_godot_naming_convention` trait).
+                let keyString = _convertEnumCaseNameToMatchGodotConvention(String(describing: v))
                 var key   = StringName(keyString)
                 let value = Int64(v.rawValue)
 

--- a/Sources/SwiftGodotRuntime/MacroDefs.swift
+++ b/Sources/SwiftGodotRuntime/MacroDefs.swift
@@ -18,7 +18,7 @@
 /// `_process` run in editor, making the class work like `@tool` annotated script in GDScript
 ///
 @attached(member,
-          names: named (_initializeClass), named(classInitializer), named (implementedOverrides))
+          names: named (_initializeClass), named(classInitializer), named (implementedOverrides), named(_before_ready))
 public macro Godot(_ behavior: ClassBehavior = .gameplay) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotMacro")
 
 public enum ClassBehavior: Int {
@@ -32,9 +32,19 @@ public enum ClassBehavior: Int {
 ///
 /// The parameters and returns type of the function must be `_GodotBridgeable`.
 ///
-/// - Parameter autoSnakeCase: if `true` (default value is `false`), the function name will be automatically translated from `camelCase` to `snake_case` when exposed to Godot
+/// The name exposed to Godot follows the engine's naming convention (`snake_case`)
+/// when the `automatic_godot_naming_convention` package trait is enabled (the default). Disable the
+/// trait to expose Swift identifiers verbatim.
 @attached(peer, names: prefixed(_mproxy_), prefixed(_pproxy_))
-public macro Callable(autoSnakeCase: Bool = false) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
+public macro Callable() = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
+
+/// Exposes the function to the Godot runtime.
+///
+/// - Parameter autoSnakeCase: Ignored. Naming is now controlled by the
+///   `automatic_godot_naming_convention` package trait.
+@available(*, deprecated, message: "Naming is now controlled by the `automatic_godot_naming_convention` package trait; the `autoSnakeCase` argument is ignored. Use `@Callable` without arguments.")
+@attached(peer, names: prefixed(_mproxy_), prefixed(_pproxy_))
+public macro Callable(autoSnakeCase: Bool) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
 
 /// Exposes a property or variable to the Godot runtime
 ///

--- a/Sources/SwiftGodotRuntime/MacroIntegration/MacroGodotPropertyPropInfo.swift
+++ b/Sources/SwiftGodotRuntime/MacroIntegration/MacroGodotPropertyPropInfo.swift
@@ -259,7 +259,9 @@ where T: RawRepresentable, T: CaseIterable, T.RawValue: BinaryInteger {
     type
         .allCases
         .map {
-            "\($0):\($0.rawValue)"
+            // The case name follows the Godot naming convention (gated by the
+            // `automatic_godot_naming_convention` trait) so it matches the registered constant.
+            "\(_convertEnumCaseNameToMatchGodotConvention(String(describing: $0))):\($0.rawValue)"
         }
         .joined(separator: ",")
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotEnumRegistrationTests.testRegistersNestedEnumAlongsideExportedProperty.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotEnumRegistrationTests.testRegistersNestedEnumAlongsideExportedProperty.swift
@@ -45,13 +45,13 @@ class Player: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Player.state,
-                name: "state",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("state"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_state",
-            setterName: "set_state",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("state")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("state")),
             getterFunction: Player._mproxy_get_state,
             setterFunction: Player._mproxy_set_state
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArrayIntGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArrayIntGodotMacro.swift
@@ -40,13 +40,13 @@ class SomeNode: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \SomeNode.someNumbers,
-                name: "some_numbers",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someNumbers"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_some_numbers",
-            setterName: "set_some_numbers",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someNumbers")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someNumbers")),
             getterFunction: SomeNode._mproxy_get_someNumbers,
             setterFunction: SomeNode._mproxy_set_someNumbers
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArraysIntGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportArraysIntGodotMacro.swift
@@ -62,13 +62,13 @@ class SomeNode: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \SomeNode.someNumbers,
-                name: "some_numbers",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someNumbers"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_some_numbers",
-            setterName: "set_some_numbers",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someNumbers")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someNumbers")),
             getterFunction: SomeNode._mproxy_get_someNumbers,
             setterFunction: SomeNode._mproxy_set_someNumbers
         )
@@ -76,13 +76,13 @@ class SomeNode: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \SomeNode.someOtherNumbers,
-                name: "some_other_numbers",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someOtherNumbers"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_some_other_numbers",
-            setterName: "set_some_other_numbers",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someOtherNumbers")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someOtherNumbers")),
             getterFunction: SomeNode._mproxy_get_someOtherNumbers,
             setterFunction: SomeNode._mproxy_set_someOtherNumbers
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGenericArrayStringGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportGenericArrayStringGodotMacro.swift
@@ -40,13 +40,13 @@ class SomeNode: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \SomeNode.greetings,
-                name: "greetings",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("greetings"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_greetings",
-            setterName: "set_greetings",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("greetings")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("greetings")),
             getterFunction: SomeNode._mproxy_get_greetings,
             setterFunction: SomeNode._mproxy_set_greetings
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportVariantArray.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testExportVariantArray.swift
@@ -40,13 +40,13 @@ class SomeNode: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \SomeNode.someArray,
-                name: "some_array",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someArray"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_some_array",
-            setterName: "set_some_array",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someArray")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("someArray")),
             getterFunction: SomeNode._mproxy_get_someArray,
             setterFunction: SomeNode._mproxy_set_someArray
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTwoStringArrays.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTwoStringArrays.swift
@@ -63,13 +63,13 @@ class ArrayTest: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \ArrayTest.firstNames,
-                name: "first_names",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("firstNames"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_first_names",
-            setterName: "set_first_names",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("firstNames")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("firstNames")),
             getterFunction: ArrayTest._mproxy_get_firstNames,
             setterFunction: ArrayTest._mproxy_set_firstNames
         )
@@ -77,13 +77,13 @@ class ArrayTest: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \ArrayTest.lastNames,
-                name: "last_names",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("lastNames"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_last_names",
-            setterName: "set_last_names",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("lastNames")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("lastNames")),
             getterFunction: ArrayTest._mproxy_get_lastNames,
             setterFunction: ArrayTest._mproxy_set_lastNames
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTypedArray.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportCollectionTests.testGodotExportTypedArray.swift
@@ -40,13 +40,13 @@ class SomeNode: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \SomeNode.greetings,
-                name: "greetings",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("greetings"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_greetings",
-            setterName: "set_greetings",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("greetings")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("greetings")),
             getterFunction: SomeNode._mproxy_get_greetings,
             setterFunction: SomeNode._mproxy_set_greetings
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportEnumTests.testExportEnumGodot.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportEnumTests.testExportEnumGodot.swift
@@ -68,13 +68,13 @@ class SomeNode: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \SomeNode.demo,
-                name: "demo",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("demo"),
                 userHint: .enum,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_demo",
-            setterName: "set_demo",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("demo")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("demo")),
             getterFunction: SomeNode._mproxy_get_demo,
             setterFunction: SomeNode._mproxy_set_demo
         )
@@ -82,13 +82,13 @@ class SomeNode: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \SomeNode.demo64,
-                name: "demo64",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("demo64"),
                 userHint: .enum,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_demo64",
-            setterName: "set_demo64",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("demo64")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("demo64")),
             getterFunction: SomeNode._mproxy_get_demo64,
             setterFunction: SomeNode._mproxy_set_demo64
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
@@ -62,13 +62,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vin,
-                name: "vin",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_vin",
-            setterName: "set_vin",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin")),
             getterFunction: Car._mproxy_get_vin,
             setterFunction: Car._mproxy_set_vin
         )
@@ -77,13 +77,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.year,
-                name: "year",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_year",
-            setterName: "set_year",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year")),
             getterFunction: Car._mproxy_get_year,
             setterFunction: Car._mproxy_set_year
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesTypedArrayPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupOnlyProducesTypedArrayPropertiesWithPrefixes_whenPropertiesAppearAfterexportGroup.swift
@@ -62,13 +62,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vins,
-                name: "vins",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_vins",
-            setterName: "set_vins",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins")),
             getterFunction: Car._mproxy_get_vins,
             setterFunction: Car._mproxy_set_vins
         )
@@ -77,13 +77,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.years,
-                name: "years",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_years",
-            setterName: "set_years",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years")),
             getterFunction: Car._mproxy_get_years,
             setterFunction: Car._mproxy_set_years
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenMixingTypedArrayTypedArrayAndNormalVariableProperties.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenMixingTypedArrayTypedArrayAndNormalVariableProperties.swift
@@ -195,13 +195,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.name,
-                name: "name",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("name"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_name",
-            setterName: "set_name",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("name")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("name")),
             getterFunction: Garage._mproxy_get_name,
             setterFunction: Garage._mproxy_set_name
         )
@@ -209,13 +209,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.rating,
-                name: "rating",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("rating"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_rating",
-            setterName: "set_rating",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("rating")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("rating")),
             getterFunction: Garage._mproxy_get_rating,
             setterFunction: Garage._mproxy_set_rating
         )
@@ -224,13 +224,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.reviews,
-                name: "reviews",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("reviews"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_reviews",
-            setterName: "set_reviews",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("reviews")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("reviews")),
             getterFunction: Garage._mproxy_get_reviews,
             setterFunction: Garage._mproxy_set_reviews
         )
@@ -238,13 +238,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.checkIns,
-                name: "check_ins",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("checkIns"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_check_ins",
-            setterName: "set_check_ins",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("checkIns")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("checkIns")),
             getterFunction: Garage._mproxy_get_checkIns,
             setterFunction: Garage._mproxy_set_checkIns
         )
@@ -252,13 +252,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.address,
-                name: "address",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("address"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_address",
-            setterName: "set_address",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("address")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("address")),
             getterFunction: Garage._mproxy_get_address,
             setterFunction: Garage._mproxy_set_address
         )
@@ -267,13 +267,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.daysOfOperation,
-                name: "days_of_operation",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("daysOfOperation"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_days_of_operation",
-            setterName: "set_days_of_operation",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("daysOfOperation")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("daysOfOperation")),
             getterFunction: Garage._mproxy_get_daysOfOperation,
             setterFunction: Garage._mproxy_set_daysOfOperation
         )
@@ -281,13 +281,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.hours,
-                name: "hours",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("hours"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_hours",
-            setterName: "set_hours",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("hours")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("hours")),
             getterFunction: Garage._mproxy_get_hours,
             setterFunction: Garage._mproxy_set_hours
         )
@@ -295,13 +295,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.insuranceProvidersAccepted,
-                name: "insurance_providers_accepted",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("insuranceProvidersAccepted"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_insurance_providers_accepted",
-            setterName: "set_insurance_providers_accepted",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("insuranceProvidersAccepted")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("insuranceProvidersAccepted")),
             getterFunction: Garage._mproxy_get_insuranceProvidersAccepted,
             setterFunction: Garage._mproxy_set_insuranceProvidersAccepted
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
@@ -107,13 +107,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vin,
-                name: "vin",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_vin",
-            setterName: "set_vin",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin")),
             getterFunction: Car._mproxy_get_vin,
             setterFunction: Car._mproxy_set_vin
         )
@@ -122,13 +122,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.year,
-                name: "year",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_year",
-            setterName: "set_year",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year")),
             getterFunction: Car._mproxy_get_year,
             setterFunction: Car._mproxy_set_year
         )
@@ -136,13 +136,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.make,
-                name: "make",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_make",
-            setterName: "set_make",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make")),
             getterFunction: Car._mproxy_get_make,
             setterFunction: Car._mproxy_set_make
         )
@@ -150,13 +150,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.model,
-                name: "model",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_model",
-            setterName: "set_model",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model")),
             getterFunction: Car._mproxy_get_model,
             setterFunction: Car._mproxy_set_model
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -63,13 +63,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.make,
-                name: "make",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_make",
-            setterName: "set_make",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make")),
             getterFunction: Car._mproxy_get_make,
             setterFunction: Car._mproxy_set_make
         )
@@ -77,13 +77,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.model,
-                name: "model",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_model",
-            setterName: "set_model",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model")),
             getterFunction: Car._mproxy_get_model,
             setterFunction: Car._mproxy_set_model
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -62,13 +62,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vin,
-                name: "vin",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_vin",
-            setterName: "set_vin",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin")),
             getterFunction: Car._mproxy_get_vin,
             setterFunction: Car._mproxy_set_vin
         )
@@ -76,13 +76,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.year,
-                name: "year",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_year",
-            setterName: "set_year",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year")),
             getterFunction: Car._mproxy_get_year,
             setterFunction: Car._mproxy_set_year
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithDifferentPrefixes_whenPropertiesAppearAfterDifferentexportGroup.swift
@@ -107,13 +107,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vins,
-                name: "vins",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_vins",
-            setterName: "set_vins",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins")),
             getterFunction: Car._mproxy_get_vins,
             setterFunction: Car._mproxy_set_vins
         )
@@ -122,13 +122,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.years,
-                name: "years",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_years",
-            setterName: "set_years",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years")),
             getterFunction: Car._mproxy_get_years,
             setterFunction: Car._mproxy_set_years
         )
@@ -136,13 +136,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.makes,
-                name: "makes",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("makes"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_makes",
-            setterName: "set_makes",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("makes")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("makes")),
             getterFunction: Car._mproxy_get_makes,
             setterFunction: Car._mproxy_set_makes
         )
@@ -150,13 +150,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.models,
-                name: "models",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("models"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_models",
-            setterName: "set_models",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("models")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("models")),
             getterFunction: Car._mproxy_get_models,
             setterFunction: Car._mproxy_set_models
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -62,13 +62,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vins,
-                name: "vins",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_vins",
-            setterName: "set_vins",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins")),
             getterFunction: Car._mproxy_get_vins,
             setterFunction: Car._mproxy_set_vins
         )
@@ -77,13 +77,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.years,
-                name: "years",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_years",
-            setterName: "set_years",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years")),
             getterFunction: Car._mproxy_get_years,
             setterFunction: Car._mproxy_set_years
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupProducesTypedArrayPropertiesWithoutPrefixes_whenAllPropertiesAppearAfterexportGroup.swift
@@ -62,13 +62,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vins,
-                name: "vins",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_vins",
-            setterName: "set_vins",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vins")),
             getterFunction: Car._mproxy_get_vins,
             setterFunction: Car._mproxy_set_vins
         )
@@ -76,13 +76,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.years,
-                name: "years",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_years",
-            setterName: "set_years",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("years")),
             getterFunction: Car._mproxy_get_years,
             setterFunction: Car._mproxy_set_years
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefix.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefix.swift
@@ -63,13 +63,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vehicle_make,
-                name: "vehicle_make",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vehicle_make"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_make",
-            setterName: "set_make",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make")),
             getterFunction: Car._mproxy_get_vehicle_make,
             setterFunction: Car._mproxy_set_vehicle_make
         )
@@ -77,13 +77,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vehicle_model,
-                name: "vehicle_model",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vehicle_model"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_model",
-            setterName: "set_model",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model")),
             getterFunction: Car._mproxy_get_vehicle_model,
             setterFunction: Car._mproxy_set_vehicle_model
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingCollectionExports.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingCollectionExports.swift
@@ -41,13 +41,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.bar,
-                name: "bar",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("bar"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_bar",
-            setterName: "set_bar",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("bar")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("bar")),
             getterFunction: Garage._mproxy_get_bar,
             setterFunction: Garage._mproxy_set_bar
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingExports.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithNoMatchingExports.swift
@@ -41,13 +41,13 @@ class Garage: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Garage.bar,
-                name: "bar",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("bar"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_bar",
-            setterName: "set_bar",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("bar")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("bar")),
             getterFunction: Garage._mproxy_get_bar,
             setterFunction: Garage._mproxy_set_bar
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingCollectionExport.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingCollectionExport.swift
@@ -63,13 +63,13 @@ public class Issue353: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Issue353.prefix1_prefixed_bool,
-                name: "prefix1_prefixed_bool",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("prefix1_prefixed_bool"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get__prefixed_bool",
-            setterName: "set__prefixed_bool",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("_prefixed_bool")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("_prefixed_bool")),
             getterFunction: Issue353._mproxy_get_prefix1_prefixed_bool,
             setterFunction: Issue353._mproxy_set_prefix1_prefixed_bool
         )
@@ -77,13 +77,13 @@ public class Issue353: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Issue353.non_prefixed_bool,
-                name: "non_prefixed_bool",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("non_prefixed_bool"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_non_prefixed_bool",
-            setterName: "set_non_prefixed_bool",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("non_prefixed_bool")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("non_prefixed_bool")),
             getterFunction: Issue353._mproxy_get_non_prefixed_bool,
             setterFunction: Issue353._mproxy_set_non_prefixed_bool
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingExport.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportGroupTests.testGodotExportGroupWithPrefixTerminatedWithOneMatchingExport.swift
@@ -63,13 +63,13 @@ public class Issue353: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Issue353.prefix1_prefixed_bool,
-                name: "prefix1_prefixed_bool",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("prefix1_prefixed_bool"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get__prefixed_bool",
-            setterName: "set__prefixed_bool",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("_prefixed_bool")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("_prefixed_bool")),
             getterFunction: Issue353._mproxy_get_prefix1_prefixed_bool,
             setterFunction: Issue353._mproxy_set_prefix1_prefixed_bool
         )
@@ -77,13 +77,13 @@ public class Issue353: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Issue353.non_prefixed_bool,
-                name: "non_prefixed_bool",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("non_prefixed_bool"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_non_prefixed_bool",
-            setterName: "set_non_prefixed_bool",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("non_prefixed_bool")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("non_prefixed_bool")),
             getterFunction: Issue353._mproxy_get_non_prefixed_bool,
             setterFunction: Issue353._mproxy_set_non_prefixed_bool
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportSubroupTests.testGodotExportSubgroupWithAndWithoutPrefixWithGroup.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotExportSubroupTests.testGodotExportSubgroupWithAndWithoutPrefixWithGroup.swift
@@ -130,13 +130,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.vin,
-                name: "vin",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_vin",
-            setterName: "set_vin",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("vin")),
             getterFunction: Car._mproxy_get_vin,
             setterFunction: Car._mproxy_set_vin
         )
@@ -145,13 +145,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.ymms_year,
-                name: "ymms_year",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("ymms_year"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_year",
-            setterName: "set_year",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("year")),
             getterFunction: Car._mproxy_get_ymms_year,
             setterFunction: Car._mproxy_set_ymms_year
         )
@@ -159,13 +159,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.ymms_make,
-                name: "ymms_make",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("ymms_make"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_make",
-            setterName: "set_make",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("make")),
             getterFunction: Car._mproxy_get_ymms_make,
             setterFunction: Car._mproxy_set_ymms_make
         )
@@ -173,13 +173,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.ymms_model,
-                name: "ymms_model",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("ymms_model"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_model",
-            setterName: "set_model",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("model")),
             getterFunction: Car._mproxy_get_ymms_model,
             setterFunction: Car._mproxy_set_ymms_model
         )
@@ -187,13 +187,13 @@ class Car: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Car.ymms_series,
-                name: "ymms_series",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("ymms_series"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_series",
-            setterName: "set_series",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("series")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("series")),
             getterFunction: Car._mproxy_get_ymms_series,
             setterFunction: Car._mproxy_set_ymms_series
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableAutoSnakeCase.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableAutoSnakeCase.swift
@@ -100,7 +100,7 @@ class TestClass: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "no_need_to_snake_case_functions_now",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("noNeedToSnakeCaseFunctionsNow")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -118,7 +118,7 @@ class TestClass: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "or_is_there",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("or_is_there")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -136,7 +136,7 @@ class TestClass: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "thatIsHideous",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("thatIsHideous")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -154,7 +154,7 @@ class TestClass: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "defaultIsLegacyCompatible",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("defaultIsLegacyCompatible")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableReturningOptionalObject.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableReturningOptionalObject.swift
@@ -59,7 +59,7 @@ class OtherThing: SwiftGodot.Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "get_thing",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("get_thing")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(MyThing?.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableTakingOptionalBuiltin.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableTakingOptionalBuiltin.swift
@@ -127,11 +127,11 @@ class OtherThing: SwiftGodot.Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "do_string",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("do_string")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(String?.self, name: "value")
+                SwiftGodotRuntime._argumentPropInfo(String?.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("value"))
             ],
             function: OtherThing._mproxy_do_string,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -145,11 +145,11 @@ class OtherThing: SwiftGodot.Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "do_int",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("do_int")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Int?.self, name: "value")
+                SwiftGodotRuntime._argumentPropInfo(Int?.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("value"))
             ],
             function: OtherThing._mproxy_do_int,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -163,7 +163,7 @@ class OtherThing: SwiftGodot.Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "get_thing",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("get_thing")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(MyThing?.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableWithDefaultArguments.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableWithDefaultArguments.swift
@@ -88,13 +88,13 @@ class Greeter: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "greet",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("greet")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(String.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(String.self, name: "name"),
-                SwiftGodotRuntime._argumentPropInfo(String.self, name: "greeting"),
-                SwiftGodotRuntime._argumentPropInfo(Int.self, name: "times")
+                SwiftGodotRuntime._argumentPropInfo(String.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("name")),
+                SwiftGodotRuntime._argumentPropInfo(String.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("greeting")),
+                SwiftGodotRuntime._argumentPropInfo(Int.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("times"))
             ],
             defaultArguments: [
                 SwiftGodotRuntime._wrapDefaultArgument(SwiftGodotRuntime._wrapCallableResult("Hello" as String)),
@@ -112,11 +112,11 @@ class Greeter: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "attach",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("attach")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Node?.self, name: "node")
+                SwiftGodotRuntime._argumentPropInfo(Node?.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("node"))
             ],
             defaultArguments: [
                 SwiftGodotRuntime._wrapDefaultArgument(SwiftGodotRuntime._wrapCallableResult(nil as Node?))

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testClassSignal.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testClassSignal.swift
@@ -1,7 +1,7 @@
 class Hi: Node {
     class var int: SimpleSignal {
         get {
-            SimpleSignal(target: self, signalName: "int")
+            SimpleSignal(target: self, signalName: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("int"))
         }
     }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testDebugThing.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testDebugThing.swift
@@ -1,7 +1,7 @@
 class DebugThing: SwiftGodot.Object {
     var livesChanged: SignalWithArguments<Swift.Int> {
         get {
-            SignalWithArguments<Swift.Int>(target: self, signalName: "lives_changed")
+            SignalWithArguments<Swift.Int>(target: self, signalName: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("livesChanged"))
         }
     }
     func do_thing(value: SwiftGodot.Variant?) -> SwiftGodot.Variant? {
@@ -54,14 +54,14 @@ class DebugThing: SwiftGodot.Object {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-        SignalWithArguments<Swift.Int>.register(as: "lives_changed", in: className, names: [])
+        SignalWithArguments<Swift.Int>.register(as: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("livesChanged")), in: className, names: [])
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "do_thing",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("do_thing")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(SwiftGodot.Variant?.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(SwiftGodot.Variant?.self, name: "value")
+                SwiftGodotRuntime._argumentPropInfo(SwiftGodot.Variant?.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("value"))
             ],
             function: DebugThing._mproxy_do_thing,
             ptrFunction: { udata, classInstance, argsPtr, retValue in

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotMacro.swift
@@ -40,13 +40,13 @@ class Hi: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Hi.goodName,
-                name: "good_name",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("goodName"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_good_name",
-            setterName: "set_good_name",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("goodName")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("goodName")),
             getterFunction: Hi._mproxy_get_goodName,
             setterFunction: Hi._mproxy_set_goodName
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotUsage.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportGodotUsage.swift
@@ -40,13 +40,13 @@ class Hi: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Hi.goodName,
-                name: "good_name",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("goodName"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_good_name",
-            setterName: "set_good_name",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("goodName")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("goodName")),
             getterFunction: Hi._mproxy_get_goodName,
             setterFunction: Hi._mproxy_set_goodName
         )

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportedInt64.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportedInt64.swift
@@ -62,19 +62,19 @@ class Thing: SwiftGodot.Object {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \Thing.value,
-                name: "value",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("value"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_value",
-            setterName: "set_value",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("value")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("value")),
             getterFunction: Thing._mproxy_get_value,
             setterFunction: Thing._mproxy_set_value
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "get_some",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("get_some")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Int64.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncHavingVariantsInSignature.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncHavingVariantsInSignature.swift
@@ -51,11 +51,11 @@ private class TestNode: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "foo",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("foo")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Variant?.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Variant?.self, name: "variant")
+                SwiftGodotRuntime._argumentPropInfo(Variant?.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("variant"))
             ],
             function: TestNode._mproxy_foo,
             ptrFunction: { udata, classInstance, argsPtr, retValue in

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithObjectParams.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithObjectParams.swift
@@ -204,7 +204,7 @@ class Castro: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "deleteEpisode",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("deleteEpisode")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -222,11 +222,11 @@ class Castro: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "subscribe",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("subscribe")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Podcast.self, name: "podcast")
+                SwiftGodotRuntime._argumentPropInfo(Podcast.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("podcast"))
             ],
             function: Castro._mproxy_subscribe,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -240,11 +240,11 @@ class Castro: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "perhapsSubscribe",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("perhapsSubscribe")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Podcast?.self, name: "podcast")
+                SwiftGodotRuntime._argumentPropInfo(Podcast?.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("podcast"))
             ],
             function: Castro._mproxy_perhapsSubscribe,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -258,11 +258,11 @@ class Castro: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "removeSilences",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("removeSilences")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Variant.self, name: "from")
+                SwiftGodotRuntime._argumentPropInfo(Variant.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("from"))
             ],
             function: Castro._mproxy_removeSilences,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -276,11 +276,11 @@ class Castro: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "getLatestEpisode",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("getLatestEpisode")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Episode.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Podcast.self, name: "podcast")
+                SwiftGodotRuntime._argumentPropInfo(Podcast.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("podcast"))
             ],
             function: Castro._mproxy_getLatestEpisode,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -294,12 +294,12 @@ class Castro: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "queue",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("queue")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Podcast.self, name: "podcast"),
-                SwiftGodotRuntime._argumentPropInfo(Podcast.self, name: "preceedingPodcast")
+                SwiftGodotRuntime._argumentPropInfo(Podcast.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("podcast")),
+                SwiftGodotRuntime._argumentPropInfo(Podcast.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("preceedingPodcast"))
             ],
             function: Castro._mproxy_queue,
             ptrFunction: { udata, classInstance, argsPtr, retValue in

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithValueParams.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncWithValueParams.swift
@@ -121,12 +121,12 @@ class MathHelper: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "multiply",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("multiply")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Int.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Int.self, name: "a"),
-                SwiftGodotRuntime._argumentPropInfo(Int.self, name: "b")
+                SwiftGodotRuntime._argumentPropInfo(Int.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("a")),
+                SwiftGodotRuntime._argumentPropInfo(Int.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("b"))
             ],
             function: MathHelper._mproxy_multiply,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -140,12 +140,12 @@ class MathHelper: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "divide",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("divide")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Float.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Float.self, name: "a"),
-                SwiftGodotRuntime._argumentPropInfo(Float.self, name: "b")
+                SwiftGodotRuntime._argumentPropInfo(Float.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("a")),
+                SwiftGodotRuntime._argumentPropInfo(Float.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("b"))
             ],
             function: MathHelper._mproxy_divide,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -159,12 +159,12 @@ class MathHelper: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "areBothTrue",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("areBothTrue")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Bool.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Bool.self, name: "a"),
-                SwiftGodotRuntime._argumentPropInfo(Bool.self, name: "b")
+                SwiftGodotRuntime._argumentPropInfo(Bool.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("a")),
+                SwiftGodotRuntime._argumentPropInfo(Bool.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("b"))
             ],
             function: MathHelper._mproxy_areBothTrue,
             ptrFunction: { udata, classInstance, argsPtr, retValue in

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithArrayParam.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithArrayParam.swift
@@ -51,11 +51,11 @@ class MultiplierNode: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "multiply",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("multiply")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Int.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo([Int].self, name: "integers")
+                SwiftGodotRuntime._argumentPropInfo([Int].self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("integers"))
             ],
             function: MultiplierNode._mproxy_multiply,
             ptrFunction: { udata, classInstance, argsPtr, retValue in

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithArrayReturnTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithArrayReturnTypes.swift
@@ -62,7 +62,7 @@ class CallableCollectionsNode: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "get_ages",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("get_ages")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo([Int].self),
             arguments: [
@@ -80,7 +80,7 @@ class CallableCollectionsNode: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "get_markers",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("get_markers")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo([Marker3D].self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithGenericArrayParam.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithGenericArrayParam.swift
@@ -51,11 +51,11 @@ class MultiplierNode: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "multiply",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("multiply")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Int.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Array<Int>.self, name: "integers")
+                SwiftGodotRuntime._argumentPropInfo(Array<Int>.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("integers"))
             ],
             function: MultiplierNode._mproxy_multiply,
             ptrFunction: { udata, classInstance, argsPtr, retValue in

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithGenericArrayReturnTypes.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithGenericArrayReturnTypes.swift
@@ -62,7 +62,7 @@ class CallableCollectionsNode: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "get_ages",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("get_ages")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Array<Int>.self),
             arguments: [
@@ -80,7 +80,7 @@ class CallableCollectionsNode: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "get_markers",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("get_markers")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Array<Marker3D>.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayParam.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayParam.swift
@@ -51,11 +51,11 @@ class SomeNode: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "square",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("square")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(TypedArray<Int>.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(TypedArray<Int>.self, name: "integers")
+                SwiftGodotRuntime._argumentPropInfo(TypedArray<Int>.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("integers"))
             ],
             function: SomeNode._mproxy_square,
             ptrFunction: { udata, classInstance, argsPtr, retValue in

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayReturnType.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testGodotMacroWithCallableFuncsWithTypedArrayReturnType.swift
@@ -40,7 +40,7 @@ class SomeNode: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "getIntegerCollection",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("getIntegerCollection")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(TypedArray<Int>.self),
             arguments: [

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testMultipleSignalBindings.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testMultipleSignalBindings.swift
@@ -15,7 +15,7 @@ class OtherThing: SwiftGodot.Node {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-        SimpleSignal.register(as: "signal0", in: className, names: [])
-        SimpleSignal.register(as: "signal1", in: className, names: [])
+        SimpleSignal.register(as: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("signal0")), in: className, names: [])
+        SimpleSignal.register(as: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("signal1")), in: className, names: [])
     }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNewSignalMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNewSignalMacro.swift
@@ -1,13 +1,13 @@
 class Demo: Node3D {
     var burp: SimpleSignal {
         get {
-            SimpleSignal(target: self, signalName: "burp")
+            SimpleSignal(target: self, signalName: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("burp"))
         }
     }
 
     var livesChanged: SignalWithArguments<Int> {
         get {
-            SignalWithArguments<Int>(target: self, signalName: "lives_changed")
+            SignalWithArguments<Int>(target: self, signalName: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("livesChanged"))
         }
     }
 
@@ -25,7 +25,7 @@ class Demo: Node3D {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-        SimpleSignal.register(as: "burp", in: className, names: [])
-        SignalWithArguments<Int>.register(as: "lives_changed", in: className, names: [])
+        SimpleSignal.register(as: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("burp")), in: className, names: [])
+        SignalWithArguments<Int>.register(as: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("livesChanged")), in: className, names: [])
     }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNoTypeAnnotationTrivia.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testNoTypeAnnotationTrivia.swift
@@ -2,7 +2,7 @@
 class TestClass: Node {     
     /* comment *//* comment */ var/* comment */ signal/* comment */: /* comment */ SimpleSignal // Comment {
         get {
-            SimpleSignal(target: self, signalName: "signal")
+            SimpleSignal(target: self, signalName: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("signal"))
         }
     }
     /* comment */
@@ -59,14 +59,14 @@ class TestClass: Node {
             // ClassDB singleton is not available prior to `.scene` level
             assert(ClassDB.classExists(class: className))
         }
-        SimpleSignal.register(as: "signal", in: className, names: [])
+        SimpleSignal.register(as: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("signal")), in: className, names: [])
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "foo",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("foo")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Int.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Int.self, name: "lala")
+                SwiftGodotRuntime._argumentPropInfo(Int.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("lala"))
             ],
             function: TestClass._mproxy_foo,
             ptrFunction: { udata, classInstance, argsPtr, retValue in

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testRpcMacro.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testRpcMacro.swift
@@ -99,11 +99,11 @@ class MultiplayerNode: Node {
         }
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "syncPosition",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("syncPosition")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
-                SwiftGodotRuntime._argumentPropInfo(Vector3.self, name: "position")
+                SwiftGodotRuntime._argumentPropInfo(Vector3.self, name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("position"))
             ],
             function: MultiplayerNode._mproxy_syncPosition,
             ptrFunction: { udata, classInstance, argsPtr, retValue in
@@ -117,7 +117,7 @@ class MultiplayerNode: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "defaultRpc",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("defaultRpc")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -135,7 +135,7 @@ class MultiplayerNode: Node {
         )
         SwiftGodotRuntime._registerMethod(
             className: className,
-            name: "fullConfig",
+            name: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("fullConfig")),
             flags: .default,
             returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
             arguments: [
@@ -156,32 +156,32 @@ class MultiplayerNode: Node {
     /// Called automatically before `_ready()`. Configures RPC for methods marked with `@Rpc`.
     override open func _before_ready() {
         super._before_ready()
+        let rpcConfigDictionary0 = GDictionary()
+        rpcConfigDictionary0[Variant("rpc_mode")] = Variant(MultiplayerAPI.RPCMode.anyPeer.rawValue)
+        rpcConfigDictionary0[Variant("call_local")] = Variant(false)
+        rpcConfigDictionary0[Variant("transfer_mode")] = Variant(MultiplayerPeer.TransferMode.reliable.rawValue)
+        rpcConfigDictionary0[Variant("channel")] = Variant(0)
         rpcConfig(
-            method: StringName("sync_position"),
-            config: Variant([
-                "rpc_mode": Variant(MultiplayerAPI.RPCMode.anyPeer.rawValue),
-                "call_local": Variant(false),
-                "transfer_mode": Variant(MultiplayerPeer.TransferMode.reliable.rawValue),
-                "channel": Variant(0)
-            ] as GDictionary)
+            method: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("syncPosition")),
+            config: Variant(rpcConfigDictionary0)
         )
+        let rpcConfigDictionary1 = GDictionary()
+        rpcConfigDictionary1[Variant("rpc_mode")] = Variant(MultiplayerAPI.RPCMode.authority.rawValue)
+        rpcConfigDictionary1[Variant("call_local")] = Variant(false)
+        rpcConfigDictionary1[Variant("transfer_mode")] = Variant(MultiplayerPeer.TransferMode.unreliable.rawValue)
+        rpcConfigDictionary1[Variant("channel")] = Variant(0)
         rpcConfig(
-            method: StringName("default_rpc"),
-            config: Variant([
-                "rpc_mode": Variant(MultiplayerAPI.RPCMode.authority.rawValue),
-                "call_local": Variant(false),
-                "transfer_mode": Variant(MultiplayerPeer.TransferMode.unreliable.rawValue),
-                "channel": Variant(0)
-            ] as GDictionary)
+            method: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("defaultRpc")),
+            config: Variant(rpcConfigDictionary1)
         )
+        let rpcConfigDictionary2 = GDictionary()
+        rpcConfigDictionary2[Variant("rpc_mode")] = Variant(MultiplayerAPI.RPCMode.authority.rawValue)
+        rpcConfigDictionary2[Variant("call_local")] = Variant(true)
+        rpcConfigDictionary2[Variant("transfer_mode")] = Variant(MultiplayerPeer.TransferMode.unreliableOrdered.rawValue)
+        rpcConfigDictionary2[Variant("channel")] = Variant(2)
         rpcConfig(
-            method: StringName("full_config"),
-            config: Variant([
-                "rpc_mode": Variant(MultiplayerAPI.RPCMode.authority.rawValue),
-                "call_local": Variant(true),
-                "transfer_mode": Variant(MultiplayerPeer.TransferMode.unreliableOrdered.rawValue),
-                "channel": Variant(2)
-            ] as GDictionary)
+            method: StringName(SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("fullConfig")),
+            config: Variant(rpcConfigDictionary2)
         )
         }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testStaticSignal.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testStaticSignal.swift
@@ -1,7 +1,7 @@
 class Hi: Node {
     static var int: SimpleSignal {
         get {
-            SimpleSignal(target: self, signalName: "int")
+            SimpleSignal(target: self, signalName: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("int"))
         }
     }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testWarningAvoidance.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testWarningAvoidance.swift
@@ -58,13 +58,13 @@ final class MyClass: Node {
             className: className,
             info: SwiftGodotRuntime._propInfo(
                 at: \MyClass.data,
-                name: "data",
+                name: SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("data"),
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_data",
-            setterName: "set_data",
+            getterName: StringName("get_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("data")),
+            setterName: StringName("set_" + SwiftGodotRuntime._convertMemberNameToMatchGodotConvention("data")),
             getterFunction: MyClass._mproxy_get_data,
             setterFunction: MyClass._mproxy_set_data
         )

--- a/Tests/SwiftGodotTestExtension/EnumRegistrationTests.swift
+++ b/Tests/SwiftGodotTestExtension/EnumRegistrationTests.swift
@@ -70,28 +70,29 @@ final class EnumRegistrationTests {
     }
 
     func testIntEnumRegistered() {
+        // Case names follow Godot's UPPER_SNAKE_CASE convention (automatic_godot_naming_convention trait).
         assertEnumRegistered("EnumRegistrationHost", "IntEnum", cases: [
-            "a": 0, "b": 1, "c": 2,
+            "A": 0, "B": 1, "C": 2,
         ])
     }
 
     func testInt64EnumRegistered() {
         // Includes a negative raw value to confirm signed values round-trip.
         assertEnumRegistered("EnumRegistrationHost", "Int64Enum", cases: [
-            "low": -5, "high": 100,
+            "LOW": -5, "HIGH": 100,
         ])
     }
 
     func testInt32EnumRegistered() {
         assertEnumRegistered("EnumRegistrationHost", "Int32Enum", cases: [
-            "x": 7, "y": 8,
+            "X": 7, "Y": 8,
         ])
     }
 
     func testUInt8EnumRegistered() {
         // Confirms an unsigned, narrower-than-Int64 raw value registers correctly.
         assertEnumRegistered("EnumRegistrationHost", "UInt8Enum", cases: [
-            "small": 3, "big": 200,
+            "SMALL": 3, "BIG": 200,
         ])
     }
 

--- a/Tests/SwiftGodotTestExtension/MacroCallableIntegrationTests.swift
+++ b/Tests/SwiftGodotTestExtension/MacroCallableIntegrationTests.swift
@@ -157,7 +157,7 @@ final class MacroCallableIntegrationTests {
         objectsArray.append(Variant(object2))
         objectsArray.append(nil)
                 
-        assertEqual(testObject.call(method: "countObjects", objectsArray.toVariant()).to(), 6)
+        assertEqual(testObject.call(method: "count_objects", objectsArray.toVariant()).to(), 6)
         testObject.free()
         object0.free()
         object1.free()
@@ -180,7 +180,7 @@ final class MacroCallableIntegrationTests {
         objectsArray.append(nil)
         objectsArray.append(Variant(RefCounted())) // this one causes the failure
                 
-        assertEqual(testObject.call(method: "countObjects", Variant(objectsArray)), 0.toVariant())
+        assertEqual(testObject.call(method: "count_objects", Variant(objectsArray)), 0.toVariant())
         testObject.free()
         object0.free()
         object1.free()
@@ -205,7 +205,7 @@ final class MacroCallableIntegrationTests {
         // this one won't be added, error is logged from Godot, RefCounted is not TestObject
         objectsArray.append(Variant(RefCounted()))
         
-        let result = testObject.call(method: "countObjects", objectsArray.toVariant())
+        let result = testObject.call(method: "count_objects", objectsArray.toVariant())
         assertEqual(result.to(), 6)
         
         testObject.free()
@@ -229,7 +229,7 @@ final class MacroCallableIntegrationTests {
         objectsArray.append(object2) // 5
         objectsArray.append(nil) // 6
         
-        assertEqual(testObject.call(method: "countObjects", Variant(objectsArray)), Variant(6))
+        assertEqual(testObject.call(method: "count_objects", Variant(objectsArray)), Variant(6))
         testObject.free()
         object0.free()
         object1.free()
@@ -244,7 +244,7 @@ final class MacroCallableIntegrationTests {
         builtinsArray.append(Variant(2))
         builtinsArray.append(Variant(3))
         
-        assertEqual(testObject.call(method: "countBuiltins", Variant(builtinsArray)), Variant(3))
+        assertEqual(testObject.call(method: "count_builtins", Variant(builtinsArray)), Variant(3))
         testObject.free()
     }
 
@@ -261,7 +261,7 @@ final class MacroCallableIntegrationTests {
         array.append(Variant(4))
         
         // Fails, prints into console and returns nil due to typed builtin array not allowing nils
-        assertEqual(testObject.call(method: "countObjects", Variant(array)), 0.toVariant())
+        assertEqual(testObject.call(method: "count_objects", Variant(array)), 0.toVariant())
         testObject.free()
     }
 
@@ -275,7 +275,7 @@ final class MacroCallableIntegrationTests {
         // this one won't be added, error is logged from Godot, nil Builtins are not allowed in typed Arrays
         builtinsArray.append(nil)
         
-        assertEqual(testObject.call(method: "countBuiltins", Variant(builtinsArray)), Variant(3))
+        assertEqual(testObject.call(method: "count_builtins", Variant(builtinsArray)), Variant(3))
         testObject.free()
     }
 
@@ -287,7 +287,7 @@ final class MacroCallableIntegrationTests {
         builtinsArray.append(2)
         builtinsArray.append(3)
         
-        assertEqual(testObject.call(method: "countBuiltins", Variant(builtinsArray)), Variant(3))
+        assertEqual(testObject.call(method: "count_builtins", Variant(builtinsArray)), Variant(3))
         testObject.free()
     }
 
@@ -308,7 +308,7 @@ final class MacroCallableIntegrationTests {
         variants.append(Variant(true)) // 7
         
         
-        assertEqual(testObject.call(method: "countMixed", Variant(builtins), Variant(objects), Variant(variants), Variant("ignored")), Variant(7))
+        assertEqual(testObject.call(method: "count_mixed", Variant(builtins), Variant(objects), Variant(variants), Variant("ignored")), Variant(7))
         testObject.free()
     }
 }

--- a/Tests/SwiftGodotTestExtension/MacroIntegrationTests.swift
+++ b/Tests/SwiftGodotTestExtension/MacroIntegrationTests.swift
@@ -61,7 +61,8 @@ final class MacroIntegrationTests {
 
         let enumPropInfo = _propInfo(at: \NoMacroExample.enumExample, name: "")
         assertEqual(enumPropInfo.propertyType, .int)
-        assertEqual(enumPropInfo.hintStr, "zero:0,one:1,two:2")
+        // Enum case names follow Godot's UPPER_SNAKE_CASE convention (automatic_godot_naming_convention trait).
+        assertEqual(enumPropInfo.hintStr, "ZERO:0,ONE:1,TWO:2")
 
         let meshInstancePropInfo = _propInfo(at: \NoMacroExample.meshInstance, name: "")
         assertEqual(meshInstancePropInfo.hint, .nodeType)

--- a/Tests/SwiftGodotTestExtension/NamingConventionTests.swift
+++ b/Tests/SwiftGodotTestExtension/NamingConventionTests.swift
@@ -1,0 +1,154 @@
+//
+//  NamingConventionTests.swift
+//  SwiftGodotTestExtension
+//
+//  End-to-end tests for the `automatic_godot_naming_convention` trait: every Swift
+//  identifier registered with Godot (methods, arguments, properties, getters/setters,
+//  signals, RPC methods, enum constants, enum hint strings) must be exposed to the
+//  engine in Godot's naming convention. These assert against the live ClassDB while
+//  the package is built with its default traits (so the trait is enabled).
+//
+
+import SwiftGodot
+
+// MARK: - Class under test
+
+@Godot
+class NamingConventionHost: Node {
+    // camelCase method + camelCase argument
+    @Callable func computeSpeedValue(targetNode: Object?) -> Int { 0 }
+
+    // Acronym handling
+    @Callable func makeHTTPRequest() {}
+
+    // Single word — identity
+    @Callable func run() {}
+
+    // @Rpc method: registered via @Callable as `sync_world_state`, and the generated
+    // `_before_ready` calls rpcConfig with the same converter, so the RPC config name
+    // stays consistent with the registered method name.
+    @Callable @Rpc func syncWorldState() {}
+
+    // camelCase property -> snake_case property + get_/set_ accessors
+    @Export var maxHealthPoints: Int = 0
+
+    // camelCase signal
+    @Signal var playerDidJump: SignalWithArguments<Int>
+
+    // Nested enum: cases -> UPPER_SNAKE_CASE constants
+    enum DamageKind: Int, CaseIterable {
+        case fireDamage = 0
+        case iceDamage = 1
+    }
+
+    // Exported enum property: drives the PROPERTY_HINT_ENUM hint string
+    @Export var damageKind: DamageKind = .fireDamage
+}
+
+// MARK: - Helpers
+
+private func methodArgumentNames(_ cls: StringName, _ method: StringName) -> [String] {
+    for entry in ClassDB.classGetMethodList(class: cls, noInheritance: true) {
+        guard let nameV = entry["name"], String(nameV) == String(method) else { continue }
+        guard let argsV = entry["args"], let args = TypedArray<VariantDictionary>(argsV) else { return [] }
+        return args.compactMap { arg in arg["name"].flatMap { String($0) } }
+    }
+    return []
+}
+
+private func enumPropertyHintString(_ host: Object, _ property: String) -> String? {
+    for prop in host.getPropertyList() {
+        guard let nameV = prop["name"], String(nameV) == property else { continue }
+        return prop["hint_string"].flatMap { String($0) }
+    }
+    return nil
+}
+
+// MARK: - Tests
+
+@SwiftGodotTestSuite
+final class NamingConventionTests {
+    public static var registeredTypes: [Object.Type] {
+        [NamingConventionHost.self]
+    }
+
+    func testMethodNameConverted() {
+        assertTrue(
+            ClassDB.classHasMethod(class: "NamingConventionHost", method: "compute_speed_value", noInheritance: true),
+            "method should be registered as compute_speed_value"
+        )
+        assertFalse(
+            ClassDB.classHasMethod(class: "NamingConventionHost", method: "computeSpeedValue", noInheritance: true),
+            "the verbatim Swift name should NOT be registered"
+        )
+        assertTrue(
+            ClassDB.classHasMethod(class: "NamingConventionHost", method: "make_http_request", noInheritance: true),
+            "acronym method should be registered as make_http_request"
+        )
+    }
+
+    func testSingleWordMethodIsIdentity() {
+        assertTrue(
+            ClassDB.classHasMethod(class: "NamingConventionHost", method: "run", noInheritance: true),
+            "single-word method should stay 'run'"
+        )
+    }
+
+    func testArgumentNameConverted() {
+        let args = methodArgumentNames("NamingConventionHost", "compute_speed_value")
+        assertEqual(args, ["target_node"], "argument name should be converted to snake_case")
+    }
+
+    func testPropertyAndAccessorsConverted() {
+        let host = NamingConventionHost()
+        defer { host.queueFree() }
+
+        let names = host.getPropertyList().compactMap { $0["name"].flatMap { String($0) } }
+        assertTrue(names.contains("max_health_points"), "property should be registered as max_health_points")
+
+        assertTrue(
+            ClassDB.classHasMethod(class: "NamingConventionHost", method: "get_max_health_points", noInheritance: true),
+            "getter should be get_max_health_points"
+        )
+        assertTrue(
+            ClassDB.classHasMethod(class: "NamingConventionHost", method: "set_max_health_points", noInheritance: true),
+            "setter should be set_max_health_points"
+        )
+    }
+
+    func testSignalNameConverted() {
+        assertTrue(
+            ClassDB.classHasSignal(class: "NamingConventionHost", signal: "player_did_jump"),
+            "signal should be registered as player_did_jump"
+        )
+        assertFalse(
+            ClassDB.classHasSignal(class: "NamingConventionHost", signal: "playerDidJump"),
+            "the verbatim Swift signal name should NOT be registered"
+        )
+    }
+
+    func testRpcMethodNameConverted() {
+        assertTrue(
+            ClassDB.classHasMethod(class: "NamingConventionHost", method: "sync_world_state", noInheritance: true),
+            "RPC method should be registered as sync_world_state"
+        )
+    }
+
+    func testEnumCasesConvertedToUpperSnake() {
+        assertEnumRegistered("NamingConventionHost", "DamageKind", cases: [
+            "FIRE_DAMAGE": 0, "ICE_DAMAGE": 1,
+        ])
+    }
+
+    func testExportedEnumHintStringConverted() {
+        let host = NamingConventionHost()
+        defer { host.queueFree() }
+
+        guard let hint = enumPropertyHintString(host, "damage_kind") else {
+            fail("Expected a hint_string for the damage_kind property")
+            return
+        }
+        // Order follows the enum's case order.
+        assertEqual(hint, "FIRE_DAMAGE:0,ICE_DAMAGE:1", "enum hint string should use Godot-convention constant names")
+    }
+}

--- a/Tests/SwiftGodotTestExtension/RawArgumentsFetchTests.swift
+++ b/Tests/SwiftGodotTestExtension/RawArgumentsFetchTests.swift
@@ -425,22 +425,22 @@ final class RawArgumentsFetchTests {
 
     func testFetchInt() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testInt", Variant(42))
+        let result = node.call(method: "test_int", Variant(42))
         assertEqual(Int(result), 84)
         node.queueFree()
     }
 
     func testFetchInt64() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testInt64", Variant(Int64(100)))
+        let result = node.call(method: "test_int64", Variant(Int64(100)))
         assertEqual(Int64(result), 200)
         node.queueFree()
     }
 
     func testFetchBool() {
         let node = RawArgumentsTestNode()
-        let resultTrue = node.call(method: "testBool", Variant(true))
-        let resultFalse = node.call(method: "testBool", Variant(false))
+        let resultTrue = node.call(method: "test_bool", Variant(true))
+        let resultFalse = node.call(method: "test_bool", Variant(false))
         assertEqual(Bool(resultTrue), false)
         assertEqual(Bool(resultFalse), true)
         node.queueFree()
@@ -448,21 +448,21 @@ final class RawArgumentsFetchTests {
 
     func testFetchString() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testString", Variant("hello"))
+        let result = node.call(method: "test_string", Variant("hello"))
         assertEqual(String(result), "hello_suffix")
         node.queueFree()
     }
 
     func testFetchDouble() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testDouble", Variant(3.14))
+        let result = node.call(method: "test_double", Variant(3.14))
         assertEqual(Double(result)!, 6.28, accuracy: 0.001)
         node.queueFree()
     }
 
     func testFetchFloat() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testFloat", Variant(Float(2.5)))
+        let result = node.call(method: "test_float", Variant(Float(2.5)))
         assertEqual(result?.gtype, .float)
         assertEqual(Float(result)!, 5.0, accuracy: 0.001)
         node.queueFree()
@@ -472,21 +472,21 @@ final class RawArgumentsFetchTests {
 
     func testFetchStringName() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testStringName", Variant(StringName("test")))
+        let result = node.call(method: "test_string_name", Variant(StringName("test")))
         assertEqual(String(StringName(result)!), "test_modified")
         node.queueFree()
     }
 
     func testFetchNodePath() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testNodePath", Variant(NodePath("root/parent")))
+        let result = node.call(method: "test_node_path", Variant(NodePath("root/parent")))
         assertEqual(String(NodePath(result)!), "root/parent/child")
         node.queueFree()
     }
 
     func testFetchVector2() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testVector2", Variant(Vector2(x: 1, y: 2)))
+        let result = node.call(method: "test_vector2", Variant(Vector2(x: 1, y: 2)))
         let vec = Vector2(result)!
         assertEqual(vec.x, 2)
         assertEqual(vec.y, 4)
@@ -495,7 +495,7 @@ final class RawArgumentsFetchTests {
 
     func testFetchVector3() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testVector3", Variant(Vector3(x: 1, y: 2, z: 3)))
+        let result = node.call(method: "test_vector3", Variant(Vector3(x: 1, y: 2, z: 3)))
         let vec = Vector3(result)!
         assertEqual(vec.x, 2)
         assertEqual(vec.y, 4)
@@ -505,7 +505,7 @@ final class RawArgumentsFetchTests {
 
     func testFetchVector4() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testVector4", Variant(Vector4(x: 1, y: 2, z: 3, w: 4)))
+        let result = node.call(method: "test_vector4", Variant(Vector4(x: 1, y: 2, z: 3, w: 4)))
         let vec = Vector4(result)!
         assertEqual(vec.x, 2)
         assertEqual(vec.y, 4)
@@ -516,7 +516,7 @@ final class RawArgumentsFetchTests {
 
     func testFetchVector2i() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testVector2i", Variant(Vector2i(x: 3, y: 4)))
+        let result = node.call(method: "test_vector2i", Variant(Vector2i(x: 3, y: 4)))
         let vec = Vector2i(result)!
         assertEqual(vec.x, 6)
         assertEqual(vec.y, 8)
@@ -525,7 +525,7 @@ final class RawArgumentsFetchTests {
 
     func testFetchVector3i() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testVector3i", Variant(Vector3i(x: 1, y: 2, z: 3)))
+        let result = node.call(method: "test_vector3i", Variant(Vector3i(x: 1, y: 2, z: 3)))
         let vec = Vector3i(result)!
         assertEqual(vec.x, 2)
         assertEqual(vec.y, 4)
@@ -535,7 +535,7 @@ final class RawArgumentsFetchTests {
 
     func testFetchVector4i() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testVector4i", Variant(Vector4i(x: 1, y: 2, z: 3, w: 4)))
+        let result = node.call(method: "test_vector4i", Variant(Vector4i(x: 1, y: 2, z: 3, w: 4)))
         let vec = Vector4i(result)!
         assertEqual(vec.x, 2)
         assertEqual(vec.y, 4)
@@ -546,7 +546,7 @@ final class RawArgumentsFetchTests {
 
     func testFetchColor() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testColor", Variant(Color(r: 0.25, g: 0.5, b: 0.125, a: 1.0)))
+        let result = node.call(method: "test_color", Variant(Color(r: 0.25, g: 0.5, b: 0.125, a: 1.0)))
         let color = Color(result)!
         assertEqual(color.red, 0.5, accuracy: 0.001)
         assertEqual(color.green, 1.0, accuracy: 0.001)
@@ -557,7 +557,7 @@ final class RawArgumentsFetchTests {
 
     func testFetchRect2() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testRect2", Variant(Rect2(position: Vector2(x: 1, y: 2), size: Vector2(x: 3, y: 4))))
+        let result = node.call(method: "test_rect2", Variant(Rect2(position: Vector2(x: 1, y: 2), size: Vector2(x: 3, y: 4))))
         let rect = Rect2(result)!
         assertEqual(rect.position.x, 2)
         assertEqual(rect.position.y, 4)
@@ -568,7 +568,7 @@ final class RawArgumentsFetchTests {
 
     func testFetchRect2i() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testRect2i", Variant(Rect2i(position: Vector2i(x: 1, y: 2), size: Vector2i(x: 3, y: 4))))
+        let result = node.call(method: "test_rect2i", Variant(Rect2i(position: Vector2i(x: 1, y: 2), size: Vector2i(x: 3, y: 4))))
         let rect = Rect2i(result)!
         assertEqual(rect.position.x, 2)
         assertEqual(rect.position.y, 4)
@@ -580,7 +580,7 @@ final class RawArgumentsFetchTests {
     func testFetchTransform2D() {
         let node = RawArgumentsTestNode()
         let transform = Transform2D()
-        let result = node.call(method: "testTransform2D", Variant(transform))
+        let result = node.call(method: "test_transform2d", Variant(transform))
         assertNotNil(Transform2D(result))
         node.queueFree()
     }
@@ -588,7 +588,7 @@ final class RawArgumentsFetchTests {
     func testFetchTransform3D() {
         let node = RawArgumentsTestNode()
         let transform = Transform3D()
-        let result = node.call(method: "testTransform3D", Variant(transform))
+        let result = node.call(method: "test_transform3d", Variant(transform))
         assertNotNil(Transform3D(result))
         node.queueFree()
     }
@@ -596,7 +596,7 @@ final class RawArgumentsFetchTests {
     func testFetchBasis() {
         let node = RawArgumentsTestNode()
         let basis = Basis()
-        let result = node.call(method: "testBasis", Variant(basis))
+        let result = node.call(method: "test_basis", Variant(basis))
         assertNotNil(Basis(result))
         node.queueFree()
     }
@@ -604,7 +604,7 @@ final class RawArgumentsFetchTests {
     func testFetchQuaternion() {
         let node = RawArgumentsTestNode()
         let quat = Quaternion()
-        let result = node.call(method: "testQuaternion", Variant(quat))
+        let result = node.call(method: "test_quaternion", Variant(quat))
         assertNotNil(Quaternion(result))
         node.queueFree()
     }
@@ -612,7 +612,7 @@ final class RawArgumentsFetchTests {
     func testFetchPlane() {
         let node = RawArgumentsTestNode()
         let plane = Plane()
-        let result = node.call(method: "testPlane", Variant(plane))
+        let result = node.call(method: "test_plane", Variant(plane))
         assertNotNil(Plane(result))
         node.queueFree()
     }
@@ -620,7 +620,7 @@ final class RawArgumentsFetchTests {
     func testFetchAABB() {
         let node = RawArgumentsTestNode()
         let aabb = AABB()
-        let result = node.call(method: "testAABB", Variant(aabb))
+        let result = node.call(method: "test_aabb", Variant(aabb))
         assertNotNil(AABB(result))
         node.queueFree()
     }
@@ -628,7 +628,7 @@ final class RawArgumentsFetchTests {
     func testFetchProjection() {
         let node = RawArgumentsTestNode()
         let projection = Projection()
-        let result = node.call(method: "testProjection", Variant(projection))
+        let result = node.call(method: "test_projection", Variant(projection))
         assertNotNil(Projection(result))
         node.queueFree()
     }
@@ -636,7 +636,7 @@ final class RawArgumentsFetchTests {
     func testFetchRID() {
         let node = RawArgumentsTestNode()
         let rid = RID()
-        let result = node.call(method: "testRID", Variant(rid))
+        let result = node.call(method: "test_rid", Variant(rid))
         assertNotNil(RID(result))
         node.queueFree()
     }
@@ -644,7 +644,7 @@ final class RawArgumentsFetchTests {
     func testFetchCallable() {
         let node = RawArgumentsTestNode()
         let callable = Callable()
-        let result = node.call(method: "testCallable", Variant(callable))
+        let result = node.call(method: "test_callable", Variant(callable))
         assertNotNil(Callable(result))
         node.queueFree()
     }
@@ -652,7 +652,7 @@ final class RawArgumentsFetchTests {
     func testFetchSignal() {
         let node = RawArgumentsTestNode()
         let signal = Signal()
-        let result = node.call(method: "testSignalArg", Variant(signal))
+        let result = node.call(method: "test_signal_arg", Variant(signal))
         assertNotNil(Signal(result))
         node.queueFree()
     }
@@ -665,7 +665,7 @@ final class RawArgumentsFetchTests {
         array.append(Variant(1))
         array.append(Variant(2))
         array.append(Variant(3))
-        let result = node.call(method: "testVariantArray", Variant(array))
+        let result = node.call(method: "test_variant_array", Variant(array))
         assertEqual(Int(result), 3)
         node.queueFree()
     }
@@ -675,7 +675,7 @@ final class RawArgumentsFetchTests {
         let dict = VariantDictionary()
         dict["a"] = Variant(1)
         dict["b"] = Variant(2)
-        let result = node.call(method: "testVariantDictionary", Variant(dict))
+        let result = node.call(method: "test_variant_dictionary", Variant(dict))
         assertEqual(Int(result), 2)
         node.queueFree()
     }
@@ -686,7 +686,7 @@ final class RawArgumentsFetchTests {
         array.append(1)
         array.append(2)
         array.append(3)
-        let result = node.call(method: "testPackedByteArray", Variant(array))
+        let result = node.call(method: "test_packed_byte_array", Variant(array))
         assertEqual(Int(result), 3)
         node.queueFree()
     }
@@ -696,7 +696,7 @@ final class RawArgumentsFetchTests {
         var array = PackedInt32Array()
         array.append(1)
         array.append(2)
-        let result = node.call(method: "testPackedInt32Array", Variant(array))
+        let result = node.call(method: "test_packed_int32_array", Variant(array))
         assertEqual(Int(result), 2)
         node.queueFree()
     }
@@ -708,7 +708,7 @@ final class RawArgumentsFetchTests {
         array.append(2)
         array.append(3)
         array.append(4)
-        let result = node.call(method: "testPackedInt64Array", Variant(array))
+        let result = node.call(method: "test_packed_int64_array", Variant(array))
         assertEqual(Int(result), 4)
         node.queueFree()
     }
@@ -718,7 +718,7 @@ final class RawArgumentsFetchTests {
         var array = PackedFloat32Array()
         array.append(1.0)
         array.append(2.0)
-        let result = node.call(method: "testPackedFloat32Array", Variant(array))
+        let result = node.call(method: "test_packed_float32_array", Variant(array))
         assertEqual(Int(result), 2)
         node.queueFree()
     }
@@ -729,7 +729,7 @@ final class RawArgumentsFetchTests {
         array.append(1.0)
         array.append(2.0)
         array.append(3.0)
-        let result = node.call(method: "testPackedFloat64Array", Variant(array))
+        let result = node.call(method: "test_packed_float64_array", Variant(array))
         assertEqual(Int(result), 3)
         node.queueFree()
     }
@@ -739,7 +739,7 @@ final class RawArgumentsFetchTests {
         var array = PackedStringArray()
         array.append("a")
         array.append("b")
-        let result = node.call(method: "testPackedStringArray", Variant(array))
+        let result = node.call(method: "test_packed_string_array", Variant(array))
         assertEqual(Int(result), 2)
         node.queueFree()
     }
@@ -748,7 +748,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         var array = PackedVector2Array()
         array.append(Vector2(x: 1, y: 2))
-        let result = node.call(method: "testPackedVector2Array", Variant(array))
+        let result = node.call(method: "test_packed_vector2_array", Variant(array))
         assertEqual(Int(result), 1)
         node.queueFree()
     }
@@ -758,7 +758,7 @@ final class RawArgumentsFetchTests {
         var array = PackedVector3Array()
         array.append(Vector3(x: 1, y: 2, z: 3))
         array.append(Vector3(x: 4, y: 5, z: 6))
-        let result = node.call(method: "testPackedVector3Array", Variant(array))
+        let result = node.call(method: "test_packed_vector3_array", Variant(array))
         assertEqual(Int(result), 2)
         node.queueFree()
     }
@@ -767,7 +767,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         var array = PackedVector4Array()
         array.append(value: Vector4(x: 1, y: 2, z: 3, w: 4))
-        let result = node.call(method: "testPackedVector4Array", Variant(array))
+        let result = node.call(method: "test_packed_vector4_array", Variant(array))
         assertEqual(Int(result), 1)
         node.queueFree()
     }
@@ -778,7 +778,7 @@ final class RawArgumentsFetchTests {
         array.append(Color.red)
         array.append(Color.green)
         array.append(Color.blue)
-        let result = node.call(method: "testPackedColorArray", Variant(array))
+        let result = node.call(method: "test_packed_color_array", Variant(array))
         assertEqual(Int(result), 3)
         node.queueFree()
     }
@@ -791,7 +791,7 @@ final class RawArgumentsFetchTests {
         array.append(1)
         array.append(2)
         array.append(3)
-        let result = node.call(method: "testTypedArrayInt", Variant(array.array))
+        let result = node.call(method: "test_typed_array_int", Variant(array.array))
         assertEqual(Int(result), 3)
         node.queueFree()
     }
@@ -801,7 +801,7 @@ final class RawArgumentsFetchTests {
         let array = TypedArray<String>()
         array.append("hello")
         array.append("world")
-        let result = node.call(method: "testTypedArrayString", Variant(array.array))
+        let result = node.call(method: "test_typed_array_string", Variant(array.array))
         assertEqual(Int(result), 2)
         node.queueFree()
     }
@@ -811,7 +811,7 @@ final class RawArgumentsFetchTests {
         let dict = TypedDictionary<Int, String>()
         dict[1] = "one"
         dict[2] = "two"
-        let result = node.call(method: "testTypedDictionaryIntString", Variant(dict.dictionary))
+        let result = node.call(method: "test_typed_dictionary_int_string", Variant(dict.dictionary))
         assertEqual(Int(result), 2)
         node.queueFree()
     }
@@ -822,7 +822,7 @@ final class RawArgumentsFetchTests {
         dict["a"] = 1
         dict["b"] = 2
         dict["c"] = 3
-        let result = node.call(method: "testTypedDictionaryStringInt", Variant(dict.dictionary))
+        let result = node.call(method: "test_typed_dictionary_string_int", Variant(dict.dictionary))
         assertEqual(Int(result), 3)
         node.queueFree()
     }
@@ -833,7 +833,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let swiftArray: [Int] = [1, 2, 3, 4, 5]
         let typedArray = TypedArray<Int>(swiftArray)
-        let result = node.call(method: "testSwiftArrayInt", Variant(typedArray.array))
+        let result = node.call(method: "test_swift_array_int", Variant(typedArray.array))
         assertEqual(Int(result), 15) // 1+2+3+4+5 = 15
         node.queueFree()
     }
@@ -842,7 +842,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let swiftArray: [String] = ["a", "b", "c"]
         let typedArray = TypedArray<String>(swiftArray)
-        let result = node.call(method: "testSwiftArrayString", Variant(typedArray.array))
+        let result = node.call(method: "test_swift_array_string", Variant(typedArray.array))
         assertEqual(String(result), "a,b,c")
         node.queueFree()
     }
@@ -851,7 +851,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let swiftDict: [Int: String] = [1: "one", 2: "two"]
         let typedDict = TypedDictionary<Int, String>(swiftDict)
-        let result = node.call(method: "testSwiftDictionaryIntString", Variant(typedDict.dictionary))
+        let result = node.call(method: "test_swift_dictionary_int_string", Variant(typedDict.dictionary))
         assertEqual(Int(result), 2)
         node.queueFree()
     }
@@ -860,7 +860,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let swiftDict: [String: Int] = ["a": 10, "b": 20, "c": 30]
         let typedDict = TypedDictionary<String, Int>(swiftDict)
-        let result = node.call(method: "testSwiftDictionaryStringInt", Variant(typedDict.dictionary))
+        let result = node.call(method: "test_swift_dictionary_string_int", Variant(typedDict.dictionary))
         assertEqual(Int(result), 60) // 10+20+30 = 60
         node.queueFree()
     }
@@ -869,14 +869,14 @@ final class RawArgumentsFetchTests {
 
     func testFetchVariant() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testVariant", Variant(42))
+        let result = node.call(method: "test_variant", Variant(42))
         assertEqual(String(result), "42")
         node.queueFree()
     }
 
     func testFetchVariantOptionalWithValue() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testVariantOptional", Variant("hello"))
+        let result = node.call(method: "test_variant_optional", Variant("hello"))
         assertEqual(String(result), "hello")
         node.queueFree()
     }
@@ -887,7 +887,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let testNode = Node()
         testNode.name = "TestNode"
-        let result = node.call(method: "testNodeOptional", Variant(testNode))
+        let result = node.call(method: "test_node_optional", Variant(testNode))
         assertEqual(String(result), "TestNode")
         testNode.queueFree()
         node.queueFree()
@@ -897,7 +897,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         let testNode = Node()
         testNode.name = "MyTestNode"
-        let result = node.call(method: "testNode", Variant(testNode))
+        let result = node.call(method: "test_node", Variant(testNode))
         assertEqual(String(result), "MyTestNode")
         testNode.queueFree()
         node.queueFree()
@@ -906,7 +906,7 @@ final class RawArgumentsFetchTests {
     func testFetchRefCountedOptional() {
         let node = RawArgumentsTestNode()
         let refCounted = RefCounted()
-        let result = node.call(method: "testRefCountedOptional", Variant(refCounted))
+        let result = node.call(method: "test_ref_counted_optional", Variant(refCounted))
         assertEqual(Bool(result), true)
         node.queueFree()
     }
@@ -916,14 +916,14 @@ final class RawArgumentsFetchTests {
     func testFetchIntEnum() {
         let node = RawArgumentsTestNode()
         // Pass the raw value since Godot doesn't know about our Swift enum
-        let result = node.call(method: "testIntEnum", Variant(2)) // TestIntEnum.second
+        let result = node.call(method: "test_int_enum", Variant(2)) // TestIntEnum.second
         assertEqual(Int(result), 20) // 2 * 10 = 20
         node.queueFree()
     }
 
     func testFetchInt64Enum() {
         let node = RawArgumentsTestNode()
-        let result = node.call(method: "testInt64Enum", Variant(200)) // TestInt64Enum.beta
+        let result = node.call(method: "test_int64_enum", Variant(200)) // TestInt64Enum.beta
         assertEqual(Int64(result), 2000) // 200 * 10 = 2000
         node.queueFree()
     }
@@ -933,7 +933,7 @@ final class RawArgumentsFetchTests {
     func testFetchCustomIntWrapper() {
         let node = RawArgumentsTestNode()
         // CustomIntWrapper is backed by Int, so we pass an Int
-        let result = node.call(method: "testCustomIntWrapper", Variant(7))
+        let result = node.call(method: "test_custom_int_wrapper", Variant(7))
         assertEqual(Int(result), 21) // 7 * 3 = 21
         node.queueFree()
     }
@@ -941,7 +941,7 @@ final class RawArgumentsFetchTests {
     func testFetchCustomStringWrapper() {
         let node = RawArgumentsTestNode()
         // CustomStringWrapper is backed by String
-        let result = node.call(method: "testCustomStringWrapper", Variant("hello"))
+        let result = node.call(method: "test_custom_string_wrapper", Variant("hello"))
         assertEqual(String(result), "HELLO")
         node.queueFree()
     }
@@ -949,7 +949,7 @@ final class RawArgumentsFetchTests {
     func testFetchCustomVector2Wrapper() {
         let node = RawArgumentsTestNode()
         // CustomVector2Wrapper is backed by Vector2
-        let result = node.call(method: "testCustomVector2Wrapper", Variant(Vector2(x: 2, y: 3)))
+        let result = node.call(method: "test_custom_vector2_wrapper", Variant(Vector2(x: 2, y: 3)))
         let vec = Vector2(result)!
         assertEqual(vec.x, 6) // 2 * 3 = 6
         assertEqual(vec.y, 9) // 3 * 3 = 9
@@ -961,7 +961,7 @@ final class RawArgumentsFetchTests {
     func testFetchMixedParams() {
         let node = RawArgumentsTestNode()
         let result = node.call(
-            method: "testMixedParams",
+            method: "test_mixed_params",
             Variant(42),
             Variant("test"),
             Variant(true),
@@ -975,7 +975,7 @@ final class RawArgumentsFetchTests {
         let node = RawArgumentsTestNode()
         // intWrapper(5) + stringWrapper("abc").count(3) + normalInt(10) = 18
         let result = node.call(
-            method: "testMixedWithCustom",
+            method: "test_mixed_with_custom",
             Variant(5),      // CustomIntWrapper
             Variant("abc"),  // CustomStringWrapper
             Variant(10)      // normal Int
@@ -998,7 +998,7 @@ final class RawArgumentsFetchTests {
 
         // 2 + 3 + 1 = 6
         let result = node.call(
-            method: "testMixedWithArrays",
+            method: "test_mixed_with_arrays",
             Variant(typedArray.array),
             Variant(swiftArray.array),
             Variant(packedArray)
@@ -1013,7 +1013,7 @@ final class RawArgumentsFetchTests {
         testNode.name = "ObjNode"
 
         let result = node.call(
-            method: "testMixedWithObjects",
+            method: "test_mixed_with_objects",
             Variant(testNode),
             Variant(123),
             Variant(3) // TestIntEnum.third

--- a/Tests/SwiftGodotTestExtension/SignalTests.swift
+++ b/Tests/SwiftGodotTestExtension/SignalTests.swift
@@ -28,7 +28,7 @@ final class SignalTests {
     public func testUserDefinedSignal() {
         let node = TestSignalNode()
 
-        node.connect (signal: TestSignalNode.mySignal, to: node, method: "receiveSignal")
+        node.connect (signal: TestSignalNode.mySignal, to: node, method: "receive_signal")
         node.emit (signal: TestSignalNode.mySignal, 22, "Joey")
 
         assertEqual (node.receivedInt, 22, "Integers should have been the same")

--- a/Tests/SwiftGodotTestProject/test_orchestrator.gd
+++ b/Tests/SwiftGodotTestProject/test_orchestrator.gd
@@ -11,8 +11,9 @@ func _ready() -> void:
 	var runner := TestRunnerNode.new()
 	add_child(runner)
 
-	# Run deferred so `runTests` can't emit `finished` before we await it below.
-	runner.call_deferred("runTests")
+	# Run deferred so `run_tests` can't emit `finished` before we await it below.
+	# Names follow Godot's convention: the Swift `runTests` is exposed as `run_tests`.
+	runner.call_deferred("run_tests")
 	var exit_code: int = await runner.finished
 
 	# The tests free their nodes with queue_free, so the actual deletions only
@@ -21,7 +22,7 @@ func _ready() -> void:
 		await get_tree().process_frame
 
 	# ...then deregister the classes (must happen AFTER their instances are freed).
-	runner.deregisterTypes()
+	runner.deregister_types()
 
 	# Now tear down the runner itself and let its free settle before quitting,
 	# so no extension instance survives and the extension can be unloaded cleanly.

--- a/Tests/SwiftGodotUniversalTests/GodotNamingTests.swift
+++ b/Tests/SwiftGodotUniversalTests/GodotNamingTests.swift
@@ -1,0 +1,120 @@
+//
+//  GodotNamingTests.swift
+//
+//  Verifies the Swift → Godot identifier conversion used when symbols are
+//  registered with the engine. These tests build with the package's default
+//  traits, so `automatic_godot_naming_convention` is enabled and the public
+//  `_convert*` entry points perform the conversion.
+//
+
+import XCTest
+import Foundation
+@testable import SwiftGodot
+
+final class GodotNamingTests: XCTestCase {
+
+    // MARK: - Member names (camelCase / PascalCase -> snake_case)
+
+    func testMemberNameConversion() {
+        let cases: [(String, String)] = [
+            ("computeSpeed", "compute_speed"),
+            ("computeSpeedValue", "compute_speed_value"),
+            ("makeHTTPRequest", "make_http_request"),
+            ("HTTPServer", "http_server"),
+            ("URLString", "url_string"),
+            ("maxHealthPoints", "max_health_points"),
+            ("maxHP", "max_hp"),
+            ("playerID", "player_id"),
+            ("getValue2", "get_value2"),
+            ("vector2D", "vector2d"),
+            ("position3D", "position3d"),
+            ("run", "run"),
+            ("_ready", "_ready"),
+            ("_process", "_process"),
+            // Already snake_case -> idempotent
+            ("get_my_prop", "get_my_prop"),
+            ("set_max_health_points", "set_max_health_points"),
+            // get_/set_ prefixes combined with a camelCase tail
+            ("get_myProp", "get_my_prop"),
+            ("set_myProp", "set_my_prop"),
+        ]
+
+        for (input, expected) in cases {
+            XCTAssertEqual(
+                _convertMemberNameToMatchGodotConvention(input),
+                expected,
+                "member conversion of \"\(input)\""
+            )
+        }
+    }
+
+    func testMemberNameConversionIsIdempotent() {
+        for input in ["computeSpeed", "HTTPServer", "get_myProp", "vector2D", "_ready"] {
+            let once = _convertMemberNameToMatchGodotConvention(input)
+            let twice = _convertMemberNameToMatchGodotConvention(once)
+            XCTAssertEqual(once, twice, "conversion of \"\(input)\" should be idempotent")
+        }
+    }
+
+    // MARK: - Enum case names (camelCase -> UPPER_SNAKE_CASE)
+
+    func testEnumCaseNameConversion() {
+        let cases: [(String, String)] = [
+            ("fireDamage", "FIRE_DAMAGE"),
+            ("iceDamage", "ICE_DAMAGE"),
+            ("a", "A"),
+            ("lowHP", "LOW_HP"),
+            ("modeKinematic", "MODE_KINEMATIC"),
+            ("vector2D", "VECTOR2D"),
+        ]
+
+        for (input, expected) in cases {
+            XCTAssertEqual(
+                _convertEnumCaseNameToMatchGodotConvention(input),
+                expected,
+                "enum case conversion of \"\(input)\""
+            )
+        }
+    }
+
+    // MARK: - Parity with the legacy regex implementation
+
+    /// The new converter must reproduce the legacy `camelToSnake` behavior used
+    /// historically by the generator and the macro library, including the
+    /// `2_D`/`3_D` fix-ups.
+    func testParityWithLegacyRegex() {
+        let corpus = [
+            "computeSpeed", "computeSpeedValue", "makeHTTPRequest", "HTTPServer",
+            "URLString", "maxHealthPoints", "maxHP", "playerID", "getValue2",
+            "vector2D", "position3D", "node2D", "size3D", "run", "_ready",
+            "_process", "_input", "getMyProp", "setMyProp", "isOnFloor",
+            "globalPosition", "zIndex", "useParentMaterial", "AABBValue",
+        ]
+
+        for input in corpus {
+            XCTAssertEqual(
+                _convertMemberNameToMatchGodotConvention(input),
+                legacyCamelToSnake(input),
+                "parity for \"\(input)\""
+            )
+        }
+    }
+
+    // Legacy reference implementation (NSRegularExpression-based), copied from
+    // Generator/StringOperations.swift / MacroGodot.swift.
+    private func legacyCamelToSnake(_ s: String) -> String {
+        func processCamelCaseRegex(_ value: String, pattern: String) -> String? {
+            let regex = try? NSRegularExpression(pattern: pattern, options: [])
+            let range = NSRange(location: 0, length: value.count)
+            return regex?.stringByReplacingMatches(in: value, options: [], range: range, withTemplate: "$1_$2")
+        }
+        let acronymPattern = "([A-Z]+)([A-Z][a-z]|[0-9])"
+        let normalPattern = "([a-z0-9])([A-Z])"
+        let snake = processCamelCaseRegex(s, pattern: acronymPattern)
+            .flatMap { processCamelCaseRegex($0, pattern: normalPattern) }?
+            .lowercased() ?? s.lowercased()
+        return snake
+            .replacingOccurrences(of: "2_d", with: "2d")
+            .replacingOccurrences(of: "3_d", with: "3d")
+    }
+}


### PR DESCRIPTION
Introduce the `automatic_godot_naming_convention` package trait (on by default) so every Swift identifier SwiftGodot registers with Godot follows the engine's convention: snake_case for methods/properties/signals/arguments, UPPER_SNAKE_CASE for enum constants, PascalCase classes unchanged.

The macros unconditionally emit calls to two non-@inlinable runtime functions (`_convertMemberNameToMatchGodotConvention`, `_convertEnumCaseNameToMatchGodotConvention` in the new GodotNaming.swift). Only those functions carry the `#if SWIFTGODOT_GODOT_NAMING` branch, and the trait sets that define on the runtime, so one switch flips behavior for every consumer. The converter is a Foundation-free scanner with byte-parity to the legacy camelToSnake regex (incl. 2D/3D fixups).

Conversion is applied at every registration site: @Callable methods + args, @Export property + get_/set_ accessors, @Signal name + args, @Rpc config name, #signal/SignalAttachment, nested-enum cases (_registerEnumIfPossible), the @Export enum PROPERTY_HINT_ENUM string (enumCasesHintStr), and manual ClassInfo registration. `@Callable(autoSnakeCase:)` is deprecated and ignored.

Fix two latent @Rpc bugs surfaced by the first compiled @Rpc usage: declare `_before_ready` in @Godot's member names, and build the rpcConfig dictionary imperatively (VariantDictionary isn't ExpressibleByDictionaryLiteral).

Tests: converter unit tests with legacy-regex parity; regenerated macro expansion fixtures; new NamingConventionTests asserting registered names against live Godot ClassDB. Migrate the embedded suite's string-based call sites and enum-case expectations to the Godot convention.