### PR TITLE
Add support for SwiftGodot classes to supply custom properties

### DIFF
--- a/Sources/SwiftGodotRuntime/Core/ClassServices.swift
+++ b/Sources/SwiftGodotRuntime/Core/ClassServices.swift
@@ -296,24 +296,24 @@ public struct PropInfo: CustomDebugStringConvertible {
     }
 }
 
-class PropertyInfoStorage {
-	let propertyName: StringName
-	let className: StringName
-	let hintStr: GString
-	
-	var propertyNameContentPtr: UnsafeMutableRawPointer?
-	var classNameContentPtr: UnsafeMutableRawPointer?
-	var hintStrContentPtr: UnsafeMutableRawPointer?
-	
-	init(propertyName: StringName, className: StringName, hintStr: GString) {
-		self.propertyName = propertyName
-		self.className = className
-		self.hintStr = hintStr
-		
-		propertyNameContentPtr = withUnsafePointer(to: &propertyName.content) { UnsafeMutableRawPointer(mutating: $0) }
-		classNameContentPtr = withUnsafePointer(to: &className.content) { UnsafeMutableRawPointer(mutating: $0) }
-		hintStrContentPtr = withUnsafePointer(to: &hintStr.content) { UnsafeMutableRawPointer(mutating: $0) }
-	}
+public class PropertyInfoStorage {
+    let propertyName: StringName
+    let className: StringName
+    let hintStr: GString
+    
+    var propertyNameContentPtr: UnsafeMutableRawPointer?
+    var classNameContentPtr: UnsafeMutableRawPointer?
+    var hintStrContentPtr: UnsafeMutableRawPointer?
+    
+    init(propertyName: StringName, className: StringName, hintStr: GString) {
+        self.propertyName = propertyName
+        self.className = className
+        self.hintStr = hintStr
+        
+        propertyNameContentPtr = withUnsafeMutablePointer(to: &propertyName.content) { UnsafeMutableRawPointer($0) }
+        classNameContentPtr = withUnsafeMutablePointer(to: &className.content) { UnsafeMutableRawPointer($0) }
+        hintStrContentPtr = withUnsafeMutablePointer(to: &hintStr.content) { UnsafeMutableRawPointer($0) }
+    }
 }
 
 func bind_call (_ udata: UnsafeMutableRawPointer?,

--- a/Sources/SwiftGodotRuntime/Core/ClassServices.swift
+++ b/Sources/SwiftGodotRuntime/Core/ClassServices.swift
@@ -270,6 +270,21 @@ public struct PropInfo: CustomDebugStringConvertible {
             }
         }
     }
+	
+	func makeOwnedNativeStruct() -> (PropertyInfoStorage, GDExtensionPropertyInfo) {
+		// Create a Storage object to make sure pointers survive
+		let propInfoStorage = PropertyInfoStorage(propertyName: propertyName, className: className, hintStr: hintStr)
+		
+		let gdPropInfo = GDExtensionPropertyInfo(
+			type: GDExtensionVariantType(GDExtensionVariantType.RawValue (propertyType.rawValue)),
+			name: propInfoStorage.propertyNameContentPtr,
+			class_name: propInfoStorage.classNameContentPtr,
+			hint: UInt32 (hint.rawValue),
+			hint_string: propInfoStorage.hintStrContentPtr,
+			usage: UInt32 (usage.rawValue))
+
+		return (propInfoStorage, gdPropInfo)
+	}
 
     /// Provides a human-readable description of the property
     public var debugDescription: String {
@@ -279,6 +294,26 @@ public struct PropInfo: CustomDebugStringConvertible {
         }
         return "PropInfo (propertyType: \(propertyType), name: \"\(propertyName.description)\", className: \"\(className.description)\", hint: [\(hint)], \(hs)usage: \(usage))"
     }
+}
+
+class PropertyInfoStorage {
+	let propertyName: StringName
+	let className: StringName
+	let hintStr: GString
+	
+	var propertyNameContentPtr: UnsafeMutableRawPointer?
+	var classNameContentPtr: UnsafeMutableRawPointer?
+	var hintStrContentPtr: UnsafeMutableRawPointer?
+	
+	init(propertyName: StringName, className: StringName, hintStr: GString) {
+		self.propertyName = propertyName
+		self.className = className
+		self.hintStr = hintStr
+		
+		propertyNameContentPtr = withUnsafePointer(to: &propertyName.content) { UnsafeMutableRawPointer(mutating: $0) }
+		classNameContentPtr = withUnsafePointer(to: &className.content) { UnsafeMutableRawPointer(mutating: $0) }
+		hintStrContentPtr = withUnsafePointer(to: &hintStr.content) { UnsafeMutableRawPointer(mutating: $0) }
+	}
 }
 
 func bind_call (_ udata: UnsafeMutableRawPointer?,

--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -309,34 +309,53 @@ open class Wrapped: Equatable, Identifiable, Hashable {
         return false
     }
     
+    /// Override this if you want to have a property with special handling, perhaps the actual value gets stored elsewhere.
+    /// - Parameters:
+    ///     - property: The name of the property to set
+    ///     - value: A Variant representing the value to be stored.
+    /// - Returns:
+    /// Return `true` if you've handled the property and stored the value supplied - or discarded it but don't wish for the standard property storage to apply.
+    /// Return `false` if you don't have any special handling for the named property. Godot will store it in the usual way.
     open func _set(property: StringName, value: consuming Variant?) -> Bool {
         return false
     }
 
-    public enum GetPropertyResult: ~Copyable {
-        case unhandledProperty
-        case variant(FastVariant?)
-        
-        static public func from(_ value: some VariantConvertible) -> Self {
-            .variant(value.toFastVariant())
-        }
-    }
-    
+    /// Override this if you want to have a property with special handling, perhaps the actual value gets stored elsewhere. For properties stored in the
+    /// standard way (such as `@Export` properties) there is no need to override default behavior and you should treat those as unhandled.
+    /// - Parameters:
+    ///     - property: The name of the property to get
+    /// - Returns:
+    /// Returns the value retieved, or `GetPropertyResult.unhandledProperty` if there is no special handling for this property. Returning
+    /// `.unhandledProperty` does not neccesarily mean that the property doesn't exist, and Godot will apply its standard behavior for get() if you return this.
     open func _get(property: StringName) -> GetPropertyResult {
         return .unhandledProperty
     }
 
-    /// Works like getPropertyList, except it can be overridden by subclasses to expose programmatic properties
-    /// to Godot. Base properties are not included in the passed-in array, so they cannot be modified or removed by this method.
-    /// Values should be PropertyInfo wrapped in Variants.
+    /// Override this method if your object has non-standard properties, such as any that are dynamically created at runtime. The list of properties
+    /// returned here is treats as *additional* to any standard properties (including `@Export` properties), and you cannot hide existing properties with this method.
+    /// If you return any properties here, you almost certainly need to also override `_get()`, `_set()` to handle your special properties, and should consider overriding
+    /// `_propertyGetRevert()` and `_propertyCanRevert()`
+    ///  - Returns:
+    ///    An array of PropInfos representing all the extra properties your object supports. If any of these properties clash with standard properties, the result is undefined.
     open func _getPropertyList() -> [PropInfo]? {
         return nil
     }
     
+    /// Override if you want to allow reverting for the named property. You should also override `_propertyGetRevert()` Note that you do NOT have to return
+    /// `true` for any properties that you are not applying special handling to. Standard properties and any `@Export` properties will be handled appropriately even
+    /// if you return `false` here.
+    ///  - Returns:
+    ///  `true` if the named property supports reverting - this will almost always result in a subsequent call to `_propertyGetRevert()`
+    ///  `false` if the property does not support reverting.
     open func _propertyCanRevert(_ property: StringName, canRevert: inout Bool) -> Bool {
         return false
     }
 
+    /// Override to return the revert value for any special properties in your class. Note that if you do not also override `_propertyCanRevert()`for the same property,
+    /// this method will never be called.
+    /// - Returns:
+    /// If you do not handle the named property, return .unhandledProperty. If it's a standard or `@Export` property, Godot will still revert it so you don't need to worry
+    /// about any of those. Otherwise return the revert value as a Variant.
     open func _propertyGetRevert(_ property: StringName) -> GetPropertyResult {
         return .unhandledProperty
     }
@@ -933,6 +952,19 @@ func existingSwiftObject(for nativeHandle: GodotNativeObjectPointer) -> Wrapped?
     }
 }
 
+/// Return value for methods which may or may not return a value for a named property
+public enum GetPropertyResult: ~Copyable {
+	/// The method doesn't recognize or chooses not to operate on the named property. This does not neccesarily mean the property doesn't exist.
+	case unhandledProperty
+	/// The method handled the named property and has returned a value corresponding to it.
+	case variant(FastVariant?)
+	
+	/// Convenience function for constructing a `GetPropertyResult` from any VariantConvertible value
+	static public func from(_ value: some VariantConvertible) -> Self {
+		.variant(value.toFastVariant())
+	}
+}
+
 /// Describes the lifetime contract of an object pointer surfaced to Swift.
 ///
 /// This enum is about refcount behavior, not construction context.
@@ -1235,6 +1267,10 @@ func validatePropertyFunc(ptr: UnsafeMutableRawPointer?, _info: UnsafeMutablePoi
     return 0
 }
 
+/// Allows subclasses to override the behavior of `set()` via our own `_set()` function.
+/// - Returns:
+/// Returns 0 if there is no special handling of the named property. This allows the normal behavior of get() to work, so classes which subclass `_set()` don't have to (and indeed,
+/// should NOT) respond with 1 for standard properties.  When 1 is returned, you are indicating that the value passed in valuePtr was stored/retained.
 func setFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, valuePtr: UnsafeRawPointer? ) -> UInt8
 {
     guard let ptr,
@@ -1251,6 +1287,10 @@ func setFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, valuePtr
     return 0
 }
 
+/// Allows subclasses to override the behavior of `get()` via our own `_get()` function.
+/// - Returns:
+/// Returns 0 if there is no special handling of the named property. This allows the normal behavior of get() to work, so classes which subclass `_get()` don't have to (and indeed,
+/// should NOT) respond with 1 for standard properties.  When 1 is returned, retValuePtr will point to a Variant representing the value of the property.
 func getFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, retValuePtr: UnsafeMutableRawPointer?) -> UInt8 {
     guard let ptr else { return 0 }
     let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
@@ -1271,8 +1311,13 @@ func getFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, retValue
     return 0
 }
 
+// These exist to hold references to property list objects that are passed back to Godot,
+// but we retain ownership until `propertyListFreeFunc` is invoked, or the class is deinit'ed.
 var propertyListStorageCache: [PropertyInfoStorage]? = nil
 var propertyListPropInfoCache: [GDExtensionPropertyInfo]? = nil
+
+/// If our instance overrides `_getPropertyList(), we return those properties to Godot. Godot treats these
+/// as additive to any existing properties the object has, and thus doesn't allow us to directly override getPropertyList()
 func propertyListFunc(ptr: UnsafeMutableRawPointer?, countPtr: UnsafeMutablePointer<UInt32>?) -> UnsafePointer<GDExtensionPropertyInfo>? {
     guard let ptr else { return nil }
     let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
@@ -1280,14 +1325,19 @@ func propertyListFunc(ptr: UnsafeMutableRawPointer?, countPtr: UnsafeMutablePoin
 
     if let propertyList = instance._getPropertyList() {
         let propertyListData = propertyList.map { $0.makeOwnedNativeStruct() }
+        // Save the PropertyInfoStorage objects so that Swift doesn't free them - these
+        // hold the backing reference for StringNames and other items we're about to return.
+        // Note: Godot is not expected to call this function multiple times without first calling the propertyListFreeFunc
+        // in between, so we can just overwrite whatever's already stored. We could assert that it's currently `nil` for
+        // extra safety?
         propertyListStorageCache = propertyListData.map { $0.0 }
         
         var gdPropInfo: [GDExtensionPropertyInfo] = .init()
-        propertyListPropInfoCache = gdPropInfo
         // Ensure the elements have contiguous storage
         gdPropInfo.reserveCapacity(propertyListData.count)
         gdPropInfo.append(contentsOf: propertyListData.map{  $0.1 })
-        
+        propertyListPropInfoCache = gdPropInfo
+
         countPtr?.pointee = UInt32(propertyListData.count)
         return UnsafePointer<GDExtensionPropertyInfo>(gdPropInfo)
     }
@@ -1296,12 +1346,17 @@ func propertyListFunc(ptr: UnsafeMutableRawPointer?, countPtr: UnsafeMutablePoin
     return nil
 }
 
+/// Frees previously cached propertly list information because Godot is finished with it.
 func propertyListFreeFunc(ptr: UnsafeMutableRawPointer?, list: UnsafePointer<GDExtensionPropertyInfo>?)
 {
     propertyListStorageCache = nil
     propertyListPropInfoCache = nil
 }
 
+/// Allows subclasses to override the behavior of `propertyCanRevert()` via our own `_propertyCanRevert()` function.
+/// - Returns:
+/// Returns 0 if the property doesn't support reverting, or 1 if it does. Note that Godot doesn't treat this response as definitive, instead if it finds any 1 response
+/// in its known hierarchy then it treats the overall response as a 1/true.
 func canRevertFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?) -> UInt8 {
     guard let ptr else { return 0 }
     let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
@@ -1316,6 +1371,10 @@ func canRevertFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?) ->
     return 0
 }
 
+/// Allows subclasses to override the behavior of `propertyGetRevert()` via our own `_propertyGetRevert()` function.
+/// - Returns:
+/// Returns 0 if no there is no revert available for the named property. If there is, returns 1 and supplies a Variant in the retValuePtr parameter, representing the
+/// reverted value for the named property.
 func getRevertFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, retValuePtr: UnsafeMutableRawPointer?) -> UInt8 {
     guard let ptr else { return 0 }
     let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()

--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -263,6 +263,8 @@ open class Wrapped: Equatable, Identifiable, Hashable {
                 }
             }
         }
+		propertyListStorageCache = nil
+		propertyListPropInfoCache = nil
         extensionInterface.objectDeinited(object: self)
     }
     #if SWIFTGODOT_WITH_MULTI_PROCESS
@@ -305,6 +307,38 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     /// Return true if you made changes to the PropInfo value you got
     open func _validateProperty(_ property: inout PropInfo) -> Bool {
         return false
+    }
+    
+    open func _set(property: StringName, value: consuming Variant?) -> Bool {
+        return false
+    }
+
+    public enum GetPropertyResult: ~Copyable {
+        case unhandledProperty
+        case variant(FastVariant?)
+        
+        static public func from(_ value: some VariantConvertible) -> Self {
+            .variant(value.toFastVariant())
+        }
+    }
+    
+    open func _get(property: StringName) -> GetPropertyResult {
+        return .unhandledProperty
+    }
+
+    /// Works like getPropertyList, except it can be overridden by subclasses to expose programmatic properties
+    /// to Godot. Base properties are not included in the passed-in array, so they cannot be modified or removed by this method.
+    /// Values should be PropertyInfo wrapped in Variants.
+    open func _getPropertyList() -> [PropInfo]? {
+        return nil
+    }
+    
+    open func _propertyCanRevert(_ property: StringName, canRevert: inout Bool) -> Bool {
+        return false
+    }
+
+    open func _propertyGetRevert(_ property: StringName) -> GetPropertyResult {
+        return .unhandledProperty
     }
 
     /// Checks if this object has a script with the given method.
@@ -542,6 +576,12 @@ func register<T: Object>(type name: StringName, parent: StringName, type: T.Type
     info.notification_func = notificationFunc
     info.recreate_instance_func = recreateFunc
     info.validate_property_func = validatePropertyFunc
+    info.get_property_list_func = propertyListFunc
+    info.free_property_list_func = propertyListFreeFunc
+    info.set_func = setFunc
+    info.get_func = getFunc
+    info.property_can_revert_func = canRevertFunc
+    info.property_get_revert_func = getRevertFunc
     info.is_exposed = 1
     
     userTypes[name.description] = T.self
@@ -1192,6 +1232,108 @@ func validatePropertyFunc(ptr: UnsafeMutableRawPointer?, _info: UnsafeMutablePoi
 
         return 1
     }
+    return 0
+}
+
+func setFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, valuePtr: UnsafeRawPointer? ) -> UInt8
+{
+    guard let ptr,
+        let valuePtr else { return 0 }
+    let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
+    guard let instance = original.value else { return 0 }
+    let pname = StringName(fromPtr: namePtr)
+    
+    if let variant = Variant(copying: valuePtr.bindMemory(to: VariantContent.self, capacity: 1).pointee),
+       instance._set(property: pname, value: variant) {
+        return 1
+    }
+    
+    return 0
+}
+
+func getFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, retValuePtr: UnsafeMutableRawPointer?) -> UInt8 {
+    guard let ptr else { return 0 }
+    let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
+    guard let instance = original.value else { return 0 }
+    let pname = StringName(fromPtr: namePtr)
+
+    let result = instance._get(property: pname)
+    switch consume result {
+        case .unhandledProperty:
+            return 0
+        case let .variant(fastVariant):
+            if let fastVariant {
+                retValuePtr?.storeBytes(of: fastVariant.content, as: VariantContent.self)
+                fastVariant.unsafelyForget() // Godot assumed ownership over `fastVariant.content`
+                return 1
+            }
+    }
+    return 0
+}
+
+var propertyListStorageCache: [PropertyInfoStorage]? = nil
+var propertyListPropInfoCache: [GDExtensionPropertyInfo]? = nil
+func propertyListFunc(ptr: UnsafeMutableRawPointer?, countPtr: UnsafeMutablePointer<UInt32>?) -> UnsafePointer<GDExtensionPropertyInfo>? {
+    guard let ptr else { return nil }
+    let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
+    guard let instance = original.value else { return nil }
+
+    if let propertyList = instance._getPropertyList() {
+        let propertyListData = propertyList.map { $0.makeOwnedNativeStruct() }
+        propertyListStorageCache = propertyListData.map { $0.0 }
+        
+        var gdPropInfo: [GDExtensionPropertyInfo] = .init()
+        propertyListPropInfoCache = gdPropInfo
+        // Ensure the elements have contiguous storage
+        gdPropInfo.reserveCapacity(propertyListData.count)
+        gdPropInfo.append(contentsOf: propertyListData.map{  $0.1 })
+        
+        countPtr?.pointee = UInt32(propertyListData.count)
+        return UnsafePointer<GDExtensionPropertyInfo>(gdPropInfo)
+    }
+    
+    countPtr?.pointee = 0
+    return nil
+}
+
+func propertyListFreeFunc(ptr: UnsafeMutableRawPointer?, list: UnsafePointer<GDExtensionPropertyInfo>?)
+{
+    propertyListStorageCache = nil
+    propertyListPropInfoCache = nil
+}
+
+func canRevertFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?) -> UInt8 {
+    guard let ptr else { return 0 }
+    let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
+    guard let instance = original.value else { return 0 }
+    let pname = StringName(fromPtr: namePtr)
+    
+    var canRevert: Bool = false
+    if instance._propertyCanRevert(pname, canRevert: &canRevert) {
+        return canRevert ? 1 : 0
+    }
+
+    return 0
+}
+
+func getRevertFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, retValuePtr: UnsafeMutableRawPointer?) -> UInt8 {
+    guard let ptr else { return 0 }
+    let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
+    guard let instance = original.value else { return 0 }
+    let pname = StringName(fromPtr: namePtr)
+
+    let result = instance._propertyGetRevert(pname)
+    switch consume result {
+        case .unhandledProperty:
+            return 0
+        case let .variant(fastVariant):
+            if let fastVariant {
+                retValuePtr?.storeBytes(of: fastVariant.content, as: VariantContent.self)
+                fastVariant.unsafelyForget() // Godot assumed ownership over `fastVariant.content`
+                return 1
+            }
+    }
+    
     return 0
 }
 

--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -162,6 +162,11 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     #endif
     public static var deferred: Callable? = nil
 
+    // These exist to hold references to property list objects that are passed back to Godot,
+    // but we retain ownership until `propertyListFreeFunc` is invoked, or the class is deinit'ed.
+    public var propertyListStorageCache: [PropertyInfoStorage]? = nil
+    public var propertyListPropInfoCache: [GDExtensionPropertyInfo]? = nil
+    
     /// Conformance to Identifiable by using the native handle to the object
     public var id: Int { Int (bitPattern: handle) }
     
@@ -263,8 +268,8 @@ open class Wrapped: Equatable, Identifiable, Hashable {
                 }
             }
         }
-		propertyListStorageCache = nil
-		propertyListPropInfoCache = nil
+        propertyListStorageCache = nil
+        propertyListPropInfoCache = nil
         extensionInterface.objectDeinited(object: self)
     }
     #if SWIFTGODOT_WITH_MULTI_PROCESS
@@ -345,10 +350,13 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     /// `true` for any properties that you are not applying special handling to. Standard properties and any `@Export` properties will be handled appropriately even
     /// if you return `false` here.
     ///  - Returns:
-    ///  `true` if the named property supports reverting - this will almost always result in a subsequent call to `_propertyGetRevert()`
+	/// `.unhandledProperty` if the method does not recognize the named property or chooses not to act on it. This doesn't imply the property doesn't exist,
+    ///                 and it's still possible the revert can happen if another implementation in the chain responds to allow it.
+    ///  `.handledProperty` if the method recognizes and handles the named property. The value will be:
+    ///   `true` if the named property supports reverting - this will almost always result in a subsequent call to `_propertyGetRevert()`
     ///  `false` if the property does not support reverting.
-    open func _propertyCanRevert(_ property: StringName, canRevert: inout Bool) -> Bool {
-        return false
+    open func _propertyCanRevert(property: StringName) -> PropertyCanRevertResult {
+		return .unhandledProperty
     }
 
     /// Override to return the revert value for any special properties in your class. Note that if you do not also override `_propertyCanRevert()`for the same property,
@@ -356,7 +364,7 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     /// - Returns:
     /// If you do not handle the named property, return .unhandledProperty. If it's a standard or `@Export` property, Godot will still revert it so you don't need to worry
     /// about any of those. Otherwise return the revert value as a Variant.
-    open func _propertyGetRevert(_ property: StringName) -> GetPropertyResult {
+    open func _propertyGetRevert(property: StringName) -> GetPropertyResult {
         return .unhandledProperty
     }
 
@@ -965,6 +973,15 @@ public enum GetPropertyResult: ~Copyable {
 	}
 }
 
+/// Return value for methods which may or may not return a value for a named property
+public enum PropertyCanRevertResult: ~Copyable {
+	/// The method doesn't recognize or chooses not to operate on the named property. This does not neccesarily mean the property doesn't exist.
+	case unhandledProperty
+	/// The method recognizes the property in question and is providing an answer as to whether revert is allowed.
+	case handledProperty(Bool)
+}
+
+
 /// Describes the lifetime contract of an object pointer surfaced to Swift.
 ///
 /// This enum is about refcount behavior, not construction context.
@@ -1311,11 +1328,6 @@ func getFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, retValue
     return 0
 }
 
-// These exist to hold references to property list objects that are passed back to Godot,
-// but we retain ownership until `propertyListFreeFunc` is invoked, or the class is deinit'ed.
-var propertyListStorageCache: [PropertyInfoStorage]? = nil
-var propertyListPropInfoCache: [GDExtensionPropertyInfo]? = nil
-
 /// If our instance overrides `_getPropertyList(), we return those properties to Godot. Godot treats these
 /// as additive to any existing properties the object has, and thus doesn't allow us to directly override getPropertyList()
 func propertyListFunc(ptr: UnsafeMutableRawPointer?, countPtr: UnsafeMutablePointer<UInt32>?) -> UnsafePointer<GDExtensionPropertyInfo>? {
@@ -1330,13 +1342,13 @@ func propertyListFunc(ptr: UnsafeMutableRawPointer?, countPtr: UnsafeMutablePoin
         // Note: Godot is not expected to call this function multiple times without first calling the propertyListFreeFunc
         // in between, so we can just overwrite whatever's already stored. We could assert that it's currently `nil` for
         // extra safety?
-        propertyListStorageCache = propertyListData.map { $0.0 }
+        instance.propertyListStorageCache = propertyListData.map { $0.0 }
         
         var gdPropInfo: [GDExtensionPropertyInfo] = .init()
         // Ensure the elements have contiguous storage
         gdPropInfo.reserveCapacity(propertyListData.count)
         gdPropInfo.append(contentsOf: propertyListData.map{  $0.1 })
-        propertyListPropInfoCache = gdPropInfo
+        instance.propertyListPropInfoCache = gdPropInfo
 
         countPtr?.pointee = UInt32(propertyListData.count)
         return UnsafePointer<GDExtensionPropertyInfo>(gdPropInfo)
@@ -1349,8 +1361,11 @@ func propertyListFunc(ptr: UnsafeMutableRawPointer?, countPtr: UnsafeMutablePoin
 /// Frees previously cached propertly list information because Godot is finished with it.
 func propertyListFreeFunc(ptr: UnsafeMutableRawPointer?, list: UnsafePointer<GDExtensionPropertyInfo>?)
 {
-    propertyListStorageCache = nil
-    propertyListPropInfoCache = nil
+    guard let ptr else { return }
+    let original = Unmanaged<WrappedReference>.fromOpaque(ptr).takeUnretainedValue()
+    guard let instance = original.value else { return }
+    instance.propertyListStorageCache = nil
+    instance.propertyListPropInfoCache = nil
 }
 
 /// Allows subclasses to override the behavior of `propertyCanRevert()` via our own `_propertyCanRevert()` function.
@@ -1364,8 +1379,12 @@ func canRevertFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?) ->
     let pname = StringName(fromPtr: namePtr)
     
     var canRevert: Bool = false
-    if instance._propertyCanRevert(pname, canRevert: &canRevert) {
-        return canRevert ? 1 : 0
+    switch instance._propertyCanRevert(property: pname)
+    {
+        case .unhandledProperty:
+            return 0
+        case .handledProperty(let result):
+            return result ? 1 : 0
     }
 
     return 0
@@ -1381,7 +1400,7 @@ func getRevertFunc(ptr: UnsafeMutableRawPointer?, namePtr: UnsafeRawPointer?, re
     guard let instance = original.value else { return 0 }
     let pname = StringName(fromPtr: namePtr)
 
-    let result = instance._propertyGetRevert(pname)
+    let result = instance._propertyGetRevert(property: pname)
     switch consume result {
         case .unhandledProperty:
             return 0

--- a/Tests/SwiftGodotTestExtension/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTestExtension/MemoryLeakTests.swift
@@ -702,4 +702,15 @@ final class MemoryLeakTests {
             dictionary.clear()
         }
     }
+    
+    public func test_propertylist_leaks() {
+        let node  = TestPropList()
+        checkLeaks {
+             _ = node.getPropertyList()
+            _ = node.propertyCanRevert(property: "Special")
+            _ = node.propertyGetRevert(property: "Special")
+            _ = node.get(property: "Special")
+             node.set(property: "Special", value: Variant(100))
+        }
+	}
 }

--- a/Tests/SwiftGodotTestExtension/PropertyListTests.swift
+++ b/Tests/SwiftGodotTestExtension/PropertyListTests.swift
@@ -29,15 +29,16 @@ private class TestPropList: Node {
         return false
     }
 
-    override func _propertyGetRevert(_ property: StringName) -> GetPropertyResult {
+    override func _propertyGetRevert(property: StringName) -> GetPropertyResult {
         if property == "Special" {
             return .from(1)
         }
         return .unhandledProperty
     }
 
-    override func _propertyCanRevert(_ property: StringName, canRevert: inout Bool) -> Bool {
-        return property == "Special"
+    override func _propertyCanRevert(property: StringName) -> PropertyCanRevertResult {
+		guard property == "Special" else { return .unhandledProperty }
+		return .handledProperty(true)
     }
 
     override func _getPropertyList() -> [PropInfo]? {
@@ -86,20 +87,18 @@ final class PropertyListTests {
         var foundStandard = false
         for prop in node.getPropertyList() {
             if let name =  prop["name"],
-               String.fromVariant(name) == "standardVariable" {
+               String.fromVariant(name) == "standard_variable" {
                 foundStandard = true
                 break
             }
         }
-        assertTrue(foundStandard, "Did not find the 'standardVariable' property in node's property list")
+        assertTrue(foundStandard, "Did not find the 'standard_variable' property in node's property list.")
         
-        assertTrue(node.propertyCanRevert(property: "standardVariable"), "`standardVariable` property should be revertable")
-        
-        let originalValue = node.get(property: "standardVariable")
-        node.set(property: "standardVariable", value: Variant(12))
-        let newValue = node.get(property: "standardVariable")
-        assertNotEqual(Int.fromVariant(originalValue), Int.fromVariant(newValue), "Setting 'standardVariable` value on Node did not change the value")
-        assertEqual(Int.fromVariant(newValue), 12, "Did not receive same value back after setting `standardVariable` value on node")
+        let originalValue = node.get(property: "standard_variable")
+        node.set(property: "standard_variable", value: Variant(12))
+        let newValue = node.get(property: "standard_variable")
+        assertNotEqual(Int.fromVariant(originalValue), Int.fromVariant(newValue), "Setting 'standard_variable` value on Node did not change the value")
+        assertEqual(Int.fromVariant(newValue), 12, "Did not receive same value back after setting `standard_variable` value on node")
         
         node.queueFree()
     }

--- a/Tests/SwiftGodotTestExtension/PropertyListTests.swift
+++ b/Tests/SwiftGodotTestExtension/PropertyListTests.swift
@@ -8,7 +8,7 @@
 @testable import SwiftGodot
 
 @Godot
-private class TestPropList: Node {
+class TestPropList: Node {
     @Export
     var standardVariable: Int = 1
 

--- a/Tests/SwiftGodotTestExtension/PropertyListTests.swift
+++ b/Tests/SwiftGodotTestExtension/PropertyListTests.swift
@@ -1,0 +1,107 @@
+//
+//  PropertyListTests.swift
+//  SwiftGodot
+//
+//  Created by Chris Backas on 6/21/26.
+//
+
+@testable import SwiftGodot
+
+@Godot
+private class TestPropList: Node {
+    @Export
+    var standardVariable: Int = 1
+
+    private var specialVar: Int = 1
+
+    override func _get(property: StringName) -> GetPropertyResult {
+        if property == "Special" {
+            return .from(specialVar)
+        }
+        return .unhandledProperty
+    }
+
+    override func _set(property: StringName, value: consuming Variant?) -> Bool {
+        if property == "Special" {
+            specialVar = Int.fromVariant(value) ?? 0
+            return true
+        }
+        return false
+    }
+
+    override func _propertyGetRevert(_ property: StringName) -> GetPropertyResult {
+        if property == "Special" {
+            return .from(1)
+        }
+        return .unhandledProperty
+    }
+
+    override func _propertyCanRevert(_ property: StringName, canRevert: inout Bool) -> Bool {
+        return property == "Special"
+    }
+
+    override func _getPropertyList() -> [PropInfo]? {
+        return [PropInfo(propertyType: .int,
+                         propertyName: "Special",
+                         className: "TestPropList",
+                         hint: .none,
+                         hintStr: "",
+                         usage: .default)]
+    }
+}
+
+@SwiftGodotTestSuite
+final class PropertyListTests {
+    public static var registeredTypes: [Object.Type] {
+        return [TestPropList.self]
+    }
+
+    public func testSpecialHandled() {
+        let node = TestPropList()
+        var foundSpecial = false
+        for prop in node.getPropertyList() {
+            if let name =  prop["name"],
+               String.fromVariant(name) == "Special" {
+                foundSpecial = true
+                break
+            }
+        }
+        assertTrue(foundSpecial, "Did not find the 'Special' property in node's property list")
+        
+        assertTrue(node.propertyCanRevert(property: "Special"), "`Special` property should be revertable")
+        let revertValue = node.propertyGetRevert(property: "Special")
+        let revertValueInt = Int.fromVariant(revertValue)
+        assertEqual(revertValueInt, 1, "Revert value should be 1, was \(revertValueInt.debugDescription)")
+        
+        let originalValue = node.get(property: "Special")
+        node.set(property: "Special", value: Variant(12))
+        let newValue = node.get(property: "Special")
+        assertNotEqual(Int.fromVariant(originalValue), Int.fromVariant(newValue), "Setting 'Special` value on Node did not change the value")
+        assertEqual(Int.fromVariant(newValue), 12, "Did not receive same value back after setting `Special` value on node")
+        node.queueFree()
+    }
+    
+    public func testStandardExportNotBroken() {
+        let node = TestPropList()
+        var foundStandard = false
+        for prop in node.getPropertyList() {
+            if let name =  prop["name"],
+               String.fromVariant(name) == "standardVariable" {
+                foundStandard = true
+                break
+            }
+        }
+        assertTrue(foundStandard, "Did not find the 'standardVariable' property in node's property list")
+        
+        assertTrue(node.propertyCanRevert(property: "standardVariable"), "`standardVariable` property should be revertable")
+        
+        let originalValue = node.get(property: "standardVariable")
+        node.set(property: "standardVariable", value: Variant(12))
+        let newValue = node.get(property: "standardVariable")
+        assertNotEqual(Int.fromVariant(originalValue), Int.fromVariant(newValue), "Setting 'standardVariable` value on Node did not change the value")
+        assertEqual(Int.fromVariant(newValue), 12, "Did not receive same value back after setting `standardVariable` value on node")
+        
+        node.queueFree()
+    }
+    
+}


### PR DESCRIPTION
There are several methods on Object that aren't virual, and so SwiftGodot creates them as `final` when generating the Swift interface. These methods are `getPropertyList()`, `propertyCanRevert()`, `propertyGetRevert()`, `get()` and `set()`

Overridding all of these is neccesary however if one wants to support custom properties in some fashion, and is a capability that other GDExtensions have (EG: C++).

The GDExtension API has function hooks for all of these methods that SwiftGodot does not supply today.

This PR adds hooks for all of these functions, and adds underbar versions of all the methods to the base Object. (`_getPropertyList()`, `_propertyCanRevert()`, `_propertyGetRevert()`, `_get()` and `_set()`)
These methods are overridable by subclasses to allow them to provide the neccesary functionality, but the default implementations don't alter the overall behavior for cases where no override is needed.