### PR TITLE
`canRevert`'s `.handledProperty` case should use an argument label for clarity

### DIFF
--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -978,7 +978,7 @@ public enum PropertyCanRevertResult: ~Copyable {
 	/// The method doesn't recognize or chooses not to operate on the named property. This does not neccesarily mean the property doesn't exist.
 	case unhandledProperty
 	/// The method recognizes the property in question and is providing an answer as to whether revert is allowed.
-	case handledProperty(Bool)
+	case handledProperty(canRevert: Bool)
 }
 
 

--- a/Tests/SwiftGodotTestExtension/PropertyListTests.swift
+++ b/Tests/SwiftGodotTestExtension/PropertyListTests.swift
@@ -38,7 +38,7 @@ class TestPropList: Node {
 
     override func _propertyCanRevert(property: StringName) -> PropertyCanRevertResult {
 		guard property == "Special" else { return .unhandledProperty }
-		return .handledProperty(true)
+		return .handledProperty(canRevert: true)
     }
 
     override func _getPropertyList() -> [PropInfo]? {


### PR DESCRIPTION
Nice QoL improvement that unfortunately missed the merge