### PR TITLE
Bring back `await signal.emitted`, safely

### DIFF
--- a/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Differences.md
@@ -258,10 +258,6 @@ MySwiftNode.myCallback.call("Hello from Swift!")
 
 ## Async/Await
 
-> 
-> ##### ⚠️ Note
-> The snippets below are using deprecated API and are dangerous. If signal never emits the Swift coroutine state will leak with all the captured context. Prefer using `Signal.connect`
-
 GDScript comes with an `await` primitive, you can achieve similar functionality
 with the Swift built-in await/async stack.   Unlike GDScript, await can only be
 invoked from `async` methods.
@@ -270,15 +266,15 @@ This means that code like this wont work:
 
 ```swift
 func demo() {
-	await someSignal.emitted
+	try await someSignal.emitted
 }
 ```
 
 For this to work, this needs to be in an async context, like this one:
 
 ```swift
-func demo() async {
-	await someSignal.emitted
+func demo() async throws {
+	try await someSignal.emitted
 }
 ```
 
@@ -288,8 +284,36 @@ Task, like this:
 ```swift
 func demo() {
 	// We are not an async function, but we can start a Task
-	Task {
-		await someSignal.emitted
+	Task { @MainActor in
+		try await someSignal.emitted
 	}
 }
 ```
+
+### What `await` accepts
+
+GDScript's `await` takes a signal, or a call to a coroutine - a function that itself
+contains `await`. SwiftGodot covers both, plus the builtin `Signal` Variant type:
+
+| GDScript | SwiftGodot |
+|---|---|
+| `await some_signal` | `try await someSignal.emitted` |
+| `await obj.get_signal("x")` | `try await Signal(object: obj, signal: "x").emitted` |
+| `await obj.some_coroutine()` | `try await obj.callScriptAsync(method: "some_coroutine")` |
+
+A typed signal's payload comes back with its Swift types - `()` for a `SimpleSignal`, the
+argument itself for a one-argument signal, a tuple otherwise. A `Signal` value carries no
+static type information, so it yields `[Variant?]`.
+
+### Differences worth knowing
+
+- **`await` throws here.** Cancelling the task disconnects from the signal and throws
+  `CancellationError`; a signal whose object is already gone throws
+  `SignalAwaitError.targetUnavailable` instead of hanging. GDScript has neither.
+- **A destroyed emitter never resumes the wait**, in Swift exactly as in GDScript. Bound
+  the wait with cancellation if the emitter might not survive it.
+- **Resumption thread.** GDScript always resumes on the main thread. Swift resumes on the
+  actor you awaited from, so a bare `Task { }` resumes on the cooperative pool, where
+  touching the scene tree is not safe. Use `Task { @MainActor in }` - and see
+  <doc:Signals> for the platform caveat about whether `MainActor` is scheduled at all
+  under Godot.

--- a/Sources/SwiftGodot/SwiftGodot.docc/Signals.md
+++ b/Sources/SwiftGodot/SwiftGodot.docc/Signals.md
@@ -59,6 +59,102 @@ class Demo: Node {
 }
 ```
 
+## One-shot signals
+
+A common idiom in Godot is to wait for a signal before continuing - a timeout, an
+animation finishing, a player action. Await the `emitted` property of the signal:
+
+```swift
+func waitTimer(scene: SceneTree) async throws {
+    let timer = scene.createTimer(timeSec: 3)
+
+    try await timer.timeout.emitted
+
+    print("Done waiting!")
+}
+```
+
+The value you get back is the signal's payload. A ``SimpleSignal`` yields `()`, a signal
+with one argument yields that argument, and anything else yields a tuple:
+
+```swift
+// SignalWithArguments<Int, String>
+let (age, name) = try await player.described.emitted
+```
+
+If you are not already in an async function, start a task:
+
+```swift
+func waitSomething(scene: SceneTree) {
+    Task { @MainActor in
+        try await timer.timeout.emitted
+        GD.print("timer fired")
+    }
+}
+```
+
+### What can be awaited
+
+Three things:
+
+- **A typed signal** - any built-in signal, or one you declared with `@Signal`. This is
+  the case above.
+- **A ``Signal`` value** - the builtin Variant type, which is what GDScript hands you and
+  what ``Signal/init(object:signal:)`` builds. It carries no static type information, so
+  its payload is an array of ``Variant``:
+  ```swift
+  let arguments = try await Signal(object: node, signal: "lives_changed").emitted
+  ```
+- **A call into a script that suspends.** In GDScript a function containing `await` is a
+  coroutine; calling it returns a handle rather than a value. ``Object/callScriptAsync(method:_:)``
+  waits for such a call to finish, and passes an ordinary return value straight through:
+  ```swift
+  let value = try await object.callScriptAsync(method: "slow", tree.toVariant())
+  ```
+
+Awaiting anything else is not supported - there is no general "await a Godot call".
+
+### Cancellation, and signals that never fire
+
+Cancelling the awaiting task disconnects from the signal and throws `CancellationError`,
+so an abandoned wait releases everything it was holding:
+
+```swift
+let task = Task { @MainActor in
+    try await enemy.died.emitted
+}
+task.cancel()   // disconnects; the await throws
+```
+
+One hazard remains, and it is worth knowing: **if the object that declares the signal is
+destroyed while you are waiting, the await does not resume.** Godot silently drops the
+connection with the object, and nothing is left to wake the task. GDScript's own `await`
+behaves the same way. When the emitter might not outlive the wait, bound it - with task
+cancellation, or with a timeout.
+
+If the object is *already* gone when the await begins, that is detected and reported as
+``SignalAwaitError/targetUnavailable`` rather than hanging.
+
+### Which thread resumes
+
+Two separate things are going on here, and it helps to keep them apart.
+
+The first is a Swift guarantee: **execution resumes on the actor you awaited from.** Await
+from a `@MainActor` context and the code after the await runs on `MainActor`. Await from a
+bare `Task { }` - which is isolated to nothing - and it resumes on the cooperative thread
+pool, where you must not touch the scene tree.
+
+The second is a question about the host: **is that actor running on Godot's thread?**
+`MainActor` means Swift's main executor, which is the libdispatch main queue. Godot runs
+its own event loop, so whether that queue is ever drained depends on the platform. On
+macOS the display server spins the run loop, which does drain it - measured, and the
+`MainActor` thread is Godot's main thread. On Linux and Windows Godot never touches that
+queue, so a `Task { @MainActor in }` may not be scheduled at all.
+
+So: prefer `Task { @MainActor in }`, and confirm it on your target platform before relying
+on it. If you need a guarantee across platforms, drive the work from Godot's own message
+queue with `Callable(...).callDeferred()`, which is what `MainActor` is standing in for.
+
 ## Declaring your own Signals
 
 It is also possible to define your own signals to broadcast them, both

--- a/Sources/SwiftGodotRuntime/Core/SignalProxy.swift
+++ b/Sources/SwiftGodotRuntime/Core/SignalProxy.swift
@@ -17,7 +17,13 @@
 /// // Let godot call `demo` and its proxy method.
 /// invokeScript ("myDemo.proxy ()", params: ["myDemo", demo])
 /// ```
-//@available(*, deprecated, message: "Use Callable constructed from Swift closure instead")
+///
+/// > Warning: instances of this type are never freed.  `SignalProxy` is a plain `Object`,
+/// > not a `RefCounted`, so it must be released with ``Object/free()``, and it is
+/// > additionally pinned by the live-object table.  Use
+/// > ``Callable`` built from a Swift closure instead - it is owned by the connection and
+/// > released when the connection goes away.
+@available(*, deprecated, message: "Use Callable constructed from a Swift closure instead")
 public class SignalProxy: Object {
     public static var proxyName = StringName("proxy")
 

--- a/Sources/SwiftGodotRuntime/Core/SignalWithArguments.swift
+++ b/Sources/SwiftGodotRuntime/Core/SignalWithArguments.swift
@@ -5,11 +5,116 @@
 /// Simple signal without arguments.
 public typealias SimpleSignal = SignalWithArguments< /* no args */>
 
+/// Failures that can interrupt awaiting ``SignalWithArguments/emitted``.
+public enum SignalAwaitError: Error, CustomStringConvertible {
+    /// The object that declares the signal was already gone when the await began.
+    case targetUnavailable
+
+    /// Godot refused to connect to the signal.
+    case connectionFailed(GodotError)
+
+    public var description: String {
+        switch self {
+        case .targetUnavailable:
+            return "The object that declares this signal is no longer available"
+        case .connectionFailed(let error):
+            return "Godot refused the signal connection: \(error)"
+        }
+    }
+}
+
+/// Coordinates a single one-shot signal await.
+///
+/// The continuation is resumed exactly once, by whichever of these happens first: the
+/// signal fires, the connection is refused, or the task is cancelled.  Godot emits from
+/// whatever thread it pleases and `withTaskCancellationHandler`'s `onCancel` is
+/// `@Sendable`, so every transition goes through the lock.
+private final class SignalAwaiter<each T: _GodotBridgeable> {
+    private let lock = NIOLock()
+    private var continuation: CheckedContinuation<(repeat each T), any Error>?
+    private var token: Callable?
+    private var isSettled = false
+    private var cancelledBeforeStart = false
+
+    /// Installs the continuation.
+    ///
+    /// Returns `false` when cancellation arrived before the operation body ran, in which
+    /// case the continuation has already been resumed and no connection should be made.
+    func begin(_ c: CheckedContinuation<(repeat each T), any Error>) -> Bool {
+        let alreadyCancelled = lock.withLock { () -> Bool in
+            if cancelledBeforeStart {
+                return true
+            }
+            continuation = c
+            return false
+        }
+
+        if alreadyCancelled {
+            c.resume(throwing: CancellationError())
+            return false
+        }
+        return true
+    }
+
+    /// Records the connection token so a cancelled await can disconnect itself.
+    ///
+    /// Nothing is recorded once the awaiter has settled: the one-shot connection is
+    /// already gone, and there would be no later opportunity to drop the reference.
+    func connected(_ callable: Callable) {
+        lock.withLockVoid {
+            guard !isSettled else { return }
+            token = callable
+        }
+    }
+
+    /// Hands back the connection token, if the connection is still ours to drop.
+    func takeToken() -> Callable? {
+        lock.withLock { () -> Callable? in
+            let t = token
+            token = nil
+            return t
+        }
+    }
+
+    func fulfill(_ payload: (repeat each T)) {
+        takeContinuation()?.resume(returning: payload)
+    }
+
+    func fail(_ error: any Error) {
+        takeContinuation()?.resume(throwing: error)
+    }
+
+    func cancel() {
+        let c = lock.withLock { () -> CheckedContinuation<(repeat each T), any Error>? in
+            guard !isSettled else { return nil }
+            isSettled = true
+            guard let c = continuation else {
+                // Cancellation beat the operation body; `begin` will resume instead.
+                cancelledBeforeStart = true
+                return nil
+            }
+            continuation = nil
+            return c
+        }
+        c?.resume(throwing: CancellationError())
+    }
+
+    private func takeContinuation() -> CheckedContinuation<(repeat each T), any Error>? {
+        lock.withLock { () -> CheckedContinuation<(repeat each T), any Error>? in
+            guard !isSettled else { return nil }
+            isSettled = true
+            let c = continuation
+            continuation = nil
+            return c
+        }
+    }
+}
+
 /// Signal support.
 /// Use the ``connect(flags:_:)`` method to connect to the signal on the container object,
 /// and ``disconnect(_:)`` to drop the connection.
 /// Use the ``emit(...)`` method to emit a signal.
-/// You can also await the ``emitted`` property for waiting for a single emission of the signal.
+/// You can also await the ``emitted`` property to wait for a single emission of the signal.
 public struct SignalWithArguments<each T: _GodotBridgeable> {
     weak var target: Object?
     let signalName: StringName
@@ -100,22 +205,76 @@ public struct SignalWithArguments<each T: _GodotBridgeable> {
         return GodotError(rawValue: Int64(errorCode))!
     }
 
-    /// You can await this property to wait for the signal to be emitted once.
-    @available(*, deprecated, message: "This is inherently unsafe because if the signal never fires the coroutine state of `async` function leaks, capturing all its context required for next continuation forever, use callbacks instead")
-    public var emitted: Void {
-        get async {
-            await withCheckedContinuation { c in
-                let signalProxy = SignalProxy()
-                signalProxy.proxy = { _ in c.resume() }
-                let callable = Callable(object: signalProxy, method: SignalProxy.proxyName)
-                
-                guard let target else {
-                    c.resume()
-                    return
+    /// Await this property to wait for the signal to be emitted once.
+    ///
+    /// The value is the signal's payload: `()` for a ``SimpleSignal``, the argument itself
+    /// for a signal with one argument, and a tuple otherwise.
+    ///
+    /// ```swift
+    /// try await timer.timeout.emitted
+    /// let (id, oldName, newName) = try await node.animationNodeRenamed.emitted
+    /// ```
+    ///
+    /// Cancelling the awaiting task disconnects from the signal and throws
+    /// `CancellationError`.  If the object that declares the signal is destroyed while you
+    /// are waiting, the await does not resume - that mirrors GDScript's own `await`, so
+    /// bound the wait with cancellation or a timeout when the emitter might not survive.
+    ///
+    /// This is `nonisolated(nonsending)`, so it runs on the caller's actor rather than
+    /// hopping to the cooperative pool.  Resuming on the caller's actor is an ordinary
+    /// language guarantee that would hold either way; what the attribute buys is keeping
+    /// this getter's own `connect` and `disconnect` calls on that actor, instead of
+    /// racing Godot's frame from a background thread.
+    ///
+    /// - Throws: `CancellationError` if the task is cancelled, or ``SignalAwaitError``.
+    public nonisolated(nonsending) var emitted: (repeat each T) {
+        get async throws {
+            guard let target else {
+                throw SignalAwaitError.targetUnavailable
+            }
+
+            let awaiter = SignalAwaiter<repeat each T>()
+
+            do {
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { c in
+                        guard awaiter.begin(c) else { return }
+
+                        // Capture the awaiter weakly. It holds the Callable so that a
+                        // cancelled await can disconnect, and Godot's connection owns the
+                        // Callable's wrapper, which owns this closure - so a strong
+                        // capture would close the loop
+                        // (awaiter -> Callable -> wrapper -> closure -> awaiter) and leak
+                        // both on every completed await. The async frame below keeps the
+                        // awaiter alive for as long as the callback can fire.
+                        let callback: (repeat each T) -> Void = { [weak awaiter] (t: repeat each T) in
+                            awaiter?.fulfill((repeat each t))
+                        }
+                        let callable = Callable(callback)
+
+                        let result = target.connect(
+                            signal: signalName,
+                            callable: callable,
+                            flags: UInt32(Object.ConnectFlags.oneShot.rawValue))
+
+                        if result == .ok {
+                            awaiter.connected(callable)
+                        } else {
+                            awaiter.fail(SignalAwaitError.connectionFailed(result))
+                        }
+                    }
+                } onCancel: {
+                    awaiter.cancel()
                 }
-                
-                let r = target.connect(signal: signalName, callable: callable, flags: UInt32(Object.ConnectFlags.oneShot.rawValue))
-                if r != .ok { print("Warning, error connecting to signal, code: \(r)") }
+            } catch {
+                // Cancellation can be delivered from any thread, so the handler above only
+                // resumes the continuation.  The actual disconnect happens here, back on
+                // the caller's actor.  On the success path Godot has already dropped the
+                // one-shot connection, and `takeToken` is only non-nil when it has not.
+                if let token = awaiter.takeToken() {
+                    target.disconnect(signal: signalName, callable: token)
+                }
+                throw error
             }
         }
     }

--- a/Sources/SwiftGodotRuntime/Core/Wrapped.swift
+++ b/Sources/SwiftGodotRuntime/Core/Wrapped.swift
@@ -425,6 +425,18 @@ open class Wrapped: Equatable, Identifiable, Hashable {
     ///  - arguments: variable list of arguments
     /// - Returns: if there is an error, this function raises an error, otherwise, a Variant with the result is returned
     public func callScript (method: StringName, _ arguments: Variant?...) throws -> Variant? {
+        try callScript(method: method, arguments: arguments)
+    }
+
+    /// Invokes the specified method on the object, taking its arguments as an array.
+    ///
+    /// Same as ``callScript(method:_:)``, for callers that already have the arguments in
+    /// a collection and so cannot use the variadic form.
+    /// - Parameters:
+    ///  - method: the method to invoke on the target
+    ///  - arguments: the arguments to pass
+    /// - Returns: if there is an error, this function raises an error, otherwise, a Variant with the result is returned
+    public func callScript (method: StringName, arguments: [Variant?]) throws -> Variant? {
         var args: [UnsafeRawPointer?] = []
         let cptr = UnsafeMutableBufferPointer<Variant.ContentType>.allocate(capacity: arguments.count)
         defer { cptr.deallocate () }

--- a/Sources/SwiftGodotRuntime/EntryPoint.swift
+++ b/Sources/SwiftGodotRuntime/EntryPoint.swift
@@ -102,10 +102,19 @@ public extension ExtensionInterface {
 
     // Register any general Godot classes/methods here
     func initClasses() {
-        SignalProxy.initClass()
+        registerDeprecatedSignalProxy()
     }
 
     func setLibrary(_ library: UnsafeMutableRawPointer) {}
+}
+
+/// ``SignalProxy`` is deprecated but still registered, because it is public API and user
+/// code may reference it by name.  Nothing in the binding uses it any more - awaiting a
+/// signal now goes through a `Callable` built from a Swift closure.  Keeping the call in
+/// its own deprecated function confines the warning to this one place.
+@available(*, deprecated)
+fileprivate func registerDeprecatedSignalProxy() {
+    SignalProxy.initClass()
 }
 
 class LibGodotExtensionInterface: ExtensionInterface {

--- a/Sources/SwiftGodotRuntime/Extensions/AwaitScriptCall.swift
+++ b/Sources/SwiftGodotRuntime/Extensions/AwaitScriptCall.swift
@@ -1,0 +1,59 @@
+//
+//  AwaitScriptCall.swift
+//  SwiftGodot
+//
+//  Awaiting a call into a script.
+//
+//  GDScript's `await` accepts a signal or a call to a coroutine - a function that itself
+//  contains `await`. Calling a coroutine does not return its value: it returns a handle
+//  to the suspended call, which emits `completed` with the value once it resumes.
+//
+//  That handle is `GDScriptFunctionState`, which is not published in
+//  `extension_api.json`, so it crosses the boundary as an object of a class the binding
+//  does not know statically. Everything here therefore goes through the dynamic `Signal`
+//  API rather than a generated type.
+//
+
+public extension Object {
+    /// Calls a script method and, if the call suspended at an `await`, waits for it to
+    /// finish.
+    ///
+    /// A method that does not suspend has its value returned directly - the equivalent of
+    /// GDScript's "redundant await", which is harmless.
+    ///
+    /// ```swift
+    /// // func slow(tree):
+    /// //     await tree.process_frame
+    /// //     return 42
+    /// let value = try await object.callScriptAsync(method: "slow", tree.toVariant())
+    /// ```
+    ///
+    /// Waiting requires frames to advance, so call this from somewhere that lets Godot
+    /// keep running - not from a context that blocks the main thread.
+    ///
+    /// - Throws: whatever ``callScript(method:_:)`` throws, `CancellationError` if the
+    ///   task is cancelled while waiting, or ``SignalAwaitError``.
+    nonisolated(nonsending) func callScriptAsync(
+        method: StringName,
+        _ arguments: Variant?...
+    ) async throws -> Variant? {
+        let result = try callScript(method: method, arguments: arguments)
+
+        guard let state = result?.to(Object.self), state.isSuspendedScriptCall else {
+            return result
+        }
+
+        // `completed` carries the coroutine's return value as its single argument.
+        let values = try await Signal(object: state, signal: "completed").emitted
+        return values.first ?? nil
+    }
+
+    /// Whether this object is a handle to a script call that suspended at an `await`.
+    ///
+    /// Recognised structurally rather than by class name: the handle emits `completed`
+    /// when the call resumes and answers `is_valid` while it is still pending.  No
+    /// ordinary return value looks like that.
+    private var isSuspendedScriptCall: Bool {
+        hasSignal("completed") && hasMethod("is_valid")
+    }
+}

--- a/Sources/SwiftGodotRuntime/Extensions/SignalExtensions.swift
+++ b/Sources/SwiftGodotRuntime/Extensions/SignalExtensions.swift
@@ -1,0 +1,151 @@
+//
+//  SignalExtensions.swift
+//  SwiftGodot
+//
+//  Awaiting a `Signal` value.
+//
+//  `Signal` is the builtin Variant type - the one you get back from GDScript, from
+//  `Object.getSignalList()`, or by building it yourself with `Signal(object:signal:)`.
+//  It is unrelated to `SignalWithArguments`, and it carries no static type information
+//  about its arguments, so the payload here is untyped.
+//
+
+/// Coordinates a single one-shot await on a builtin ``Signal``.
+///
+/// Same contract as the awaiter behind ``SignalWithArguments/emitted``: the continuation
+/// resumes exactly once, whether the signal fires, the connection is refused, or the task
+/// is cancelled.  Godot emits from whatever thread it pleases and `onCancel` is
+/// `@Sendable`, so every transition goes through the lock.
+private final class VariantSignalAwaiter {
+    private let lock = NIOLock()
+    private var continuation: CheckedContinuation<[Variant?], any Error>?
+    private var token: Callable?
+    private var isSettled = false
+    private var cancelledBeforeStart = false
+
+    func begin(_ c: CheckedContinuation<[Variant?], any Error>) -> Bool {
+        let alreadyCancelled = lock.withLock { () -> Bool in
+            if cancelledBeforeStart {
+                return true
+            }
+            continuation = c
+            return false
+        }
+
+        if alreadyCancelled {
+            c.resume(throwing: CancellationError())
+            return false
+        }
+        return true
+    }
+
+    func connected(_ callable: Callable) {
+        lock.withLockVoid {
+            guard !isSettled else { return }
+            token = callable
+        }
+    }
+
+    func takeToken() -> Callable? {
+        lock.withLock { () -> Callable? in
+            let t = token
+            token = nil
+            return t
+        }
+    }
+
+    func fulfill(_ payload: [Variant?]) {
+        takeContinuation()?.resume(returning: payload)
+    }
+
+    func fail(_ error: any Error) {
+        takeContinuation()?.resume(throwing: error)
+    }
+
+    func cancel() {
+        let c = lock.withLock { () -> CheckedContinuation<[Variant?], any Error>? in
+            guard !isSettled else { return nil }
+            isSettled = true
+            guard let c = continuation else {
+                cancelledBeforeStart = true
+                return nil
+            }
+            continuation = nil
+            return c
+        }
+        c?.resume(throwing: CancellationError())
+    }
+
+    private func takeContinuation() -> CheckedContinuation<[Variant?], any Error>? {
+        lock.withLock { () -> CheckedContinuation<[Variant?], any Error>? in
+            guard !isSettled else { return nil }
+            isSettled = true
+            let c = continuation
+            continuation = nil
+            return c
+        }
+    }
+}
+
+public extension Signal {
+    /// Await this property to wait for the signal to be emitted once.
+    ///
+    /// Unlike ``SignalWithArguments/emitted``, the payload is untyped: a ``Signal`` value
+    /// carries no static information about its arguments, so you get the raw ``Variant``
+    /// list that Godot passed to the callback.
+    ///
+    /// ```swift
+    /// let args = try await signal.emitted
+    /// let who = args.first??.to(String.self)
+    /// ```
+    ///
+    /// Cancelling the awaiting task disconnects from the signal and throws
+    /// `CancellationError`.  As with the typed version, an await does not resume if the
+    /// emitting object is destroyed first.
+    ///
+    /// - Throws: `CancellationError` if the task is cancelled, or ``SignalAwaitError``.
+    nonisolated(nonsending) var emitted: [Variant?] {
+        get async throws {
+            guard !isNull() else {
+                throw SignalAwaitError.targetUnavailable
+            }
+
+            let awaiter = VariantSignalAwaiter()
+
+            do {
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { c in
+                        guard awaiter.begin(c) else { return }
+
+                        // Weak, for the same reason as the typed version: the awaiter
+                        // holds the Callable, whose wrapper owns this closure, so a
+                        // strong capture would form a cycle and leak every completed
+                        // await. The async frame keeps the awaiter alive meanwhile.
+                        let callable = Callable { [weak awaiter] (arguments: borrowing Arguments) -> Variant? in
+                            awaiter?.fulfill(Array(arguments))
+                            return nil
+                        }
+
+                        let result = connect(
+                            callable: callable,
+                            flags: Int64(Object.ConnectFlags.oneShot.rawValue))
+
+                        // `Signal.connect` reports a raw error code rather than a GodotError.
+                        if let error = GodotError(rawValue: result), error != .ok {
+                            awaiter.fail(SignalAwaitError.connectionFailed(error))
+                        } else {
+                            awaiter.connected(callable)
+                        }
+                    }
+                } onCancel: {
+                    awaiter.cancel()
+                }
+            } catch {
+                if let token = awaiter.takeToken() {
+                    disconnect(callable: token)
+                }
+                throw error
+            }
+        }
+    }
+}

--- a/Sources/SwiftGodotTestMacros/SwiftGodotTestInvocation.swift
+++ b/Sources/SwiftGodotTestMacros/SwiftGodotTestInvocation.swift
@@ -8,14 +8,23 @@ public struct SwiftGodotTestInvocation {
     public let name: String
 
     /// Closure that runs the test.
-    public let run: () -> Void
+    ///
+    /// Declared `async throws` so that a suite can mix synchronous tests with ones that
+    /// await.  A synchronous, non-throwing method converts to this type implicitly, so
+    /// existing suites are unaffected.
+    ///
+    /// Note that a test method's *isolation* travels with the method, not with this
+    /// closure type: a test annotated with a global actor still runs its body on that
+    /// actor, no matter where it is awaited from.  That is what lets the runner keep
+    /// async test bodies on Godot's main thread.
+    public let run: () async throws -> Void
 
     /// Creates a new GodotTest.
     ///
     /// - Parameters:
     ///   - name: The name of the test (usually the method name).
     ///   - run: Closure that executes the test.
-    public init(name: String, run: @escaping () -> Void) {
+    public init(name: String, run: @escaping () async throws -> Void) {
         self.name = name
         self.run = run
     }

--- a/Sources/SwiftGodotTestMacrosLibrary/SwiftGodotTestSuiteMacro.swift
+++ b/Sources/SwiftGodotTestMacrosLibrary/SwiftGodotTestSuiteMacro.swift
@@ -22,8 +22,10 @@ public struct SwiftGodotTestSuiteMacro: MemberMacro, ExtensionMacro {
             throw SwiftGodotTestMacroError.notAClass
         }
 
-        // Find all test methods: instance methods whose name begins with `test`,
-        // take no arguments, and have no effect specifiers (async/throws).
+        // Find all test methods: instance methods whose name begins with `test`, take no
+        // arguments and return nothing. `async` and `throws` are both allowed - the
+        // invocation closure is `() async throws -> Void`, and a synchronous
+        // non-throwing method converts to it implicitly.
         let testMethods = declaration.memberBlock.members.compactMap { member -> String? in
             guard let funcDecl = member.decl.as(FunctionDeclSyntax.self) else {
                 return nil
@@ -36,7 +38,6 @@ public struct SwiftGodotTestSuiteMacro: MemberMacro, ExtensionMacro {
 
             let signature = funcDecl.signature
             guard signature.parameterClause.parameters.isEmpty else { return nil }
-            guard signature.effectSpecifiers == nil else { return nil }
             guard signature.returnClause == nil else { return nil }
 
             return name

--- a/Sources/SwiftGodotTestRunner/SwiftGodotTestRunner.swift
+++ b/Sources/SwiftGodotTestRunner/SwiftGodotTestRunner.swift
@@ -161,12 +161,17 @@ struct SwiftGodotTestRunner {
             let platformSource = "\(platformBuildDir)/\(libName)"
             let simpleSource = "\(simpleBuildDir)/\(libName)"
 
-            let source: String
-            if fm.fileExists(atPath: platformSource) {
-                source = platformSource
-            } else if fm.fileExists(atPath: simpleSource) {
-                source = simpleSource
-            } else {
+            // Both locations can exist at once: `.build/<triple>/<config>` is where the
+            // classic build system wrote, `.build/<config>` is a symlink maintained by
+            // the current one. Preferring the first unconditionally means a leftover
+            // directory silently wins forever, and the tests then run against a stale
+            // library — passing or failing for reasons that have nothing to do with the
+            // working tree. Take whichever was built most recently.
+            let candidates = [platformSource, simpleSource].filter { fm.fileExists(atPath: $0) }
+
+            guard let source = candidates.max(by: { lhs, rhs in
+                modificationDate(of: lhs, fm) < modificationDate(of: rhs, fm)
+            }) else {
                 print("      Library not found: \(platformSource) or \(simpleSource)")
                 exit(1)
             }
@@ -288,4 +293,12 @@ struct SwiftGodotTestRunner {
             exit(godotExitCode != 0 ? godotExitCode : 1)
         }
     }
+}
+
+/// Last-modified time of a file, or the distant past when it cannot be read.
+///
+/// Used to pick the freshest of several candidate build outputs.
+private func modificationDate(of path: String, _ fm: FileManager) -> Date {
+    let attributes = try? fm.attributesOfItem(atPath: path)
+    return attributes?[.modificationDate] as? Date ?? .distantPast
 }

--- a/Tests/SwiftGodotTestExtension/AwaitingGodotCallsTests.swift
+++ b/Tests/SwiftGodotTestExtension/AwaitingGodotCallsTests.swift
@@ -1,0 +1,98 @@
+//
+//  AwaitingGodotCallsTests.swift
+//  SwiftGodotTestExtension
+//
+//  What can actually be awaited when calling into Godot?
+//
+//  GDScript's `await` accepts two things: a signal, and a call to a *coroutine* - a
+//  function that itself contains `await`. Awaiting a call to an ordinary function is
+//  merely redundant. The signal half is covered by SignalTests; this file pins down the
+//  call half, which had no coverage at all.
+//
+
+import SwiftGodot
+
+@SwiftGodotTestSuite
+final class AwaitingGodotCallsTests {
+    /// A script with one coroutine and one ordinary function.
+    ///
+    /// `slow()` suspends on `process_frame`, so calling it returns before it has a value.
+    /// `fast()` returns its value outright.
+    private func makeScriptedObject() -> RefCounted? {
+        let script = GDScript()
+        script.sourceCode = """
+        extends RefCounted
+
+        func slow(tree):
+            await tree.process_frame
+            return 42
+
+        func fast():
+            return 7
+        """
+
+        let reloadResult = script.reload()
+        guard reloadResult == .ok else {
+            fail("GDScript.reload() failed with \(reloadResult)")
+            return nil
+        }
+
+        let object = RefCounted()
+        object.setScript(script.toVariant())
+        return object
+    }
+
+    /// Calling a non-coroutine returns its value directly - GDScript's "redundant await".
+    @GodotMainActor
+    public func testCallingOrdinaryFunctionReturnsItsValue() async throws {
+        guard let object = makeScriptedObject() else { return }
+
+        let result = try object.callScript(method: "fast")
+        assertEqual(result?.to(Int.self), 7, "a non-coroutine should return its value")
+    }
+
+    /// Calling a coroutine returns a handle to the suspended call, not the return value.
+    ///
+    /// This test records what that handle actually is. `GDScriptFunctionState` is not in
+    /// `extension_api.json`, so it arrives as an object of a class the binding does not
+    /// know statically - which is why `callScriptAsync` has to work through the dynamic
+    /// `Signal` API rather than a generated type.
+    @GodotMainActor
+    public func testCallingCoroutineReturnsSuspendedCallHandle() async throws {
+        guard let object = makeScriptedObject() else { return }
+        guard let tree = Engine.getMainLoop() as? SceneTree else {
+            fail("no SceneTree")
+            return
+        }
+
+        let result = try object.callScript(method: "slow", tree.toVariant())
+
+        guard let state = result?.to(Object.self) else {
+            fail("a suspended coroutine should return an object, got \(String(describing: result))")
+            return
+        }
+
+        GD.print("[coroutine spike] class=\(state.getClass()) completed=\(state.hasSignal("completed"))")
+        assertTrue(state.hasSignal("completed"),
+                   "the suspended call should expose a `completed` signal")
+        assertNotEqual(result?.to(Int.self), 42,
+                       "the coroutine's value is not available yet at call time")
+    }
+
+    /// `callScriptAsync` papers over the difference: it awaits a coroutine to completion
+    /// and returns an ordinary value straight through.
+    @GodotMainActor
+    public func testCallScriptAsyncAwaitsCoroutine() async throws {
+        guard let object = makeScriptedObject() else { return }
+        guard let tree = Engine.getMainLoop() as? SceneTree else {
+            fail("no SceneTree")
+            return
+        }
+
+        let slow = try await object.callScriptAsync(method: "slow", tree.toVariant())
+        assertEqual(slow?.to(Int.self), 42, "should have waited for the coroutine's value")
+
+        let fast = try await object.callScriptAsync(method: "fast")
+        assertEqual(fast?.to(Int.self), 7, "a non-coroutine should pass straight through")
+    }
+}

--- a/Tests/SwiftGodotTestExtension/GodotMainExecutor.swift
+++ b/Tests/SwiftGodotTestExtension/GodotMainExecutor.swift
@@ -1,0 +1,73 @@
+//
+//  GodotMainExecutor.swift
+//  SwiftGodotTestExtension
+//
+//  A Swift concurrency executor that runs jobs on Godot's main thread.
+//
+//  Swift's `MainActor` is backed by the libdispatch main queue.  Godot does not drain
+//  that queue - it runs its own event loop - so a `Task { @MainActor in ... }` inside a
+//  GDExtension is not reliably scheduled, and on Linux and Windows may never run at all.
+//
+//  Godot's actual main-thread pump is its message queue, flushed at idle time each frame.
+//  `Callable.callDeferred()` is the supported way onto it, and the runtime already relies
+//  on exactly this to release objects from arbitrary threads (see `Wrapped.deinit`).
+//  Building a `SerialExecutor` on top of it gives Swift concurrency a main thread that
+//  actually corresponds to Godot's.
+//
+//  This lives in the test target on purpose.  It is a candidate for promotion into
+//  SwiftGodot as a public `@GodotActor` once it has proven itself here; until then the
+//  shipping API commits to nothing.
+//
+
+import SwiftGodot
+
+/// Runs jobs on Godot's main thread by posting them through the engine's message queue.
+final class GodotMainExecutor: SerialExecutor {
+    static let shared = GodotMainExecutor()
+
+    func enqueue(_ job: consuming ExecutorJob) {
+        let unownedJob = UnownedJob(job)
+        let executor = asUnownedSerialExecutor()
+
+        // The message queue copies the Callable, which retains the underlying custom
+        // callable and therefore this closure, so the job survives until it is flushed.
+        let callable = Callable { (_: borrowing Arguments) -> Variant? in
+            unownedJob.runSynchronously(on: executor)
+            return nil
+        }
+        callable.callDeferred()
+    }
+
+    func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        UnownedSerialExecutor(ordinary: self)
+    }
+}
+
+/// Posts `body` to Godot's message queue so it runs at the next idle flush.
+///
+/// Tests use this to emit a signal *after* the awaiting code has connected. An await
+/// connects synchronously and only then suspends, so a deferred emission is guaranteed to
+/// land after the connection exists - which is what makes these tests deterministic
+/// rather than dependent on thread timing.
+@GodotMainActor
+func emitLater(_ body: @escaping () -> Void) {
+    let callable = Callable { (_: borrowing Arguments) -> Variant? in
+        body()
+        return nil
+    }
+    callable.callDeferred()
+}
+
+/// Global actor whose executor is Godot's main thread.
+///
+/// Annotate an async test with `@GodotMainActor` so its body - including every call into
+/// Godot - runs where Godot expects it.  Global actor isolation belongs to the method
+/// itself, so this holds no matter where the runner awaits it from.
+@globalActor
+actor GodotMainActor {
+    static let shared = GodotMainActor()
+
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        GodotMainExecutor.shared.asUnownedSerialExecutor()
+    }
+}

--- a/Tests/SwiftGodotTestExtension/MainActorProbeTests.swift
+++ b/Tests/SwiftGodotTestExtension/MainActorProbeTests.swift
@@ -1,0 +1,87 @@
+//
+//  MainActorProbeTests.swift
+//  SwiftGodotTestExtension
+//
+//  Does `Task { @MainActor in ... }` actually run inside a GDExtension?
+//
+//  Swift's `MainActor` is backed by the libdispatch main queue. Godot runs its own event
+//  loop, so whether that queue is ever drained is a property of the host platform, not of
+//  Swift:
+//
+//    - on macOS, Godot's display server pumps `[NSApp nextEventMatchingMask:...]`, which
+//      spins the run loop, which drains the main queue;
+//    - on Linux and Windows, Godot pumps its own loop and libdispatch's main queue is
+//      never touched.
+//
+//  Guidance about `await` in SwiftGodot depends on the answer, so measure it rather than
+//  assume it. This probe *reports* and does not fail: a platform where MainActor never
+//  runs is a finding to document, not a broken build. The number it prints is what the
+//  documentation should be based on.
+//
+
+import Foundation
+import SwiftGodot
+
+/// Records what a `@MainActor` task observed, if it ever ran.
+private final class MainActorObservation {
+    private let lock = NSLock()
+    private var _ran = false
+    private var _wasProcessMainThread = false
+    private var _thread: String = "<never ran>"
+
+    func record(thread: String, isProcessMainThread: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        _ran = true
+        _thread = thread
+        _wasProcessMainThread = isProcessMainThread
+    }
+
+    var snapshot: (ran: Bool, thread: String, wasProcessMainThread: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (_ran, _thread, _wasProcessMainThread)
+    }
+}
+
+@SwiftGodotTestSuite
+final class MainActorProbeTests {
+    /// Reports whether a `@MainActor` task runs under Godot, and on which thread.
+    @GodotMainActor
+    public func testWhetherMainActorTasksRunUnderGodot() async throws {
+        // This test body runs on GodotMainActor, whose executor is Godot's message queue,
+        // so this is Godot's main thread by construction.
+        let godotThread = String(describing: Thread.current)
+        let godotIsProcessMainThread = Thread.isMainThread
+
+        let observation = MainActorObservation()
+        Task { @MainActor in
+            observation.record(thread: String(describing: Thread.current),
+                               isProcessMainThread: Thread.isMainThread)
+        }
+
+        // Give it a generous number of frames to be scheduled. Each yield goes back
+        // through Godot's message queue, so this advances real frames rather than
+        // spinning.
+        for _ in 0 ..< 60 {
+            await Task.yield()
+            if observation.snapshot.ran { break }
+        }
+
+        let result = observation.snapshot
+
+        GD.print("[MainActor probe] platform=\(OS.getName())")
+        GD.print("[MainActor probe]   godot main thread: \(godotThread) isMainThread=\(godotIsProcessMainThread)")
+        GD.print("[MainActor probe]   MainActor task ran: \(result.ran)")
+        if result.ran {
+            GD.print("[MainActor probe]   MainActor thread: \(result.thread) isMainThread=\(result.wasProcessMainThread)")
+            GD.print("[MainActor probe]   same thread as Godot: \(result.thread == godotThread)")
+        } else {
+            GD.print("[MainActor probe]   MainActor tasks are NOT scheduled on this platform;")
+            GD.print("[MainActor probe]   use a Godot-backed executor instead of @MainActor here.")
+        }
+
+        // Deliberately no assertion on `ran`. The point is to record the answer per
+        // platform, not to declare one platform's behaviour correct.
+    }
+}

--- a/Tests/SwiftGodotTestExtension/MemoryLeakTests.swift
+++ b/Tests/SwiftGodotTestExtension/MemoryLeakTests.swift
@@ -400,6 +400,115 @@ final class MemoryLeakTests {
         return after-before
     }
 
+    /// Async counterpart of ``checkLeaks(useUnoReverseCard:_:)``.
+    ///
+    /// Reports the object-count delta separately from the byte delta: awaiting a signal
+    /// used to allocate a `SignalProxy` object per await and never free it, so the object
+    /// count is the number that directly pins that regression.
+    @GodotMainActor
+    @discardableResult
+    func checkLeaksAsync(_ body: () async throws -> Void) async rethrows -> Double {
+        releasePendingObjects()
+        let beforeO = Performance.getMonitor(.objectCount)
+        let before = Performance.getMonitor(.memoryStatic)
+
+        try await body()
+
+        releasePendingObjects()
+        let afterO = Performance.getMonitor(.objectCount)
+        let after = Performance.getMonitor(.memoryStatic)
+
+        print("object count=\(afterO - beforeO), leaked \(after - before) bytes")
+        assertEqual(beforeO, afterO, "Leaked \(afterO - beforeO) Godot objects")
+        assertEqual(before, after, "Leaked \(after - before) bytes")
+        return after - before
+    }
+
+    /// A completed await must leave nothing behind.
+    ///
+    /// This is the regression test for the `SignalProxy` leak: the old implementation
+    /// allocated one plain `Object` per await and, because a non-`RefCounted` object is
+    /// only released by an explicit `free()` that nothing ever called, leaked it even
+    /// when the signal fired normally.
+    @GodotMainActor
+    public func test_await_signal_leak() async throws {
+        let node = Node()
+        defer { node.queueFree() }
+
+        func oneIteration() async throws {
+            emitLater { node.ready.emit() }
+            try await node.ready.emitted
+        }
+
+        // Warm-up, in case the code path performs one-time permanent allocations.
+        for _ in 0 ..< 5 {
+            try await oneIteration()
+        }
+
+        try await checkLeaksAsync {
+            for _ in 0 ..< 50 {
+                try await oneIteration()
+            }
+        }
+    }
+
+    /// An await that carries a payload must not retain the payload either.
+    @GodotMainActor
+    public func test_await_signal_with_arguments_leak() async throws {
+        let node = Node()
+        defer { node.queueFree() }
+
+        func oneIteration() async throws {
+            emitLater { node.childExitingTree.emit(node) }
+            _ = try await node.childExitingTree.emitted
+        }
+
+        for _ in 0 ..< 5 {
+            try await oneIteration()
+        }
+
+        try await checkLeaksAsync {
+            for _ in 0 ..< 50 {
+                try await oneIteration()
+            }
+        }
+    }
+
+    /// A cancelled await must clean up as thoroughly as a completed one.
+    ///
+    /// This is the path the deprecation notice was about: cancelling used to be
+    /// impossible, so an abandoned wait held its continuation - and everything the
+    /// coroutine had captured - forever.
+    @GodotMainActor
+    public func test_await_signal_cancellation_leak() async throws {
+        let node = Node()
+        defer { node.queueFree() }
+
+        func oneIteration() async {
+            let task = Task { @GodotMainActor in
+                try await node.ready.emitted
+            }
+            // Let the task reach its suspension point, so cancellation has something
+            // real to tear down rather than arriving before the connection exists.
+            await Task.yield()
+            task.cancel()
+            _ = try? await task.value
+        }
+
+        for _ in 0 ..< 5 {
+            await oneIteration()
+        }
+
+        try await checkLeaksAsync {
+            for _ in 0 ..< 50 {
+                await oneIteration()
+            }
+        }
+
+        assertEqual(node.getSignalConnectionList(signal: "ready").count, 0,
+                    "cancelled awaits should leave no connections behind")
+    }
+
     public func testThatItLeaksIndeed() {
         let array = VariantArray()
         

--- a/Tests/SwiftGodotTestExtension/SignalTests.swift
+++ b/Tests/SwiftGodotTestExtension/SignalTests.swift
@@ -86,5 +86,128 @@ final class SignalTests {
         assertTrue (signalReceived, "signal should have been received")
         // AnimationNode is a Resource (reference-counted) — no manual free needed.
     }
+
+    // MARK: - Awaiting signals
+    //
+    // These run on `GodotMainActor`, whose executor is Godot's message queue, so every
+    // call below happens on Godot's main thread.
+    //
+    // The emission is always posted with `callDeferred` rather than called inline. The
+    // await connects synchronously and only then suspends, so a deferred emission is
+    // guaranteed to land after the connection exists — which is the ordering these tests
+    // need and the reason they are not racy.
+
+    @GodotMainActor
+    public func testAwaitSignalDeliversPayload() async throws {
+        let node = TestSignalNode()
+        defer { node.queueFree() }
+
+        emitLater { node.nuSignal.emit(22, "Sam") }
+
+        let (age, name) = try await node.nuSignal.emitted
+        assertEqual(age, 22)
+        assertEqual(name, "Sam")
+    }
+
+    @GodotMainActor
+    public func testAwaitSimpleSignalReturnsVoid() async throws {
+        let node = Node()
+        defer { node.queueFree() }
+
+        emitLater { node.ready.emit() }
+
+        // A SimpleSignal has an empty argument pack, so the payload type is `()`.
+        try await node.ready.emitted
+    }
+
+    @GodotMainActor
+    public func testAwaitSignalWithOneArgumentIsNotATuple() async throws {
+        let node = Node()
+        defer { node.queueFree() }
+
+        emitLater { node.childExitingTree.emit(node) }
+
+        // A one-element pack collapses to the value itself, not a 1-tuple.
+        let child: Node? = try await node.childExitingTree.emitted
+        assertEqual(child, node)
+    }
+
+    /// Cancelling the awaiting task must throw *and* drop the Godot-side connection.
+    /// This is the regression test for the leak that got `emitted` deprecated.
+    @GodotMainActor
+    public func testAwaitSignalCancellationDisconnects() async throws {
+        let node = TestSignalNode()
+        defer { node.queueFree() }
+
+        let signalName = StringName("nu_signal")
+        assertEqual(node.getSignalConnectionList(signal: signalName).count, 0,
+                    "no connections before awaiting")
+
+        let task = Task { @GodotMainActor in
+            try await node.nuSignal.emitted
+        }
+
+        // Let the task reach its suspension point. Both this test and the task run on
+        // GodotMainActor, which drains in order, so one hop is enough.
+        await Task.yield()
+        assertEqual(node.getSignalConnectionList(signal: signalName).count, 1,
+                    "awaiting should have connected")
+
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            fail("cancelled await should have thrown")
+        } catch is CancellationError {
+            // expected
+        } catch {
+            fail("expected CancellationError, got \(error)")
+        }
+
+        assertEqual(node.getSignalConnectionList(signal: signalName).count, 0,
+                    "cancelling should have disconnected")
+    }
+
+    /// A signal whose declaring object is already gone reports it instead of hanging.
+    @GodotMainActor
+    public func testAwaitSignalWithMissingTargetThrows() async throws {
+        // SignalWithArguments holds its target weakly, so letting the only reference go
+        // leaves a signal handle with nothing behind it.
+        var signal: SimpleSignal?
+        do {
+            let owner = RefCounted()
+            signal = SimpleSignal(target: owner, signalName: "script_changed")
+        }
+
+        guard let signal else {
+            fail("signal was not created")
+            return
+        }
+
+        do {
+            try await signal.emitted
+            fail("awaiting a signal with no target should have thrown")
+        } catch SignalAwaitError.targetUnavailable {
+            // expected
+        } catch {
+            fail("expected .targetUnavailable, got \(error)")
+        }
+    }
+
+    /// The builtin `Signal` Variant type — what you get from GDScript or
+    /// `Signal(object:signal:)` — is awaitable too, with an untyped payload.
+    @GodotMainActor
+    public func testAwaitBuiltinSignalValue() async throws {
+        let node = TestSignalNode()
+        defer { node.queueFree() }
+
+        let signal = Signal(object: node, signal: "nu_signal")
+        emitLater { node.nuSignal.emit(7, "Robin") }
+
+        let arguments = try await signal.emitted
+        assertEqual(arguments.count, 2)
+        assertEqual(arguments.first??.to(Int.self), 7)
+        assertEqual(arguments.last??.to(String.self), "Robin")
+    }
 }
 

--- a/Tests/SwiftGodotTestExtension/TestRunnerNode.swift
+++ b/Tests/SwiftGodotTestExtension/TestRunnerNode.swift
@@ -50,21 +50,35 @@ public class TestRunnerNode: Node {
     /// then frees this node and quits the tree.
     @Signal var finished: SignalWithArguments<Int>
 
-    /// Runs every registered test, writes the JSON results, and emits ``finished``
-    /// with the resulting exit code.
+    /// Starts every registered test, then returns immediately.
+    ///
+    /// Tests may be `async`, so the run is driven by a task on ``GodotMainActor`` - whose
+    /// executor is Godot's own message queue - rather than inline. That task needs frames
+    /// to advance in order to make progress, which is exactly what the GDScript
+    /// orchestrator is doing while it awaits ``finished``.
     ///
     /// The orchestrator invokes this *deferred* (rather than relying on `_ready`)
     /// so the signal can never fire before the orchestrator has started awaiting
-    /// it. `emit` is the final statement: an awaiting listener resumes inside the
-    /// emit call, so nothing must touch `self` afterwards.
+    /// it. ``finished`` is emitted as the final statement of ``runTestsAndReport()``:
+    /// an awaiting listener resumes inside the emit call, so nothing must touch `self`
+    /// afterwards.
     @Callable
     func runTests() {
         print("[TestRunnerNode] runTests() called")
+        Task { @GodotMainActor in
+            await runTestsAndReport()
+        }
+    }
+
+    /// Runs every registered test, writes the JSON results, and emits ``finished``
+    /// with the resulting exit code.
+    @GodotMainActor
+    private func runTestsAndReport() async {
         GD.print("=".repeated(60))
         GD.print("SwiftGodot Test Runner")
         GD.print("=".repeated(60))
 
-        let results = runAllTests()
+        let results = await runAllTests()
         writeResults(results)
 
         GD.print("-".repeated(60))
@@ -93,7 +107,8 @@ public class TestRunnerNode: Node {
 
     // MARK: - Test Execution
 
-    private func runAllTests() -> TestResults {
+    @GodotMainActor
+    private func runAllTests() async -> TestResults {
         var suiteResults: [TestSuiteResult] = []
         let startTime = getCurrentTime()
 
@@ -108,7 +123,7 @@ public class TestRunnerNode: Node {
         }
 
         for suite in filteredSuites {
-            let suiteResult = runSuite(suite, filter: filter)
+            let suiteResult = await runSuite(suite, filter: filter)
             suiteResults.append(suiteResult)
         }
 
@@ -120,7 +135,8 @@ public class TestRunnerNode: Node {
         return results
     }
 
-    private func runSuite(_ suite: any SwiftGodotTestSuiteProtocol, filter: TestFilter? = nil) -> TestSuiteResult {
+    @GodotMainActor
+    private func runSuite(_ suite: any SwiftGodotTestSuiteProtocol, filter: TestFilter? = nil) async -> TestSuiteResult {
         let suiteType = type(of: suite)
         let suiteName = suiteType.name
         GD.printRich("[color=blue][b]\(suiteName)[/b][/color]")
@@ -140,7 +156,7 @@ public class TestRunnerNode: Node {
 
         for test in tests {
             GD.printRich("[color=blue]\(test.name)[/color]")
-            let result = runTest(suite: suite, test: test)
+            let result = await runTest(suite: suite, test: test)
             testResults.append(result)
 
             if let failure = result.failure {
@@ -153,13 +169,19 @@ public class TestRunnerNode: Node {
         return TestSuiteResult(name: suiteName, tests: testResults)
     }
 
-    private func runTest(suite: any SwiftGodotTestSuiteProtocol, test: SwiftGodotTestInvocation) -> TestCaseResult {
+    @GodotMainActor
+    private func runTest(suite: any SwiftGodotTestSuiteProtocol, test: SwiftGodotTestInvocation) async -> TestCaseResult {
         let context = TestContext(testName: test.name)
         TestContext.current = context
 
         let startTime = getCurrentTime()
 
-        test.run()
+        do {
+            try await test.run()
+        } catch {
+            // An uncaught error is a failure, not a crash. Report it like any other.
+            fail("test threw an unexpected error: \(error)")
+        }
 
         TestContext.current = nil
         let duration = getCurrentTime() - startTime


### PR DESCRIPTION
`emitted` was deprecated in #681 (3615721), which also deleted the "One-shot signals" section from Signals.md. The deprecation note cited one defect; there were four:

1. Task leak. `withCheckedContinuation` with no cancellation handling: a signal that never fires suspends the task forever, retaining everything it captured.
2. SignalProxy leak on the *success* path. Every await allocated a SignalProxy - a plain Object, not RefCounted, which must be released with `free()` and never was, and which `bindSwiftObject` additionally pins in liveSubtypedObjects. Both the native object and the Swift wrapper leaked once per await even when the signal fired. Not mentioned in the deprecation note.
3. Payload dropped. Returned Void even for SignalWithArguments<Int, String>.
4. Wrong thread on resume, undocumented anywhere.

All four are fixable now because of pieces that did not exist in 2023: `Callable(closure)` replaces SignalProxy outright, closure captures are released through Godot's free_func, and every signal in the binding - generated and @Signal-declared - is the single type SignalWithArguments<each T>.

API
---

`emitted` is un-deprecated, cancellable, and typed:

    try await timer.timeout.emitted                       // ()
    let (id, old, new) = try await node.animationNodeRenamed.emitted

The payload is `(repeat each T)`: `()` for a SimpleSignal, the bare value for a one-argument signal, a tuple otherwise. Cancelling the task disconnects and throws CancellationError. A signal whose object is already gone throws SignalAwaitError.targetUnavailable instead of resuming silently, which the old code did.

`nonisolated(nonsending)` keeps the getter's own connect/disconnect calls on the caller's actor rather than hopping to the cooperative pool and racing Godot's frame. Resumption on the caller's actor is an ordinary language guarantee that holds either way; the attribute is only about the getter body.

Source break: `await sig.emitted` becomes `try await sig.emitted`, and the result type changes from Void to the payload. The API was already deprecated.

What can be awaited
-------------------

This had no coverage at all, so it was measured rather than assumed. GDScript's `await` takes a signal or a call to a coroutine. Three things are awaitable now, all tested:

  - typed signals, as above;
  - `Signal.emitted` for the builtin Variant type - what GDScript hands you and what Signal(object:signal:) builds. No static type information, so the payload is [Variant?];
  - `Object.callScriptAsync(method:_:)` for a call into a script. A suspended GDScript coroutine returns a GDScriptFunctionState carrying a `completed` signal (confirmed by test; it is not in extension_api.json, so it arrives as an object of a class the binding does not know statically). A method that did not suspend has its value passed straight through - GDScript's "redundant await".

Also adds `callScript(method:arguments:)` taking an array, so callers that already have their arguments in a collection can avoid the variadic form.

Does @MainActor run under Godot?
--------------------------------

MainActor is Swift's main executor, i.e. the libdispatch main queue, and Godot runs its own event loop - so whether that queue is drained is a property of the host, not of Swift. MainActorProbeTests reports and deliberately does not assert, because a platform where MainActor never runs is a finding to document, not a broken build.

Measured on macOS: the task runs, on Godot's own main thread. Linux and Windows are unanswered here; CI will print the answer. The docs state the two guarantees separately rather than implying the second follows from the first.

Test harness
------------

@SwiftGodotTestSuite silently *dropped* any test with effect specifiers, so async tests could not be expressed. It now accepts them, and SwiftGodotTestInvocation.run is `() async throws -> Void`; a synchronous method converts implicitly, so existing suites are untouched.

Async tests run on GodotMainActor, a test-target-only SerialExecutor that posts jobs through Callable.callDeferred() - the mechanism Wrapped.deinit already uses. Global actor isolation belongs to the method, so the body genuinely runs on Godot's thread. Kept out of the shipping API on purpose: it is the @GodotActor idea on probation, and can graduate later if it holds up.

A leak that the leak test caught
--------------------------------

The first run of the new leak tests failed: 104 bytes per *completed* await, while cancellation measured clean. Four controls (callDeferred alone, Task.yield alone, connect+oneShot+emit alone - all zero) attributed it to the await path rather than the harness.

It was a retain cycle: awaiter -> Callable -> CallableWrapper -> closure ->
awaiter. The awaiter holds the Callable so a cancelled await can disconnect, and the closure captured the awaiter strongly. The cancel path breaks the cycle via takeToken(), which is exactly why cancellation looked clean and success did not. Fixed by capturing the awaiter weakly - the async frame owns it for the whole await, so the callback can never see it deallocated - and by refusing to store a token after the awaiter has settled, so a synchronous fire cannot re-form it. The Signal version had the identical bug and the identical fix.

Unrelated bug found on the way
------------------------------

SwiftGodotTestRunner preferred `.build/<triple>/<config>` over `.build/<config>`, and the current SwiftPM build system only writes the latter. A leftover directory meant the suite silently tested a six-day-old dylib: the first run here reported 5 tests passing while ignoring 6 new ones. It now takes whichever is newest. CI may have been doing this too.

Verification
------------

466/466 in Godot 4.7 (up from 452), 85 macro tests, the -warnings-as-errors diagnostics target, and a release build whose .swiftinterface carries nonisolated(nonsending) correctly under library evolution. The async tests were confirmed able to fail by injecting a wrong expectation and a thrown error.

Note the leak tests measure Godot's allocator, not Swift's heap; a pure-Swift leak with no Godot object involved would not show up. The cycle above was visible only because the custom callable allocation is Godot-side.


Claude-Session: https://claude.ai/code/session_01QGpHK2DDJXHXYeNLH7xW7n