### PR TITLE
Add an "explicitName" argument to @Callable and @Export

### DIFF
--- a/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroCallable.swift
@@ -87,7 +87,7 @@ public struct GodotCallable: PeerMacro {
         let callArgs = callArgsList.joined(separator: ", ")
         
         body += """
-        \(indentation)    return SwiftGodotRuntime._wrapCallableResult(\(objectOrSelf).\(funcName)(\(callArgs)))
+        \n\(indentation)    return SwiftGodotRuntime._wrapCallableResult(\(objectOrSelf).\(funcName)(\(callArgs)))
         
         """
 

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -107,9 +107,17 @@ class GodotMacroProcessor {
         let funcName = funcDecl.name.text
         
         let godotFuncName: String
-        if try callableAttribute.callableAutoSnakeCaseArgument {
+        let autoSnakeCase = try callableAttribute.callableAutoSnakeCaseArgument
+        let explicitName = try callableAttribute.explicitNameArgument
+        guard autoSnakeCase == false || explicitName == nil else {
+            throw GodotMacroError.invalidArgumentCombination(("autoSnakeCase", "explicitName"))
+        }
+        if autoSnakeCase {
             godotFuncName = funcName.camelCaseToSnakeCase()
-        } else {
+        } else if let explicitName {
+            godotFuncName = explicitName
+        }
+        else {
             godotFuncName = funcName
         }
         
@@ -302,8 +310,19 @@ class GodotMacroProcessor {
             // Determine if this property needs a setter (same logic as Export macro)
             let needsSetter = Self.bindingNeedsSetter(variableDecl: varDecl, binding: binding)
             
-            let varNameWithPrefix = ips.identifier.text
-            let varNameWithoutPrefix = String(varNameWithPrefix.trimmingPrefix(prefix ?? ""))
+            // Decide what we're going to name this property
+            var godotNameIsExplicit = false
+            let varNameWithPrefix: String
+            let varNameWithoutPrefix: String
+            if let explicitName = try exportAttribute.explicitNameArgument {
+                varNameWithPrefix = "\(prefix ?? "")\(explicitName)"
+                varNameWithoutPrefix = explicitName
+                godotNameIsExplicit = true
+            } else {
+                varNameWithPrefix = ips.identifier.text
+                varNameWithoutPrefix = String(varNameWithPrefix.trimmingPrefix(prefix ?? ""))
+            }
+            
             // For the case where there is no setter, set the proxySetterName to the empty string
             let proxySetterName = needsSetter ? "_mproxy_set_\(varNameWithPrefix)" : ""
             let proxyGetterName = "_mproxy_get_\(varNameWithPrefix)"
@@ -314,7 +333,7 @@ class GodotMacroProcessor {
             // Keep building the args list as before.
             var args: [String] = [
                 "at: \\\(className).\(varNameWithPrefix)",
-                "name: \"\(varNameWithPrefix.camelCaseToSnakeCase())\""
+                "name: \"\(godotNameIsExplicit ? varNameWithPrefix : varNameWithPrefix.camelCaseToSnakeCase())\""
             ]
             
             if let hint = hintExpr?.trimmedDescription {

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -307,18 +307,15 @@ class GodotMacroProcessor {
             // Determine if this property needs a setter (same logic as Export macro)
             let needsSetter = Self.bindingNeedsSetter(variableDecl: varDecl, binding: binding)
             
-            // Decide what we're going to name this property
-            var godotNameIsExplicit = false
-            let varNameWithPrefix: String
-            let varNameWithoutPrefix: String
+            let varNameWithPrefix = ips.identifier.text
+            let varNameWithoutPrefix = String(varNameWithPrefix.trimmingPrefix(prefix ?? ""))
+            var nameGodotSees: String
             if let explicitName = try exportAttribute.explicitNameArgument {
-                varNameWithPrefix = "\(prefix ?? "")\(explicitName)"
-                varNameWithoutPrefix = explicitName
-                godotNameIsExplicit = true
+                nameGodotSees = explicitName
             } else {
-                varNameWithPrefix = ips.identifier.text
-                varNameWithoutPrefix = String(varNameWithPrefix.trimmingPrefix(prefix ?? ""))
+                nameGodotSees = varNameWithPrefix.camelCaseToSnakeCase()
             }
+            
             
             // For the case where there is no setter, set the proxySetterName to the empty string
             let proxySetterName = needsSetter ? "_mproxy_set_\(varNameWithPrefix)" : ""
@@ -330,7 +327,7 @@ class GodotMacroProcessor {
             // Keep building the args list as before.
             var args: [String] = [
                 "at: \\\(className).\(varNameWithPrefix)",
-                "name: \"\(godotNameIsExplicit ? varNameWithPrefix : varNameWithPrefix.camelCaseToSnakeCase())\""
+                "name: \"\(nameGodotSees)\""
             ]
             
             if let hint = hintExpr?.trimmedDescription {

--- a/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroGodot.swift
@@ -109,9 +109,6 @@ class GodotMacroProcessor {
         let godotFuncName: String
         let autoSnakeCase = try callableAttribute.callableAutoSnakeCaseArgument
         let explicitName = try callableAttribute.explicitNameArgument
-        guard autoSnakeCase == false || explicitName == nil else {
-            throw GodotMacroError.invalidArgumentCombination(("autoSnakeCase", "explicitName"))
-        }
         if autoSnakeCase {
             godotFuncName = funcName.camelCaseToSnakeCase()
         } else if let explicitName {

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -30,7 +30,9 @@ enum GodotMacroError: Error, DiagnosticMessage {
     case nameCollision(String)
     case legacySignalMacroUnexpectedArgumentsSyntax
     case legacySignalMacroTooManyArguments
-    case illegalCallableAutoSnakeCaseArgument(String)    
+    case illegalCallableAutoSnakeCaseArgument(String)
+    case invalidExplicitNameArgument(String)
+    case invalidArgumentCombination((String, String))
     
     var severity: DiagnosticSeverity {
         return .error
@@ -38,6 +40,10 @@ enum GodotMacroError: Error, DiagnosticMessage {
 
     var message: String {
         switch self {
+        case .invalidArgumentCombination(let args):
+            "The arguments \(args.0) and \(args.1) are mutually exclusive."
+        case .invalidExplicitNameArgument(let expr):
+            "`explicitName` \(expr) is illegal."
         case .illegalCallableAutoSnakeCaseArgument(let expr):
             "`autoSnakeCase: \(expr)` is illegal. `true` or `false` expected."
         case .exportMacroOnReadonlyVariable:

--- a/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
+++ b/Sources/SwiftGodotMacroLibrary/MacroSharedApi.swift
@@ -32,7 +32,6 @@ enum GodotMacroError: Error, DiagnosticMessage {
     case legacySignalMacroTooManyArguments
     case illegalCallableAutoSnakeCaseArgument(String)
     case invalidExplicitNameArgument(String)
-    case invalidArgumentCombination((String, String))
     
     var severity: DiagnosticSeverity {
         return .error
@@ -40,8 +39,6 @@ enum GodotMacroError: Error, DiagnosticMessage {
 
     var message: String {
         switch self {
-        case .invalidArgumentCombination(let args):
-            "The arguments \(args.0) and \(args.1) are mutually exclusive."
         case .invalidExplicitNameArgument(let expr):
             "`explicitName` \(expr) is illegal."
         case .illegalCallableAutoSnakeCaseArgument(let expr):

--- a/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftGodotMacroLibrary/SwiftSyntaxExtensions.swift
@@ -135,6 +135,23 @@ extension AttributeSyntax {
     }
 }
 
+extension AttributeSyntax {
+    var explicitNameArgument: String? {
+        get throws {
+            guard let exprSyntax = arguments?.argument(labeled: "explicitName") else {
+                return nil
+            }
+            
+            guard let stringExprSyntax: StringLiteralExprSyntax = exprSyntax.expression.as(StringLiteralExprSyntax.self),
+                  let expr = stringExprSyntax.segments.first?.as(StringSegmentSyntax.self)?.trimmedDescription,
+                  !expr.isEmpty else {
+                throw GodotMacroError.invalidExplicitNameArgument(exprSyntax.expression.trimmedDescription)
+            }
+            return expr
+        }
+    }
+}
+
 extension AttributeListSyntax {
     func attribute(named name: String) -> AttributeSyntax? {
         for element in self {

--- a/Sources/SwiftGodotRuntime/MacroDefs.swift
+++ b/Sources/SwiftGodotRuntime/MacroDefs.swift
@@ -32,9 +32,11 @@ public enum ClassBehavior: Int {
 ///
 /// The parameters and returns type of the function must be `_GodotBridgeable`.
 ///
-/// - Parameter autoSnakeCase: if `true` (default value is `false`), the function name will be automatically translated from `camelCase` to `snake_case` when exposed to Godot
+/// - Parameter autoSnakeCase: if `true` (default value is `false`), the function name will be automatically translated from `camelCase` to `snake_case` when exposed to Godot. `explicitName` must be set to nil to use autoSnakeCase.
+/// - Parameter explicitName: If not nil, this will be used as the function name exported to Godot exactly as written.  If using `explicitName`, `autoSnakeCase` must be false.
+///
 @attached(peer, names: prefixed(_mproxy_), prefixed(_pproxy_))
-public macro Callable(autoSnakeCase: Bool = false) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
+public macro Callable(autoSnakeCase: Bool = false, explicitName: String? = nil) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
 
 /// Exposes a property or variable to the Godot runtime
 ///
@@ -49,9 +51,10 @@ public macro Callable(autoSnakeCase: Bool = false) = #externalMacro(module: "Swi
 /// - Parameter hintStr: some of the hint types can use an additional configuration option as a string
 /// and this is used for this.  For example the `.file` option can have a mask to select files, for example `"*.png"`
 /// - Parameter usage: The desired usage flags, applies to exported variables
+/// - Parameter explicitName:If not nil, this will be used as the property name exported to Godot exactly as written.
 ///
 @attached(peer, names: prefixed(_mproxy_get_), prefixed(_mproxy_set_), arbitrary)
-public macro Export(_ hint: PropertyHint = .none, _ hintStr: String? = nil, usage: PropertyUsageFlags = .default) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotExport")
+public macro Export(_ hint: PropertyHint = .none, _ hintStr: String? = nil, usage: PropertyUsageFlags = .default, explicitName: String? = nil) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotExport")
 
 // MARK: - Freestanding Macros
 

--- a/Sources/SwiftGodotRuntime/MacroDefs.swift
+++ b/Sources/SwiftGodotRuntime/MacroDefs.swift
@@ -32,11 +32,13 @@ public enum ClassBehavior: Int {
 ///
 /// The parameters and returns type of the function must be `_GodotBridgeable`.
 ///
-/// - Parameter autoSnakeCase: if `true` (default value is `false`), the function name will be automatically translated from `camelCase` to `snake_case` when exposed to Godot. `explicitName` must be set to nil to use autoSnakeCase.
-/// - Parameter explicitName: If not nil, this will be used as the function name exported to Godot exactly as written.  If using `explicitName`, `autoSnakeCase` must be false.
+/// - Parameter autoSnakeCase: if `true` (default value is `false`), the function name will be automatically translated from `camelCase` to `snake_case` when exposed to Godot. `
 ///
 @attached(peer, names: prefixed(_mproxy_), prefixed(_pproxy_))
-public macro Callable(autoSnakeCase: Bool = false, explicitName: String? = nil) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
+public macro Callable(autoSnakeCase: Bool = false) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
+/// - Parameter explicitName: This will be used as the function name exported to Godot exactly as written.
+@attached(peer, names: prefixed(_mproxy_), prefixed(_pproxy_))
+public macro Callable(explicitName: String) = #externalMacro(module: "SwiftGodotMacroLibrary", type: "GodotCallable")
 
 /// Exposes a property or variable to the Godot runtime
 ///

--- a/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
+++ b/Tests/SwiftGodotMacrosTests/MacroGodotTests.swift
@@ -482,6 +482,28 @@ final class MacroGodotTests: MacroGodotTestCase {
         )
     }
     
+    func testCallableExplicitName() {
+        assertExpansion(
+            of: """
+            @Godot class TestClass: Node {
+                @Callable(explicitName: "testExplicitName")
+                func originalName() {}
+            }
+            """
+        )
+    }
+
+    func testExportExplicitName() {
+        assertExpansion(
+            of: """
+            @Godot class TestClass: Node {
+                @Export(explicitName: "testExplicitName")
+                var originalName: Node? = nil
+            }
+            """
+        )
+    }
+    
     func testNoTypeAnnotationTrivia() {
         assertExpansion(
             of: """

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableExplicitName.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testCallableExplicitName.swift
@@ -1,0 +1,57 @@
+class TestClass: Node {
+    func originalName() {}
+
+    static func _mproxy_originalName(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodotRuntime.Arguments) -> SwiftGodotRuntime.FastVariant? {
+        guard let object = SwiftGodotRuntime._unwrap(self, pInstance: pInstance) else {
+            SwiftGodotRuntime.GD.printErr("Error calling `originalName`: failed to unwrap instance \(String(describing: pInstance))")
+            return nil
+        }
+        return SwiftGodotRuntime._wrapCallableResult(object.originalName())
+
+    }
+    static func _pproxy_originalName(        
+    _ pInstance: UnsafeMutableRawPointer?,
+    _ rargs: SwiftGodotRuntime.RawArguments,
+    _ returnValue: UnsafeMutableRawPointer?) {
+        guard let object = SwiftGodotRuntime._unwrap(self, pInstance: pInstance) else {
+            SwiftGodotRuntime.GD.printErr("Error calling `originalName`: failed to unwrap instance \(String(describing: pInstance))")
+            return
+        }
+        SwiftGodotRuntime.RawReturnWriter.writeResult(returnValue, object.originalName()) 
+
+    }
+
+    override open class var classInitializer: Void {
+        let _ = super.classInitializer
+        return _initializeClass()
+    }
+
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: TestClass.self) else {
+            return
+        }
+        let className = StringName("TestClass")
+        if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
+            // ClassDB singleton is not available prior to `.scene` level
+            assert(ClassDB.classExists(class: className))
+        }
+        SwiftGodotRuntime._registerMethod(
+            className: className,
+            name: "testExplicitName",
+            flags: .default,
+            returnValue: SwiftGodotRuntime._returnValuePropInfo(Swift.Void.self),
+            arguments: [
+
+            ],
+            function: TestClass._mproxy_originalName,
+            ptrFunction: { udata, classInstance, argsPtr, retValue in
+                guard let argsPtr else {
+                    GD.print("Godot is not passing the arguments");
+                    return
+                }
+                TestClass._pproxy_originalName (classInstance, RawArguments(args: argsPtr), retValue)
+            }
+
+        )
+    }
+}

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportExplicitName.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportExplicitName.swift
@@ -39,16 +39,16 @@ class TestClass: Node {
         SwiftGodotRuntime._registerPropertyWithGetterSetter(
             className: className,
             info: SwiftGodotRuntime._propInfo(
-                at: \TestClass.testExplicitName,
+                at: \TestClass.originalName,
                 name: "testExplicitName",
                 userHint: nil,
                 userHintStr: nil,
                 userUsage: nil
             ),
-            getterName: "get_test_explicit_name",
-            setterName: "set_test_explicit_name",
-            getterFunction: TestClass._mproxy_get_testExplicitName,
-            setterFunction: TestClass._mproxy_set_testExplicitName
+            getterName: "get_original_name",
+            setterName: "set_original_name",
+            getterFunction: TestClass._mproxy_get_originalName,
+            setterFunction: TestClass._mproxy_set_originalName
         )
     }
 }

--- a/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportExplicitName.swift
+++ b/Tests/SwiftGodotMacrosTests/Resources/MacroGodotTests.testExportExplicitName.swift
@@ -1,0 +1,54 @@
+class TestClass: Node {
+    var originalName: Node? = nil
+
+    static func _mproxy_set_originalName(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodotRuntime.Arguments) -> SwiftGodotRuntime.FastVariant? {
+        guard let object = _unwrap(self, pInstance: pInstance) else {
+            SwiftGodotRuntime.GD.printErr("Error calling setter for originalName: failed to unwrap instance \(String(describing: pInstance))")
+            return nil
+        }
+
+        SwiftGodotRuntime._invokeSetter(arguments, "originalName", object.originalName) {
+            object.originalName = $0
+        }
+        return nil
+    }
+
+    static func _mproxy_get_originalName(pInstance: UnsafeRawPointer?, arguments: borrowing SwiftGodotRuntime.Arguments) -> SwiftGodotRuntime.FastVariant? {
+        guard let object = _unwrap(self, pInstance: pInstance) else {
+            SwiftGodotRuntime.GD.printErr("Error calling getter for originalName: failed to unwrap instance \(String(describing: pInstance))")
+            return nil
+        }
+
+        return SwiftGodotRuntime._invokeGetter(object.originalName)
+    }
+
+    override open class var classInitializer: Void {
+        let _ = super.classInitializer
+        return _initializeClass()
+    }
+
+    private static func _initializeClass() {
+        guard swiftGodotShouldInitializeClass(type: TestClass.self) else {
+            return
+        }
+        let className = StringName("TestClass")
+        if classInitializationLevel.rawValue >= ExtensionInitializationLevel.scene.rawValue {
+            // ClassDB singleton is not available prior to `.scene` level
+            assert(ClassDB.classExists(class: className))
+        }
+        SwiftGodotRuntime._registerPropertyWithGetterSetter(
+            className: className,
+            info: SwiftGodotRuntime._propInfo(
+                at: \TestClass.testExplicitName,
+                name: "testExplicitName",
+                userHint: nil,
+                userHintStr: nil,
+                userUsage: nil
+            ),
+            getterName: "get_test_explicit_name",
+            setterName: "set_test_explicit_name",
+            getterFunction: TestClass._mproxy_get_testExplicitName,
+            setterFunction: TestClass._mproxy_set_testExplicitName
+        )
+    }
+}


### PR DESCRIPTION
Sometimes you might need to want direct control over the name that Godot sees for your method or property. For instance, maybe you want Godot/GDScript to see a different name for a property than Swift does:

@Export(explicitName = "my_param")
var myParamVariant: Variant? = nil

var myParam: String? { 
get { return String.fromVariant(myParamVariant)
}

That way the "myParam" property is nicely usable in Swift while maintaining a familiar name on the Godot side as well.